### PR TITLE
Small typo mnemonics

### DIFF
--- a/backends/ext_pdf_doc/templates/ext_pdf.adoc.erb
+++ b/backends/ext_pdf_doc/templates/ext_pdf.adoc.erb
@@ -354,9 +354,9 @@ The following <%= ext.instructions.size %> instructions are added by this extens
 Synopsis::
 <%= i.long_name %>
 
-Mnemoic::
+Mnemonic::
 ----
-<%= i.name %><%= i.assembly.gsub('x', 'r') %>
+<%= i.name %> <%= i.assembly.gsub('x', 'r') %>
 ----
 
 Encoding::


### PR DESCRIPTION
Hello! While trying the repository I found this:

- There was small typo on the generated pdf that was printing "Mnemoic" 
- There was a space missing in the mnemonic generation