### PR TITLE
Fix Encoding for addiw Instruction

### DIFF
--- a/arch/inst/I/addiw.yaml
+++ b/arch/inst/I/addiw.yaml
@@ -7,7 +7,7 @@ addiw:
   base: 64
   assembly: xd, xs1, imm
   encoding:
-    match: -----------------000-----0001011
+    match: -----------------000-----0011011
     variables:
     - name: imm
       location: 31-20


### PR DESCRIPTION
The encoding for the addiw instruction did not match the specification.

Previously, we had:
` [imm:12][rs1:5]000[rd:5]0001011`
Corrected to:
`[imm:12][rs1:5]000[rd:5]0011011`

Please refer to [page 575 of the specification](https://drive.google.com/file/d/1uviu1nH-tScFfgrovvFCrj7Omv8tFtkp/view) for more details.

Thank you!