### PR TITLE
[Draft] Script to generate instr_dict.json from riscv-opcodes using UDB data

### DIFF
--- a/opcodes_maker/generate_instr_dict.py
+++ b/opcodes_maker/generate_instr_dict.py
@@ -1,0 +1,148 @@
+from typing import List, Dict
+import os
+import yaml
+import json
+
+
+def range_size(range_str: str) -> int:
+    try:
+        end, start = map(int, range_str.split('-'))
+        return abs(end - start) + 1
+    except ValueError:
+        return 0;
+
+reg_names = {'qs1', 'qs2', 'qd',
+             'fs1', 'fs2', 'fd'}
+
+def GetVariables(vars: List[Dict[str, str]]):
+    var_names = []
+    for var in vars:
+        var_name = var['name']
+        if var_name in reg_names:
+            # Since strings are immutable.
+            lst_var_name = list(var_name)
+            lst_var_name[0] = 'r'
+            var_name = "".join(lst_var_name)
+        elif var_name == "shamt":
+            size = range_size(var['location'])
+            if size == 5:
+                var_name = "shamtw"
+            elif size == 6:
+                var_name = "shamtd"
+        var_names.append(var_name)
+    var_names.reverse()
+
+    return var_names
+
+def BitStringToHex(bit_str: str) -> str:
+    new_bit_str = ""
+    for bit in bit_str:
+        if bit == '-':
+            new_bit_str += '0'
+        else:
+            new_bit_str += bit
+    return hex(int(new_bit_str, 2))
+
+def GetMask(bit_str: str) -> str:
+    mask_str = ""
+    for bit in bit_str:
+        if bit == '-':
+            mask_str += '0'
+        else:
+            mask_str += '1'
+    return hex(int(mask_str, 2))
+
+def GetExtension(ext, base):
+    prefix = f'rv{base}_'
+    final_extensions = []
+
+    if isinstance(ext, str):
+        final_extensions.append(prefix + ext.lower())
+    elif isinstance(ext, dict):
+        for _, extensions in ext.items():
+            for extension in extensions:
+                final_extensions.append(prefix + extension.lower())
+            final_extensions.reverse()
+
+    return final_extensions
+
+def find_first_match(data):
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if key == "match":
+                return value
+            elif isinstance(value, (dict, list)):
+                result = find_first_match(value)
+                if result is not None:
+                    return result
+    elif isinstance(data, list):
+        for item in data:
+            result = find_first_match(item)
+            if result is not None:
+                return result
+    return ""
+
+def GetEncodings(enc: str):
+    n = len(enc)
+    if n < 32:
+        return '-' * (32-n) + enc
+    return enc
+
+def convert(file_dir: str, json_out):
+    with open(file_dir, 'r') as file:
+        data = yaml.safe_load(file)
+        instr_name = data['name'].replace('.', '_')
+
+        print(instr_name)
+        encodings = data['encoding']
+         
+        # USE RV_64
+        rv64_flag = False
+        if 'RV64' in encodings:
+            encodings = encodings['RV64']
+            rv64_flag = True
+        enc_match = GetEncodings(encodings['match'])
+
+        var_names = []
+        if 'variables' in encodings:
+            var_names = GetVariables(encodings['variables'])
+
+        extension = []
+        prefix = ""
+        if rv64_flag:
+            prefix = "64"
+        if "base" in data:
+            extension = GetExtension(data["definedBy"], data["base"])
+        else:
+            extension = GetExtension(data["definedBy"], prefix) 
+
+        match_hex = BitStringToHex(enc_match)
+        match_mask = GetMask(enc_match)
+
+        json_out[instr_name] = {
+            "encoding": enc_match,
+            "variable_fields": var_names,
+            "extension": extension,
+            "match": match_hex,
+            "mask": match_mask
+        }
+
+def read_yaml_insts(path: str):
+    yaml_files = []
+    for root, _, files in os.walk(path):
+        for file in files:
+            if file.endswith('.yaml') or file.endswith('.yml'):
+                yaml_files.append(os.path.join(root, file))
+    return yaml_files
+
+def main():
+    directory = "../arch/inst/"
+    insts = read_yaml_insts(directory)
+    
+    inst_dict = {}
+    with open('data.json', 'w') as outfile:
+        for inst_dir in insts:
+            convert(inst_dir, inst_dict)
+        json.dump(inst_dict, outfile, indent=4)
+main()
+

--- a/opcodes_maker/instr_dict.json
+++ b/opcodes_maker/instr_dict.json
@@ -1,0 +1,15446 @@
+{
+  "vsm3c_vi": {
+    "encoding": "1010111----------010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "zimm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvksh",
+      "rv_zvks"
+    ],
+    "match": "0xae002077",
+    "mask": "0xfe00707f"
+  },
+  "vsm3me_vv": {
+    "encoding": "1000001----------010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvksh",
+      "rv_zvks"
+    ],
+    "match": "0x82002077",
+    "mask": "0xfe00707f"
+  },
+  "vsm4k_vi": {
+    "encoding": "1000011----------010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "zimm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvksed",
+      "rv_zvks"
+    ],
+    "match": "0x86002077",
+    "mask": "0xfe00707f"
+  },
+  "vsm4r_vv": {
+    "encoding": "1010001-----10000010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvksed",
+      "rv_zvks"
+    ],
+    "match": "0xa2082077",
+    "mask": "0xfe0ff07f"
+  },
+  "vsm4r_vs": {
+    "encoding": "1010011-----10000010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvksed",
+      "rv_zvks"
+    ],
+    "match": "0xa6082077",
+    "mask": "0xfe0ff07f"
+  },
+  "vsha2ms_vv": {
+    "encoding": "1011011----------010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvknha",
+      "rv_zvknhb",
+      "rv_zvkn"
+    ],
+    "match": "0xb6002077",
+    "mask": "0xfe00707f"
+  },
+  "vsha2ch_vv": {
+    "encoding": "1011101----------010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvknha",
+      "rv_zvknhb",
+      "rv_zvkn"
+    ],
+    "match": "0xba002077",
+    "mask": "0xfe00707f"
+  },
+  "vsha2cl_vv": {
+    "encoding": "1011111----------010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvknha",
+      "rv_zvknhb",
+      "rv_zvkn"
+    ],
+    "match": "0xbe002077",
+    "mask": "0xfe00707f"
+  },
+  "vaesdf_vv": {
+    "encoding": "1010001-----00001010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvkned",
+      "rv_zvkn"
+    ],
+    "match": "0xa200a077",
+    "mask": "0xfe0ff07f"
+  },
+  "vaesdf_vs": {
+    "encoding": "1010011-----00001010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvkned",
+      "rv_zvkn"
+    ],
+    "match": "0xa600a077",
+    "mask": "0xfe0ff07f"
+  },
+  "vaesdm_vv": {
+    "encoding": "1010001-----00000010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvkned",
+      "rv_zvkn"
+    ],
+    "match": "0xa2002077",
+    "mask": "0xfe0ff07f"
+  },
+  "vaesdm_vs": {
+    "encoding": "1010011-----00000010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvkned",
+      "rv_zvkn"
+    ],
+    "match": "0xa6002077",
+    "mask": "0xfe0ff07f"
+  },
+  "vaesef_vv": {
+    "encoding": "1010001-----00011010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvkned",
+      "rv_zvkn"
+    ],
+    "match": "0xa201a077",
+    "mask": "0xfe0ff07f"
+  },
+  "vaesef_vs": {
+    "encoding": "1010011-----00011010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvkned",
+      "rv_zvkn"
+    ],
+    "match": "0xa601a077",
+    "mask": "0xfe0ff07f"
+  },
+  "vaesem_vv": {
+    "encoding": "1010001-----00010010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvkned",
+      "rv_zvkn"
+    ],
+    "match": "0xa2012077",
+    "mask": "0xfe0ff07f"
+  },
+  "vaesem_vs": {
+    "encoding": "1010011-----00010010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvkned",
+      "rv_zvkn"
+    ],
+    "match": "0xa6012077",
+    "mask": "0xfe0ff07f"
+  },
+  "vaesz_vs": {
+    "encoding": "1010011-----00111010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvkned",
+      "rv_zvkn"
+    ],
+    "match": "0xa603a077",
+    "mask": "0xfe0ff07f"
+  },
+  "vaeskf1_vi": {
+    "encoding": "1000101----------010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "zimm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvkned",
+      "rv_zvkn"
+    ],
+    "match": "0x8a002077",
+    "mask": "0xfe00707f"
+  },
+  "vaeskf2_vi": {
+    "encoding": "1010101----------010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "zimm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvkned",
+      "rv_zvkn"
+    ],
+    "match": "0xaa002077",
+    "mask": "0xfe00707f"
+  },
+  "vgmul_vv": {
+    "encoding": "1010001-----10001010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvkg"
+    ],
+    "match": "0xa208a077",
+    "mask": "0xfe0ff07f"
+  },
+  "vghsh_vv": {
+    "encoding": "1011001----------010-----1110111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvkg"
+    ],
+    "match": "0xb2002077",
+    "mask": "0xfe00707f"
+  },
+  "vfwmaccbf16_vv": {
+    "encoding": "111011-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvfbfwma"
+    ],
+    "match": "0xec001057",
+    "mask": "0xfc00707f"
+  },
+  "vfwmaccbf16_vf": {
+    "encoding": "111011-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvfbfwma"
+    ],
+    "match": "0xec005057",
+    "mask": "0xfc00707f"
+  },
+  "vfncvtbf16_f_f_w": {
+    "encoding": "010010------11101001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvfbfmin"
+    ],
+    "match": "0x480e9057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfwcvtbf16_f_f_v": {
+    "encoding": "010010------01101001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvfbfmin"
+    ],
+    "match": "0x48069057",
+    "mask": "0xfc0ff07f"
+  },
+  "vclmul_vv": {
+    "encoding": "001100-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbc",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x30002057",
+    "mask": "0xfc00707f"
+  },
+  "vclmul_vx": {
+    "encoding": "001100-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbc",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x30006057",
+    "mask": "0xfc00707f"
+  },
+  "vclmulh_vv": {
+    "encoding": "001101-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbc",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x34002057",
+    "mask": "0xfc00707f"
+  },
+  "vclmulh_vx": {
+    "encoding": "001101-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbc",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x34006057",
+    "mask": "0xfc00707f"
+  },
+  "vandn_vv": {
+    "encoding": "000001-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x4000057",
+    "mask": "0xfc00707f"
+  },
+  "vandn_vx": {
+    "encoding": "000001-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x4004057",
+    "mask": "0xfc00707f"
+  },
+  "vbrev_v": {
+    "encoding": "010010------01010010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x48052057",
+    "mask": "0xfc0ff07f"
+  },
+  "vbrev8_v": {
+    "encoding": "010010------01000010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x48042057",
+    "mask": "0xfc0ff07f"
+  },
+  "vrev8_v": {
+    "encoding": "010010------01001010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x4804a057",
+    "mask": "0xfc0ff07f"
+  },
+  "vclz_v": {
+    "encoding": "010010------01100010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x48062057",
+    "mask": "0xfc0ff07f"
+  },
+  "vctz_v": {
+    "encoding": "010010------01101010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x4806a057",
+    "mask": "0xfc0ff07f"
+  },
+  "vcpop_v": {
+    "encoding": "010010------01110010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x48072057",
+    "mask": "0xfc0ff07f"
+  },
+  "vrol_vv": {
+    "encoding": "010101-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x54000057",
+    "mask": "0xfc00707f"
+  },
+  "vrol_vx": {
+    "encoding": "010101-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x54004057",
+    "mask": "0xfc00707f"
+  },
+  "vror_vv": {
+    "encoding": "010100-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x50000057",
+    "mask": "0xfc00707f"
+  },
+  "vror_vx": {
+    "encoding": "010100-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x50004057",
+    "mask": "0xfc00707f"
+  },
+  "vror_vi": {
+    "encoding": "01010------------011-----1010111",
+    "variable_fields": [
+      "zimm6hi",
+      "vm",
+      "vs2",
+      "zimm6lo",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0x50003057",
+    "mask": "0xf800707f"
+  },
+  "vwsll_vv": {
+    "encoding": "110101-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0xd4000057",
+    "mask": "0xfc00707f"
+  },
+  "vwsll_vx": {
+    "encoding": "110101-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0xd4004057",
+    "mask": "0xfc00707f"
+  },
+  "vwsll_vi": {
+    "encoding": "110101-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "zimm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_zvbb",
+      "rv_zvks",
+      "rv_zvkn"
+    ],
+    "match": "0xd4003057",
+    "mask": "0xfc00707f"
+  },
+  "sm3p0": {
+    "encoding": "000100001000-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zksh",
+      "rv_zks"
+    ],
+    "match": "0x10801013",
+    "mask": "0xfff0707f"
+  },
+  "sm3p1": {
+    "encoding": "000100001001-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zksh",
+      "rv_zks"
+    ],
+    "match": "0x10901013",
+    "mask": "0xfff0707f"
+  },
+  "sm4ed": {
+    "encoding": "--11000----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "bs"
+    ],
+    "extension": [
+      "rv_zksed",
+      "rv_zks"
+    ],
+    "match": "0x30000033",
+    "mask": "0x3e00707f"
+  },
+  "sm4ks": {
+    "encoding": "--11010----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "bs"
+    ],
+    "extension": [
+      "rv_zksed",
+      "rv_zks"
+    ],
+    "match": "0x34000033",
+    "mask": "0x3e00707f"
+  },
+  "sha256sum0": {
+    "encoding": "000100000000-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zknh",
+      "rv_zkn",
+      "rv_zk"
+    ],
+    "match": "0x10001013",
+    "mask": "0xfff0707f"
+  },
+  "sha256sum1": {
+    "encoding": "000100000001-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zknh",
+      "rv_zkn",
+      "rv_zk"
+    ],
+    "match": "0x10101013",
+    "mask": "0xfff0707f"
+  },
+  "sha256sig0": {
+    "encoding": "000100000010-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zknh",
+      "rv_zkn",
+      "rv_zk"
+    ],
+    "match": "0x10201013",
+    "mask": "0xfff0707f"
+  },
+  "sha256sig1": {
+    "encoding": "000100000011-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zknh",
+      "rv_zkn",
+      "rv_zk"
+    ],
+    "match": "0x10301013",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_N": {
+    "encoding": "1-00--0111-------100-----1110011",
+    "variable_fields": [
+      "mop_r_t_30",
+      "mop_r_t_27_26",
+      "mop_r_t_21_20",
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x81c04073",
+    "mask": "0xb3c0707f"
+  },
+  "mop_rr_N": {
+    "encoding": "1-00--1----------100-----1110011",
+    "variable_fields": [
+      "mop_rr_t_30",
+      "mop_rr_t_27_26",
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x82004073",
+    "mask": "0xb200707f"
+  },
+  "fence_i": {
+    "encoding": "-----------------001-----0001111",
+    "variable_fields": [
+      "imm12",
+      "rs1",
+      "rd"
+    ],
+    "extension": [
+      "rv_zifencei"
+    ],
+    "match": "0x100f",
+    "mask": "0x707f"
+  },
+  "csrrw": {
+    "encoding": "-----------------001-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "csr"
+    ],
+    "extension": [
+      "rv_zicsr"
+    ],
+    "match": "0x1073",
+    "mask": "0x707f"
+  },
+  "csrrs": {
+    "encoding": "-----------------010-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "csr"
+    ],
+    "extension": [
+      "rv_zicsr"
+    ],
+    "match": "0x2073",
+    "mask": "0x707f"
+  },
+  "csrrc": {
+    "encoding": "-----------------011-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "csr"
+    ],
+    "extension": [
+      "rv_zicsr"
+    ],
+    "match": "0x3073",
+    "mask": "0x707f"
+  },
+  "csrrwi": {
+    "encoding": "-----------------101-----1110011",
+    "variable_fields": [
+      "rd",
+      "csr",
+      "zimm"
+    ],
+    "extension": [
+      "rv_zicsr"
+    ],
+    "match": "0x5073",
+    "mask": "0x707f"
+  },
+  "csrrsi": {
+    "encoding": "-----------------110-----1110011",
+    "variable_fields": [
+      "rd",
+      "csr",
+      "zimm"
+    ],
+    "extension": [
+      "rv_zicsr"
+    ],
+    "match": "0x6073",
+    "mask": "0x707f"
+  },
+  "csrrci": {
+    "encoding": "-----------------111-----1110011",
+    "variable_fields": [
+      "rd",
+      "csr",
+      "zimm"
+    ],
+    "extension": [
+      "rv_zicsr"
+    ],
+    "match": "0x7073",
+    "mask": "0x707f"
+  },
+  "czero_eqz": {
+    "encoding": "0000111----------101-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zicond"
+    ],
+    "match": "0xe005033",
+    "mask": "0xfe00707f"
+  },
+  "czero_nez": {
+    "encoding": "0000111----------111-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zicond"
+    ],
+    "match": "0xe007033",
+    "mask": "0xfe00707f"
+  },
+  "ssamoswap_w": {
+    "encoding": "01001------------010-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zicfiss"
+    ],
+    "match": "0x4800202f",
+    "mask": "0xf800707f"
+  },
+  "ssamoswap_d": {
+    "encoding": "01001------------011-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zicfiss"
+    ],
+    "match": "0x4800302f",
+    "mask": "0xf800707f"
+  },
+  "cbo_clean": {
+    "encoding": "000000000001-----010000000001111",
+    "variable_fields": [
+      "rs1"
+    ],
+    "extension": [
+      "rv_zicbo"
+    ],
+    "match": "0x10200f",
+    "mask": "0xfff07fff"
+  },
+  "cbo_flush": {
+    "encoding": "000000000010-----010000000001111",
+    "variable_fields": [
+      "rs1"
+    ],
+    "extension": [
+      "rv_zicbo"
+    ],
+    "match": "0x20200f",
+    "mask": "0xfff07fff"
+  },
+  "cbo_inval": {
+    "encoding": "000000000000-----010000000001111",
+    "variable_fields": [
+      "rs1"
+    ],
+    "extension": [
+      "rv_zicbo"
+    ],
+    "match": "0x200f",
+    "mask": "0xfff07fff"
+  },
+  "cbo_zero": {
+    "encoding": "000000000100-----010000000001111",
+    "variable_fields": [
+      "rs1"
+    ],
+    "extension": [
+      "rv_zicbo"
+    ],
+    "match": "0x40200f",
+    "mask": "0xfff07fff"
+  },
+  "fli_h": {
+    "encoding": "111101000001-----000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zfh_zfa"
+    ],
+    "match": "0xf4100053",
+    "mask": "0xfff0707f"
+  },
+  "fminm_h": {
+    "encoding": "0010110----------010-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zfh_zfa"
+    ],
+    "match": "0x2c002053",
+    "mask": "0xfe00707f"
+  },
+  "fmaxm_h": {
+    "encoding": "0010110----------011-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zfh_zfa"
+    ],
+    "match": "0x2c003053",
+    "mask": "0xfe00707f"
+  },
+  "fround_h": {
+    "encoding": "010001000100-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh_zfa"
+    ],
+    "match": "0x44400053",
+    "mask": "0xfff0007f"
+  },
+  "froundnx_h": {
+    "encoding": "010001000101-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh_zfa"
+    ],
+    "match": "0x44500053",
+    "mask": "0xfff0007f"
+  },
+  "fleq_h": {
+    "encoding": "1010010----------100-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zfh_zfa"
+    ],
+    "match": "0xa4004053",
+    "mask": "0xfe00707f"
+  },
+  "fltq_h": {
+    "encoding": "1010010----------101-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zfh_zfa"
+    ],
+    "match": "0xa4005053",
+    "mask": "0xfe00707f"
+  },
+  "flh": {
+    "encoding": "-----------------001-----0000111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x1007",
+    "mask": "0x707f"
+  },
+  "fsh": {
+    "encoding": "-----------------001-----0100111",
+    "variable_fields": [
+      "imm12hi",
+      "rs1",
+      "rs2",
+      "imm12lo"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x1027",
+    "mask": "0x707f"
+  },
+  "fmadd_h": {
+    "encoding": "-----10------------------1000011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x4000043",
+    "mask": "0x600007f"
+  },
+  "fmsub_h": {
+    "encoding": "-----10------------------1000111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x4000047",
+    "mask": "0x600007f"
+  },
+  "fnmsub_h": {
+    "encoding": "-----10------------------1001011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x400004b",
+    "mask": "0x600007f"
+  },
+  "fnmadd_h": {
+    "encoding": "-----10------------------1001111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x400004f",
+    "mask": "0x600007f"
+  },
+  "fadd_h": {
+    "encoding": "0000010------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x4000053",
+    "mask": "0xfe00007f"
+  },
+  "fsub_h": {
+    "encoding": "0000110------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0xc000053",
+    "mask": "0xfe00007f"
+  },
+  "fmul_h": {
+    "encoding": "0001010------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x14000053",
+    "mask": "0xfe00007f"
+  },
+  "fdiv_h": {
+    "encoding": "0001110------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x1c000053",
+    "mask": "0xfe00007f"
+  },
+  "fsqrt_h": {
+    "encoding": "010111000000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x5c000053",
+    "mask": "0xfff0007f"
+  },
+  "fsgnj_h": {
+    "encoding": "0010010----------000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x24000053",
+    "mask": "0xfe00707f"
+  },
+  "fsgnjn_h": {
+    "encoding": "0010010----------001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x24001053",
+    "mask": "0xfe00707f"
+  },
+  "fsgnjx_h": {
+    "encoding": "0010010----------010-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x24002053",
+    "mask": "0xfe00707f"
+  },
+  "fmin_h": {
+    "encoding": "0010110----------000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x2c000053",
+    "mask": "0xfe00707f"
+  },
+  "fmax_h": {
+    "encoding": "0010110----------001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x2c001053",
+    "mask": "0xfe00707f"
+  },
+  "fcvt_s_h": {
+    "encoding": "010000000010-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x40200053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_h_s": {
+    "encoding": "010001000000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0x44000053",
+    "mask": "0xfff0007f"
+  },
+  "feq_h": {
+    "encoding": "1010010----------010-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0xa4002053",
+    "mask": "0xfe00707f"
+  },
+  "flt_h": {
+    "encoding": "1010010----------001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0xa4001053",
+    "mask": "0xfe00707f"
+  },
+  "fle_h": {
+    "encoding": "1010010----------000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0xa4000053",
+    "mask": "0xfe00707f"
+  },
+  "fclass_h": {
+    "encoding": "111001000000-----001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0xe4001053",
+    "mask": "0xfff0707f"
+  },
+  "fcvt_w_h": {
+    "encoding": "110001000000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0xc4000053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_wu_h": {
+    "encoding": "110001000001-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0xc4100053",
+    "mask": "0xfff0007f"
+  },
+  "fmv_x_h": {
+    "encoding": "111001000000-----000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0xe4000053",
+    "mask": "0xfff0707f"
+  },
+  "fcvt_h_w": {
+    "encoding": "110101000000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0xd4000053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_h_wu": {
+    "encoding": "110101000001-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0xd4100053",
+    "mask": "0xfff0007f"
+  },
+  "fmv_h_x": {
+    "encoding": "111101000000-----000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zfh"
+    ],
+    "match": "0xf4000053",
+    "mask": "0xfff0707f"
+  },
+  "fcvt_bf16_s": {
+    "encoding": "010001001000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfbfmin"
+    ],
+    "match": "0x44800053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_s_bf16": {
+    "encoding": "010000000110-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_zfbfmin"
+    ],
+    "match": "0x40600053",
+    "mask": "0xfff0007f"
+  },
+  "cm_jalt": {
+    "encoding": "----------------101000--------10",
+    "variable_fields": [
+      "c_index"
+    ],
+    "extension": [
+      "rv_zcmt"
+    ],
+    "match": "0xa002",
+    "mask": "0xfc03"
+  },
+  "cm_push": {
+    "encoding": "----------------10111000------10",
+    "variable_fields": [
+      "c_rlist",
+      "c_spimm"
+    ],
+    "extension": [
+      "rv_zcmp"
+    ],
+    "match": "0xb802",
+    "mask": "0xff03"
+  },
+  "cm_pop": {
+    "encoding": "----------------10111010------10",
+    "variable_fields": [
+      "c_rlist",
+      "c_spimm"
+    ],
+    "extension": [
+      "rv_zcmp"
+    ],
+    "match": "0xba02",
+    "mask": "0xff03"
+  },
+  "cm_popretz": {
+    "encoding": "----------------10111100------10",
+    "variable_fields": [
+      "c_rlist",
+      "c_spimm"
+    ],
+    "extension": [
+      "rv_zcmp"
+    ],
+    "match": "0xbc02",
+    "mask": "0xff03"
+  },
+  "cm_popret": {
+    "encoding": "----------------10111110------10",
+    "variable_fields": [
+      "c_rlist",
+      "c_spimm"
+    ],
+    "extension": [
+      "rv_zcmp"
+    ],
+    "match": "0xbe02",
+    "mask": "0xff03"
+  },
+  "cm_mvsa01": {
+    "encoding": "----------------101011---01---10",
+    "variable_fields": [
+      "c_sreg1",
+      "c_sreg2"
+    ],
+    "extension": [
+      "rv_zcmp"
+    ],
+    "match": "0xac22",
+    "mask": "0xfc63"
+  },
+  "cm_mva01s": {
+    "encoding": "----------------101011---11---10",
+    "variable_fields": [
+      "c_sreg1",
+      "c_sreg2"
+    ],
+    "extension": [
+      "rv_zcmp"
+    ],
+    "match": "0xac62",
+    "mask": "0xfc63"
+  },
+  "c_mop_N": {
+    "encoding": "----------------01100---10000001",
+    "variable_fields": [
+      "c_mop_t"
+    ],
+    "extension": [
+      "rv_zcmop"
+    ],
+    "match": "0x6081",
+    "mask": "0xf8ff"
+  },
+  "c_lbu": {
+    "encoding": "----------------100000--------00",
+    "variable_fields": [
+      "rd_p",
+      "rs1_p",
+      "c_uimm2"
+    ],
+    "extension": [
+      "rv_zcb"
+    ],
+    "match": "0x8000",
+    "mask": "0xfc03"
+  },
+  "c_lhu": {
+    "encoding": "----------------100001---0----00",
+    "variable_fields": [
+      "rd_p",
+      "rs1_p",
+      "c_uimm1"
+    ],
+    "extension": [
+      "rv_zcb"
+    ],
+    "match": "0x8400",
+    "mask": "0xfc43"
+  },
+  "c_lh": {
+    "encoding": "----------------100001---1----00",
+    "variable_fields": [
+      "rd_p",
+      "rs1_p",
+      "c_uimm1"
+    ],
+    "extension": [
+      "rv_zcb"
+    ],
+    "match": "0x8440",
+    "mask": "0xfc43"
+  },
+  "c_sb": {
+    "encoding": "----------------100010--------00",
+    "variable_fields": [
+      "rs2_p",
+      "rs1_p",
+      "c_uimm2"
+    ],
+    "extension": [
+      "rv_zcb"
+    ],
+    "match": "0x8800",
+    "mask": "0xfc03"
+  },
+  "c_sh": {
+    "encoding": "----------------100011---0----00",
+    "variable_fields": [
+      "rs2_p",
+      "rs1_p",
+      "c_uimm1"
+    ],
+    "extension": [
+      "rv_zcb"
+    ],
+    "match": "0x8c00",
+    "mask": "0xfc43"
+  },
+  "c_zext_b": {
+    "encoding": "----------------100111---1100001",
+    "variable_fields": [
+      "rd_rs1_p"
+    ],
+    "extension": [
+      "rv_zcb"
+    ],
+    "match": "0x9c61",
+    "mask": "0xfc7f"
+  },
+  "c_sext_b": {
+    "encoding": "----------------100111---1100101",
+    "variable_fields": [
+      "rd_rs1_p"
+    ],
+    "extension": [
+      "rv_zcb"
+    ],
+    "match": "0x9c65",
+    "mask": "0xfc7f"
+  },
+  "c_zext_h": {
+    "encoding": "----------------100111---1101001",
+    "variable_fields": [
+      "rd_rs1_p"
+    ],
+    "extension": [
+      "rv_zcb"
+    ],
+    "match": "0x9c69",
+    "mask": "0xfc7f"
+  },
+  "c_sext_h": {
+    "encoding": "----------------100111---1101101",
+    "variable_fields": [
+      "rd_rs1_p"
+    ],
+    "extension": [
+      "rv_zcb"
+    ],
+    "match": "0x9c6d",
+    "mask": "0xfc7f"
+  },
+  "c_not": {
+    "encoding": "----------------100111---1110101",
+    "variable_fields": [
+      "rd_rs1_p"
+    ],
+    "extension": [
+      "rv_zcb"
+    ],
+    "match": "0x9c75",
+    "mask": "0xfc7f"
+  },
+  "c_mul": {
+    "encoding": "----------------100111---10---01",
+    "variable_fields": [
+      "rd_rs1_p",
+      "rs2_p"
+    ],
+    "extension": [
+      "rv_zcb"
+    ],
+    "match": "0x9c41",
+    "mask": "0xfc63"
+  },
+  "bclr": {
+    "encoding": "0100100----------001-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbs"
+    ],
+    "match": "0x48001033",
+    "mask": "0xfe00707f"
+  },
+  "bext": {
+    "encoding": "0100100----------101-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbs"
+    ],
+    "match": "0x48005033",
+    "mask": "0xfe00707f"
+  },
+  "binv": {
+    "encoding": "0110100----------001-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbs"
+    ],
+    "match": "0x68001033",
+    "mask": "0xfe00707f"
+  },
+  "bset": {
+    "encoding": "0010100----------001-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbs"
+    ],
+    "match": "0x28001033",
+    "mask": "0xfe00707f"
+  },
+  "xperm4": {
+    "encoding": "0010100----------010-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbkx",
+      "rv_zks",
+      "rv_zkn",
+      "rv_zk"
+    ],
+    "match": "0x28002033",
+    "mask": "0xfe00707f"
+  },
+  "xperm8": {
+    "encoding": "0010100----------100-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbkx",
+      "rv_zks",
+      "rv_zkn",
+      "rv_zk"
+    ],
+    "match": "0x28004033",
+    "mask": "0xfe00707f"
+  },
+  "pack": {
+    "encoding": "0000100----------100-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbkb",
+      "rv_zks",
+      "rv_zkn",
+      "rv_zk"
+    ],
+    "match": "0x8004033",
+    "mask": "0xfe00707f"
+  },
+  "packh": {
+    "encoding": "0000100----------111-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbkb",
+      "rv_zks",
+      "rv_zkn",
+      "rv_zk"
+    ],
+    "match": "0x8007033",
+    "mask": "0xfe00707f"
+  },
+  "clmul": {
+    "encoding": "0000101----------001-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbc",
+      "rv_zks",
+      "rv_zkn",
+      "rv_zk",
+      "rv_zbkc"
+    ],
+    "match": "0xa001033",
+    "mask": "0xfe00707f"
+  },
+  "clmulr": {
+    "encoding": "0000101----------010-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbc"
+    ],
+    "match": "0xa002033",
+    "mask": "0xfe00707f"
+  },
+  "clmulh": {
+    "encoding": "0000101----------011-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbc",
+      "rv_zks",
+      "rv_zkn",
+      "rv_zk",
+      "rv_zbkc"
+    ],
+    "match": "0xa003033",
+    "mask": "0xfe00707f"
+  },
+  "andn": {
+    "encoding": "0100000----------111-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbb",
+      "rv_zks",
+      "rv_zkn",
+      "rv_zk",
+      "rv_zbkb"
+    ],
+    "match": "0x40007033",
+    "mask": "0xfe00707f"
+  },
+  "orn": {
+    "encoding": "0100000----------110-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbb",
+      "rv_zks",
+      "rv_zkn",
+      "rv_zk",
+      "rv_zbkb"
+    ],
+    "match": "0x40006033",
+    "mask": "0xfe00707f"
+  },
+  "xnor": {
+    "encoding": "0100000----------100-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbb",
+      "rv_zks",
+      "rv_zkn",
+      "rv_zk",
+      "rv_zbkb"
+    ],
+    "match": "0x40004033",
+    "mask": "0xfe00707f"
+  },
+  "clz": {
+    "encoding": "011000000000-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zbb"
+    ],
+    "match": "0x60001013",
+    "mask": "0xfff0707f"
+  },
+  "ctz": {
+    "encoding": "011000000001-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zbb"
+    ],
+    "match": "0x60101013",
+    "mask": "0xfff0707f"
+  },
+  "cpop": {
+    "encoding": "011000000010-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zbb"
+    ],
+    "match": "0x60201013",
+    "mask": "0xfff0707f"
+  },
+  "max": {
+    "encoding": "0000101----------110-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbb"
+    ],
+    "match": "0xa006033",
+    "mask": "0xfe00707f"
+  },
+  "maxu": {
+    "encoding": "0000101----------111-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbb"
+    ],
+    "match": "0xa007033",
+    "mask": "0xfe00707f"
+  },
+  "min": {
+    "encoding": "0000101----------100-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbb"
+    ],
+    "match": "0xa004033",
+    "mask": "0xfe00707f"
+  },
+  "minu": {
+    "encoding": "0000101----------101-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbb"
+    ],
+    "match": "0xa005033",
+    "mask": "0xfe00707f"
+  },
+  "sext_b": {
+    "encoding": "011000000100-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zbb"
+    ],
+    "match": "0x60401013",
+    "mask": "0xfff0707f"
+  },
+  "sext_h": {
+    "encoding": "011000000101-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zbb"
+    ],
+    "match": "0x60501013",
+    "mask": "0xfff0707f"
+  },
+  "rol": {
+    "encoding": "0110000----------001-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbb",
+      "rv_zks",
+      "rv_zkn",
+      "rv_zk",
+      "rv_zbkb"
+    ],
+    "match": "0x60001033",
+    "mask": "0xfe00707f"
+  },
+  "ror": {
+    "encoding": "0110000----------101-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbb",
+      "rv_zks",
+      "rv_zkn",
+      "rv_zk",
+      "rv_zbkb"
+    ],
+    "match": "0x60005033",
+    "mask": "0xfe00707f"
+  },
+  "sh1add": {
+    "encoding": "0010000----------010-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zba"
+    ],
+    "match": "0x20002033",
+    "mask": "0xfe00707f"
+  },
+  "sh2add": {
+    "encoding": "0010000----------100-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zba"
+    ],
+    "match": "0x20004033",
+    "mask": "0xfe00707f"
+  },
+  "sh3add": {
+    "encoding": "0010000----------110-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zba"
+    ],
+    "match": "0x20006033",
+    "mask": "0xfe00707f"
+  },
+  "wrs_nto": {
+    "encoding": "00000000110100000000000001110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_zawrs"
+    ],
+    "match": "0xd00073",
+    "mask": "0xffffffff"
+  },
+  "wrs_sto": {
+    "encoding": "00000001110100000000000001110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_zawrs"
+    ],
+    "match": "0x1d00073",
+    "mask": "0xffffffff"
+  },
+  "amocas_w": {
+    "encoding": "00101------------010-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zacas"
+    ],
+    "match": "0x2800202f",
+    "mask": "0xf800707f"
+  },
+  "amocas_d": {
+    "encoding": "00101------------011-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zacas"
+    ],
+    "match": "0x2800302f",
+    "mask": "0xf800707f"
+  },
+  "amoswap_b": {
+    "encoding": "00001------------000-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0x800002f",
+    "mask": "0xf800707f"
+  },
+  "amoadd_b": {
+    "encoding": "00000------------000-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0x2f",
+    "mask": "0xf800707f"
+  },
+  "amoxor_b": {
+    "encoding": "00100------------000-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0x2000002f",
+    "mask": "0xf800707f"
+  },
+  "amoand_b": {
+    "encoding": "01100------------000-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0x6000002f",
+    "mask": "0xf800707f"
+  },
+  "amoor_b": {
+    "encoding": "01000------------000-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0x4000002f",
+    "mask": "0xf800707f"
+  },
+  "amomin_b": {
+    "encoding": "10000------------000-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0x8000002f",
+    "mask": "0xf800707f"
+  },
+  "amomax_b": {
+    "encoding": "10100------------000-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0xa000002f",
+    "mask": "0xf800707f"
+  },
+  "amominu_b": {
+    "encoding": "11000------------000-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0xc000002f",
+    "mask": "0xf800707f"
+  },
+  "amomaxu_b": {
+    "encoding": "11100------------000-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0xe000002f",
+    "mask": "0xf800707f"
+  },
+  "amocas_b": {
+    "encoding": "00101------------000-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0x2800002f",
+    "mask": "0xf800707f"
+  },
+  "amoswap_h": {
+    "encoding": "00001------------001-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0x800102f",
+    "mask": "0xf800707f"
+  },
+  "amoadd_h": {
+    "encoding": "00000------------001-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0x102f",
+    "mask": "0xf800707f"
+  },
+  "amoxor_h": {
+    "encoding": "00100------------001-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0x2000102f",
+    "mask": "0xf800707f"
+  },
+  "amoand_h": {
+    "encoding": "01100------------001-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0x6000102f",
+    "mask": "0xf800707f"
+  },
+  "amoor_h": {
+    "encoding": "01000------------001-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0x4000102f",
+    "mask": "0xf800707f"
+  },
+  "amomin_h": {
+    "encoding": "10000------------001-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0x8000102f",
+    "mask": "0xf800707f"
+  },
+  "amomax_h": {
+    "encoding": "10100------------001-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0xa000102f",
+    "mask": "0xf800707f"
+  },
+  "amominu_h": {
+    "encoding": "11000------------001-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0xc000102f",
+    "mask": "0xf800707f"
+  },
+  "amomaxu_h": {
+    "encoding": "11100------------001-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0xe000102f",
+    "mask": "0xf800707f"
+  },
+  "amocas_h": {
+    "encoding": "00101------------001-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_zabha"
+    ],
+    "match": "0x2800102f",
+    "mask": "0xf800707f"
+  },
+  "vsetivli": {
+    "encoding": "11---------------111-----1010111",
+    "variable_fields": [
+      "zimm10",
+      "zimm",
+      "rd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc0007057",
+    "mask": "0xc000707f"
+  },
+  "vsetvli": {
+    "encoding": "0----------------111-----1010111",
+    "variable_fields": [
+      "zimm11",
+      "rs1",
+      "rd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x7057",
+    "mask": "0x8000707f"
+  },
+  "vsetvl": {
+    "encoding": "1000000----------111-----1010111",
+    "variable_fields": [
+      "rs2",
+      "rs1",
+      "rd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80007057",
+    "mask": "0xfe00707f"
+  },
+  "vlm_v": {
+    "encoding": "000000101011-----000-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2b00007",
+    "mask": "0xfff0707f"
+  },
+  "vsm_v": {
+    "encoding": "000000101011-----000-----0100111",
+    "variable_fields": [
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2b00027",
+    "mask": "0xfff0707f"
+  },
+  "vle8_v": {
+    "encoding": "000000-00000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x7",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg2e8_v": {
+    "encoding": "001000-00000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x20000007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg3e8_v": {
+    "encoding": "010000-00000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x40000007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg4e8_v": {
+    "encoding": "011000-00000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x60000007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg5e8_v": {
+    "encoding": "100000-00000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80000007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg6e8_v": {
+    "encoding": "101000-00000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa0000007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg7e8_v": {
+    "encoding": "110000-00000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc0000007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg8e8_v": {
+    "encoding": "111000-00000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe0000007",
+    "mask": "0xfdf0707f"
+  },
+  "vle16_v": {
+    "encoding": "000000-00000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x5007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg2e16_v": {
+    "encoding": "001000-00000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x20005007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg3e16_v": {
+    "encoding": "010000-00000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x40005007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg4e16_v": {
+    "encoding": "011000-00000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x60005007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg5e16_v": {
+    "encoding": "100000-00000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80005007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg6e16_v": {
+    "encoding": "101000-00000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa0005007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg7e16_v": {
+    "encoding": "110000-00000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc0005007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg8e16_v": {
+    "encoding": "111000-00000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe0005007",
+    "mask": "0xfdf0707f"
+  },
+  "vle32_v": {
+    "encoding": "000000-00000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg2e32_v": {
+    "encoding": "001000-00000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x20006007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg3e32_v": {
+    "encoding": "010000-00000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x40006007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg4e32_v": {
+    "encoding": "011000-00000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x60006007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg5e32_v": {
+    "encoding": "100000-00000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80006007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg6e32_v": {
+    "encoding": "101000-00000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa0006007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg7e32_v": {
+    "encoding": "110000-00000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc0006007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg8e32_v": {
+    "encoding": "111000-00000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe0006007",
+    "mask": "0xfdf0707f"
+  },
+  "vle64_v": {
+    "encoding": "000000-00000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x7007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg2e64_v": {
+    "encoding": "001000-00000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x20007007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg3e64_v": {
+    "encoding": "010000-00000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x40007007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg4e64_v": {
+    "encoding": "011000-00000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x60007007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg5e64_v": {
+    "encoding": "100000-00000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80007007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg6e64_v": {
+    "encoding": "101000-00000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa0007007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg7e64_v": {
+    "encoding": "110000-00000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc0007007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg8e64_v": {
+    "encoding": "111000-00000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe0007007",
+    "mask": "0xfdf0707f"
+  },
+  "vse8_v": {
+    "encoding": "000000-00000-----000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x27",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg2e8_v": {
+    "encoding": "001000-00000-----000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x20000027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg3e8_v": {
+    "encoding": "010000-00000-----000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x40000027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg4e8_v": {
+    "encoding": "011000-00000-----000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x60000027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg5e8_v": {
+    "encoding": "100000-00000-----000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80000027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg6e8_v": {
+    "encoding": "101000-00000-----000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa0000027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg7e8_v": {
+    "encoding": "110000-00000-----000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc0000027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg8e8_v": {
+    "encoding": "111000-00000-----000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe0000027",
+    "mask": "0xfdf0707f"
+  },
+  "vse16_v": {
+    "encoding": "000000-00000-----101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x5027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg2e16_v": {
+    "encoding": "001000-00000-----101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x20005027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg3e16_v": {
+    "encoding": "010000-00000-----101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x40005027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg4e16_v": {
+    "encoding": "011000-00000-----101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x60005027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg5e16_v": {
+    "encoding": "100000-00000-----101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80005027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg6e16_v": {
+    "encoding": "101000-00000-----101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa0005027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg7e16_v": {
+    "encoding": "110000-00000-----101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc0005027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg8e16_v": {
+    "encoding": "111000-00000-----101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe0005027",
+    "mask": "0xfdf0707f"
+  },
+  "vse32_v": {
+    "encoding": "000000-00000-----110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg2e32_v": {
+    "encoding": "001000-00000-----110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x20006027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg3e32_v": {
+    "encoding": "010000-00000-----110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x40006027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg4e32_v": {
+    "encoding": "011000-00000-----110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x60006027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg5e32_v": {
+    "encoding": "100000-00000-----110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80006027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg6e32_v": {
+    "encoding": "101000-00000-----110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa0006027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg7e32_v": {
+    "encoding": "110000-00000-----110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc0006027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg8e32_v": {
+    "encoding": "111000-00000-----110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe0006027",
+    "mask": "0xfdf0707f"
+  },
+  "vse64_v": {
+    "encoding": "000000-00000-----111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x7027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg2e64_v": {
+    "encoding": "001000-00000-----111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x20007027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg3e64_v": {
+    "encoding": "010000-00000-----111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x40007027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg4e64_v": {
+    "encoding": "011000-00000-----111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x60007027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg5e64_v": {
+    "encoding": "100000-00000-----111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80007027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg6e64_v": {
+    "encoding": "101000-00000-----111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa0007027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg7e64_v": {
+    "encoding": "110000-00000-----111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc0007027",
+    "mask": "0xfdf0707f"
+  },
+  "vsseg8e64_v": {
+    "encoding": "111000-00000-----111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe0007027",
+    "mask": "0xfdf0707f"
+  },
+  "vluxei8_v": {
+    "encoding": "000001-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4000007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg2ei8_v": {
+    "encoding": "001001-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x24000007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg3ei8_v": {
+    "encoding": "010001-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x44000007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg4ei8_v": {
+    "encoding": "011001-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x64000007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg5ei8_v": {
+    "encoding": "100001-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x84000007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg6ei8_v": {
+    "encoding": "101001-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa4000007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg7ei8_v": {
+    "encoding": "110001-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc4000007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg8ei8_v": {
+    "encoding": "111001-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe4000007",
+    "mask": "0xfc00707f"
+  },
+  "vluxei16_v": {
+    "encoding": "000001-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4005007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg2ei16_v": {
+    "encoding": "001001-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x24005007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg3ei16_v": {
+    "encoding": "010001-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x44005007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg4ei16_v": {
+    "encoding": "011001-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x64005007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg5ei16_v": {
+    "encoding": "100001-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x84005007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg6ei16_v": {
+    "encoding": "101001-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa4005007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg7ei16_v": {
+    "encoding": "110001-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc4005007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg8ei16_v": {
+    "encoding": "111001-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe4005007",
+    "mask": "0xfc00707f"
+  },
+  "vluxei32_v": {
+    "encoding": "000001-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4006007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg2ei32_v": {
+    "encoding": "001001-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x24006007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg3ei32_v": {
+    "encoding": "010001-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x44006007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg4ei32_v": {
+    "encoding": "011001-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x64006007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg5ei32_v": {
+    "encoding": "100001-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x84006007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg6ei32_v": {
+    "encoding": "101001-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa4006007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg7ei32_v": {
+    "encoding": "110001-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc4006007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg8ei32_v": {
+    "encoding": "111001-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe4006007",
+    "mask": "0xfc00707f"
+  },
+  "vluxei64_v": {
+    "encoding": "000001-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4007007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg2ei64_v": {
+    "encoding": "001001-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x24007007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg3ei64_v": {
+    "encoding": "010001-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x44007007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg4ei64_v": {
+    "encoding": "011001-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x64007007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg5ei64_v": {
+    "encoding": "100001-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x84007007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg6ei64_v": {
+    "encoding": "101001-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa4007007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg7ei64_v": {
+    "encoding": "110001-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc4007007",
+    "mask": "0xfc00707f"
+  },
+  "vluxseg8ei64_v": {
+    "encoding": "111001-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe4007007",
+    "mask": "0xfc00707f"
+  },
+  "vsuxei8_v": {
+    "encoding": "000001-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4000027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg2ei8_v": {
+    "encoding": "001001-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x24000027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg3ei8_v": {
+    "encoding": "010001-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x44000027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg4ei8_v": {
+    "encoding": "011001-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x64000027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg5ei8_v": {
+    "encoding": "100001-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x84000027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg6ei8_v": {
+    "encoding": "101001-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa4000027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg7ei8_v": {
+    "encoding": "110001-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc4000027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg8ei8_v": {
+    "encoding": "111001-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe4000027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxei16_v": {
+    "encoding": "000001-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4005027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg2ei16_v": {
+    "encoding": "001001-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x24005027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg3ei16_v": {
+    "encoding": "010001-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x44005027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg4ei16_v": {
+    "encoding": "011001-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x64005027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg5ei16_v": {
+    "encoding": "100001-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x84005027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg6ei16_v": {
+    "encoding": "101001-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa4005027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg7ei16_v": {
+    "encoding": "110001-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc4005027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg8ei16_v": {
+    "encoding": "111001-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe4005027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxei32_v": {
+    "encoding": "000001-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4006027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg2ei32_v": {
+    "encoding": "001001-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x24006027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg3ei32_v": {
+    "encoding": "010001-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x44006027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg4ei32_v": {
+    "encoding": "011001-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x64006027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg5ei32_v": {
+    "encoding": "100001-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x84006027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg6ei32_v": {
+    "encoding": "101001-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa4006027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg7ei32_v": {
+    "encoding": "110001-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc4006027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg8ei32_v": {
+    "encoding": "111001-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe4006027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxei64_v": {
+    "encoding": "000001-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4007027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg2ei64_v": {
+    "encoding": "001001-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x24007027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg3ei64_v": {
+    "encoding": "010001-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x44007027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg4ei64_v": {
+    "encoding": "011001-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x64007027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg5ei64_v": {
+    "encoding": "100001-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x84007027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg6ei64_v": {
+    "encoding": "101001-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa4007027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg7ei64_v": {
+    "encoding": "110001-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc4007027",
+    "mask": "0xfc00707f"
+  },
+  "vsuxseg8ei64_v": {
+    "encoding": "111001-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe4007027",
+    "mask": "0xfc00707f"
+  },
+  "vlse8_v": {
+    "encoding": "000010-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8000007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg2e8_v": {
+    "encoding": "001010-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x28000007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg3e8_v": {
+    "encoding": "010010-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48000007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg4e8_v": {
+    "encoding": "011010-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x68000007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg5e8_v": {
+    "encoding": "100010-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x88000007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg6e8_v": {
+    "encoding": "101010-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa8000007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg7e8_v": {
+    "encoding": "110010-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc8000007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg8e8_v": {
+    "encoding": "111010-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe8000007",
+    "mask": "0xfc00707f"
+  },
+  "vlse16_v": {
+    "encoding": "000010-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8005007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg2e16_v": {
+    "encoding": "001010-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x28005007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg3e16_v": {
+    "encoding": "010010-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48005007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg4e16_v": {
+    "encoding": "011010-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x68005007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg5e16_v": {
+    "encoding": "100010-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x88005007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg6e16_v": {
+    "encoding": "101010-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa8005007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg7e16_v": {
+    "encoding": "110010-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc8005007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg8e16_v": {
+    "encoding": "111010-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe8005007",
+    "mask": "0xfc00707f"
+  },
+  "vlse32_v": {
+    "encoding": "000010-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8006007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg2e32_v": {
+    "encoding": "001010-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x28006007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg3e32_v": {
+    "encoding": "010010-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48006007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg4e32_v": {
+    "encoding": "011010-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x68006007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg5e32_v": {
+    "encoding": "100010-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x88006007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg6e32_v": {
+    "encoding": "101010-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa8006007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg7e32_v": {
+    "encoding": "110010-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc8006007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg8e32_v": {
+    "encoding": "111010-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe8006007",
+    "mask": "0xfc00707f"
+  },
+  "vlse64_v": {
+    "encoding": "000010-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8007007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg2e64_v": {
+    "encoding": "001010-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x28007007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg3e64_v": {
+    "encoding": "010010-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48007007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg4e64_v": {
+    "encoding": "011010-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x68007007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg5e64_v": {
+    "encoding": "100010-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x88007007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg6e64_v": {
+    "encoding": "101010-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa8007007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg7e64_v": {
+    "encoding": "110010-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc8007007",
+    "mask": "0xfc00707f"
+  },
+  "vlsseg8e64_v": {
+    "encoding": "111010-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe8007007",
+    "mask": "0xfc00707f"
+  },
+  "vsse8_v": {
+    "encoding": "000010-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8000027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg2e8_v": {
+    "encoding": "001010-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x28000027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg3e8_v": {
+    "encoding": "010010-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48000027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg4e8_v": {
+    "encoding": "011010-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x68000027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg5e8_v": {
+    "encoding": "100010-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x88000027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg6e8_v": {
+    "encoding": "101010-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa8000027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg7e8_v": {
+    "encoding": "110010-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc8000027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg8e8_v": {
+    "encoding": "111010-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe8000027",
+    "mask": "0xfc00707f"
+  },
+  "vsse16_v": {
+    "encoding": "000010-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8005027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg2e16_v": {
+    "encoding": "001010-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x28005027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg3e16_v": {
+    "encoding": "010010-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48005027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg4e16_v": {
+    "encoding": "011010-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x68005027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg5e16_v": {
+    "encoding": "100010-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x88005027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg6e16_v": {
+    "encoding": "101010-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa8005027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg7e16_v": {
+    "encoding": "110010-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc8005027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg8e16_v": {
+    "encoding": "111010-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe8005027",
+    "mask": "0xfc00707f"
+  },
+  "vsse32_v": {
+    "encoding": "000010-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8006027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg2e32_v": {
+    "encoding": "001010-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x28006027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg3e32_v": {
+    "encoding": "010010-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48006027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg4e32_v": {
+    "encoding": "011010-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x68006027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg5e32_v": {
+    "encoding": "100010-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x88006027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg6e32_v": {
+    "encoding": "101010-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa8006027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg7e32_v": {
+    "encoding": "110010-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc8006027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg8e32_v": {
+    "encoding": "111010-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe8006027",
+    "mask": "0xfc00707f"
+  },
+  "vsse64_v": {
+    "encoding": "000010-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8007027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg2e64_v": {
+    "encoding": "001010-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x28007027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg3e64_v": {
+    "encoding": "010010-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48007027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg4e64_v": {
+    "encoding": "011010-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x68007027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg5e64_v": {
+    "encoding": "100010-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x88007027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg6e64_v": {
+    "encoding": "101010-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa8007027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg7e64_v": {
+    "encoding": "110010-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc8007027",
+    "mask": "0xfc00707f"
+  },
+  "vssseg8e64_v": {
+    "encoding": "111010-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "rs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe8007027",
+    "mask": "0xfc00707f"
+  },
+  "vloxei8_v": {
+    "encoding": "000011-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc000007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg2ei8_v": {
+    "encoding": "001011-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2c000007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg3ei8_v": {
+    "encoding": "010011-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4c000007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg4ei8_v": {
+    "encoding": "011011-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6c000007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg5ei8_v": {
+    "encoding": "100011-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8c000007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg6ei8_v": {
+    "encoding": "101011-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xac000007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg7ei8_v": {
+    "encoding": "110011-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xcc000007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg8ei8_v": {
+    "encoding": "111011-----------000-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xec000007",
+    "mask": "0xfc00707f"
+  },
+  "vloxei16_v": {
+    "encoding": "000011-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc005007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg2ei16_v": {
+    "encoding": "001011-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2c005007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg3ei16_v": {
+    "encoding": "010011-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4c005007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg4ei16_v": {
+    "encoding": "011011-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6c005007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg5ei16_v": {
+    "encoding": "100011-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8c005007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg6ei16_v": {
+    "encoding": "101011-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xac005007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg7ei16_v": {
+    "encoding": "110011-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xcc005007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg8ei16_v": {
+    "encoding": "111011-----------101-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xec005007",
+    "mask": "0xfc00707f"
+  },
+  "vloxei32_v": {
+    "encoding": "000011-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc006007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg2ei32_v": {
+    "encoding": "001011-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2c006007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg3ei32_v": {
+    "encoding": "010011-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4c006007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg4ei32_v": {
+    "encoding": "011011-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6c006007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg5ei32_v": {
+    "encoding": "100011-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8c006007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg6ei32_v": {
+    "encoding": "101011-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xac006007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg7ei32_v": {
+    "encoding": "110011-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xcc006007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg8ei32_v": {
+    "encoding": "111011-----------110-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xec006007",
+    "mask": "0xfc00707f"
+  },
+  "vloxei64_v": {
+    "encoding": "000011-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc007007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg2ei64_v": {
+    "encoding": "001011-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2c007007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg3ei64_v": {
+    "encoding": "010011-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4c007007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg4ei64_v": {
+    "encoding": "011011-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6c007007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg5ei64_v": {
+    "encoding": "100011-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8c007007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg6ei64_v": {
+    "encoding": "101011-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xac007007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg7ei64_v": {
+    "encoding": "110011-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xcc007007",
+    "mask": "0xfc00707f"
+  },
+  "vloxseg8ei64_v": {
+    "encoding": "111011-----------111-----0000111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xec007007",
+    "mask": "0xfc00707f"
+  },
+  "vsoxei8_v": {
+    "encoding": "000011-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc000027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg2ei8_v": {
+    "encoding": "001011-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2c000027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg3ei8_v": {
+    "encoding": "010011-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4c000027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg4ei8_v": {
+    "encoding": "011011-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6c000027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg5ei8_v": {
+    "encoding": "100011-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8c000027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg6ei8_v": {
+    "encoding": "101011-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xac000027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg7ei8_v": {
+    "encoding": "110011-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xcc000027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg8ei8_v": {
+    "encoding": "111011-----------000-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xec000027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxei16_v": {
+    "encoding": "000011-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc005027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg2ei16_v": {
+    "encoding": "001011-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2c005027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg3ei16_v": {
+    "encoding": "010011-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4c005027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg4ei16_v": {
+    "encoding": "011011-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6c005027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg5ei16_v": {
+    "encoding": "100011-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8c005027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg6ei16_v": {
+    "encoding": "101011-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xac005027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg7ei16_v": {
+    "encoding": "110011-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xcc005027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg8ei16_v": {
+    "encoding": "111011-----------101-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xec005027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxei32_v": {
+    "encoding": "000011-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc006027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg2ei32_v": {
+    "encoding": "001011-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2c006027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg3ei32_v": {
+    "encoding": "010011-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4c006027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg4ei32_v": {
+    "encoding": "011011-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6c006027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg5ei32_v": {
+    "encoding": "100011-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8c006027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg6ei32_v": {
+    "encoding": "101011-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xac006027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg7ei32_v": {
+    "encoding": "110011-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xcc006027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg8ei32_v": {
+    "encoding": "111011-----------110-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xec006027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxei64_v": {
+    "encoding": "000011-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc007027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg2ei64_v": {
+    "encoding": "001011-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2c007027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg3ei64_v": {
+    "encoding": "010011-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4c007027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg4ei64_v": {
+    "encoding": "011011-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6c007027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg5ei64_v": {
+    "encoding": "100011-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8c007027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg6ei64_v": {
+    "encoding": "101011-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xac007027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg7ei64_v": {
+    "encoding": "110011-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xcc007027",
+    "mask": "0xfc00707f"
+  },
+  "vsoxseg8ei64_v": {
+    "encoding": "111011-----------111-----0100111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xec007027",
+    "mask": "0xfc00707f"
+  },
+  "vle8ff_v": {
+    "encoding": "000000-10000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x1000007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg2e8ff_v": {
+    "encoding": "001000-10000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x21000007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg3e8ff_v": {
+    "encoding": "010000-10000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x41000007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg4e8ff_v": {
+    "encoding": "011000-10000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x61000007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg5e8ff_v": {
+    "encoding": "100000-10000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x81000007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg6e8ff_v": {
+    "encoding": "101000-10000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa1000007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg7e8ff_v": {
+    "encoding": "110000-10000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc1000007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg8e8ff_v": {
+    "encoding": "111000-10000-----000-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe1000007",
+    "mask": "0xfdf0707f"
+  },
+  "vle16ff_v": {
+    "encoding": "000000-10000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x1005007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg2e16ff_v": {
+    "encoding": "001000-10000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x21005007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg3e16ff_v": {
+    "encoding": "010000-10000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x41005007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg4e16ff_v": {
+    "encoding": "011000-10000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x61005007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg5e16ff_v": {
+    "encoding": "100000-10000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x81005007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg6e16ff_v": {
+    "encoding": "101000-10000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa1005007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg7e16ff_v": {
+    "encoding": "110000-10000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc1005007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg8e16ff_v": {
+    "encoding": "111000-10000-----101-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe1005007",
+    "mask": "0xfdf0707f"
+  },
+  "vle32ff_v": {
+    "encoding": "000000-10000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x1006007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg2e32ff_v": {
+    "encoding": "001000-10000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x21006007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg3e32ff_v": {
+    "encoding": "010000-10000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x41006007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg4e32ff_v": {
+    "encoding": "011000-10000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x61006007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg5e32ff_v": {
+    "encoding": "100000-10000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x81006007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg6e32ff_v": {
+    "encoding": "101000-10000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa1006007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg7e32ff_v": {
+    "encoding": "110000-10000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc1006007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg8e32ff_v": {
+    "encoding": "111000-10000-----110-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe1006007",
+    "mask": "0xfdf0707f"
+  },
+  "vle64ff_v": {
+    "encoding": "000000-10000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x1007007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg2e64ff_v": {
+    "encoding": "001000-10000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x21007007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg3e64ff_v": {
+    "encoding": "010000-10000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x41007007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg4e64ff_v": {
+    "encoding": "011000-10000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x61007007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg5e64ff_v": {
+    "encoding": "100000-10000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x81007007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg6e64ff_v": {
+    "encoding": "101000-10000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa1007007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg7e64ff_v": {
+    "encoding": "110000-10000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc1007007",
+    "mask": "0xfdf0707f"
+  },
+  "vlseg8e64ff_v": {
+    "encoding": "111000-10000-----111-----0000111",
+    "variable_fields": [
+      "vm",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe1007007",
+    "mask": "0xfdf0707f"
+  },
+  "vl1re8_v": {
+    "encoding": "000000101000-----000-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2800007",
+    "mask": "0xfff0707f"
+  },
+  "vl1re16_v": {
+    "encoding": "000000101000-----101-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2805007",
+    "mask": "0xfff0707f"
+  },
+  "vl1re32_v": {
+    "encoding": "000000101000-----110-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2806007",
+    "mask": "0xfff0707f"
+  },
+  "vl1re64_v": {
+    "encoding": "000000101000-----111-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2807007",
+    "mask": "0xfff0707f"
+  },
+  "vl2re8_v": {
+    "encoding": "001000101000-----000-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x22800007",
+    "mask": "0xfff0707f"
+  },
+  "vl2re16_v": {
+    "encoding": "001000101000-----101-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x22805007",
+    "mask": "0xfff0707f"
+  },
+  "vl2re32_v": {
+    "encoding": "001000101000-----110-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x22806007",
+    "mask": "0xfff0707f"
+  },
+  "vl2re64_v": {
+    "encoding": "001000101000-----111-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x22807007",
+    "mask": "0xfff0707f"
+  },
+  "vl4re8_v": {
+    "encoding": "011000101000-----000-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x62800007",
+    "mask": "0xfff0707f"
+  },
+  "vl4re16_v": {
+    "encoding": "011000101000-----101-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x62805007",
+    "mask": "0xfff0707f"
+  },
+  "vl4re32_v": {
+    "encoding": "011000101000-----110-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x62806007",
+    "mask": "0xfff0707f"
+  },
+  "vl4re64_v": {
+    "encoding": "011000101000-----111-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x62807007",
+    "mask": "0xfff0707f"
+  },
+  "vl8re8_v": {
+    "encoding": "111000101000-----000-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe2800007",
+    "mask": "0xfff0707f"
+  },
+  "vl8re16_v": {
+    "encoding": "111000101000-----101-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe2805007",
+    "mask": "0xfff0707f"
+  },
+  "vl8re32_v": {
+    "encoding": "111000101000-----110-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe2806007",
+    "mask": "0xfff0707f"
+  },
+  "vl8re64_v": {
+    "encoding": "111000101000-----111-----0000111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe2807007",
+    "mask": "0xfff0707f"
+  },
+  "vs1r_v": {
+    "encoding": "000000101000-----000-----0100111",
+    "variable_fields": [
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2800027",
+    "mask": "0xfff0707f"
+  },
+  "vs2r_v": {
+    "encoding": "001000101000-----000-----0100111",
+    "variable_fields": [
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x22800027",
+    "mask": "0xfff0707f"
+  },
+  "vs4r_v": {
+    "encoding": "011000101000-----000-----0100111",
+    "variable_fields": [
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x62800027",
+    "mask": "0xfff0707f"
+  },
+  "vs8r_v": {
+    "encoding": "111000101000-----000-----0100111",
+    "variable_fields": [
+      "rs1",
+      "vs3"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe2800027",
+    "mask": "0xfff0707f"
+  },
+  "vfadd_vf": {
+    "encoding": "000000-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x5057",
+    "mask": "0xfc00707f"
+  },
+  "vfsub_vf": {
+    "encoding": "000010-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8005057",
+    "mask": "0xfc00707f"
+  },
+  "vfmin_vf": {
+    "encoding": "000100-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x10005057",
+    "mask": "0xfc00707f"
+  },
+  "vfmax_vf": {
+    "encoding": "000110-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x18005057",
+    "mask": "0xfc00707f"
+  },
+  "vfsgnj_vf": {
+    "encoding": "001000-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x20005057",
+    "mask": "0xfc00707f"
+  },
+  "vfsgnjn_vf": {
+    "encoding": "001001-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x24005057",
+    "mask": "0xfc00707f"
+  },
+  "vfsgnjx_vf": {
+    "encoding": "001010-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x28005057",
+    "mask": "0xfc00707f"
+  },
+  "vfslide1up_vf": {
+    "encoding": "001110-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x38005057",
+    "mask": "0xfc00707f"
+  },
+  "vfslide1down_vf": {
+    "encoding": "001111-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x3c005057",
+    "mask": "0xfc00707f"
+  },
+  "vfmv_s_f": {
+    "encoding": "010000100000-----101-----1010111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x42005057",
+    "mask": "0xfff0707f"
+  },
+  "vfmerge_vfm": {
+    "encoding": "0101110----------101-----1010111",
+    "variable_fields": [
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x5c005057",
+    "mask": "0xfe00707f"
+  },
+  "vfmv_v_f": {
+    "encoding": "010111100000-----101-----1010111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x5e005057",
+    "mask": "0xfff0707f"
+  },
+  "vmfeq_vf": {
+    "encoding": "011000-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x60005057",
+    "mask": "0xfc00707f"
+  },
+  "vmfle_vf": {
+    "encoding": "011001-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x64005057",
+    "mask": "0xfc00707f"
+  },
+  "vmflt_vf": {
+    "encoding": "011011-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6c005057",
+    "mask": "0xfc00707f"
+  },
+  "vmfne_vf": {
+    "encoding": "011100-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x70005057",
+    "mask": "0xfc00707f"
+  },
+  "vmfgt_vf": {
+    "encoding": "011101-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x74005057",
+    "mask": "0xfc00707f"
+  },
+  "vmfge_vf": {
+    "encoding": "011111-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x7c005057",
+    "mask": "0xfc00707f"
+  },
+  "vfdiv_vf": {
+    "encoding": "100000-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80005057",
+    "mask": "0xfc00707f"
+  },
+  "vfrdiv_vf": {
+    "encoding": "100001-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x84005057",
+    "mask": "0xfc00707f"
+  },
+  "vfmul_vf": {
+    "encoding": "100100-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x90005057",
+    "mask": "0xfc00707f"
+  },
+  "vfrsub_vf": {
+    "encoding": "100111-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x9c005057",
+    "mask": "0xfc00707f"
+  },
+  "vfmadd_vf": {
+    "encoding": "101000-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa0005057",
+    "mask": "0xfc00707f"
+  },
+  "vfnmadd_vf": {
+    "encoding": "101001-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa4005057",
+    "mask": "0xfc00707f"
+  },
+  "vfmsub_vf": {
+    "encoding": "101010-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa8005057",
+    "mask": "0xfc00707f"
+  },
+  "vfnmsub_vf": {
+    "encoding": "101011-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xac005057",
+    "mask": "0xfc00707f"
+  },
+  "vfmacc_vf": {
+    "encoding": "101100-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb0005057",
+    "mask": "0xfc00707f"
+  },
+  "vfnmacc_vf": {
+    "encoding": "101101-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb4005057",
+    "mask": "0xfc00707f"
+  },
+  "vfmsac_vf": {
+    "encoding": "101110-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb8005057",
+    "mask": "0xfc00707f"
+  },
+  "vfnmsac_vf": {
+    "encoding": "101111-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xbc005057",
+    "mask": "0xfc00707f"
+  },
+  "vfwadd_vf": {
+    "encoding": "110000-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc0005057",
+    "mask": "0xfc00707f"
+  },
+  "vfwsub_vf": {
+    "encoding": "110010-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc8005057",
+    "mask": "0xfc00707f"
+  },
+  "vfwadd_wf": {
+    "encoding": "110100-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xd0005057",
+    "mask": "0xfc00707f"
+  },
+  "vfwsub_wf": {
+    "encoding": "110110-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xd8005057",
+    "mask": "0xfc00707f"
+  },
+  "vfwmul_vf": {
+    "encoding": "111000-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe0005057",
+    "mask": "0xfc00707f"
+  },
+  "vfwmacc_vf": {
+    "encoding": "111100-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xf0005057",
+    "mask": "0xfc00707f"
+  },
+  "vfwnmacc_vf": {
+    "encoding": "111101-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xf4005057",
+    "mask": "0xfc00707f"
+  },
+  "vfwmsac_vf": {
+    "encoding": "111110-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xf8005057",
+    "mask": "0xfc00707f"
+  },
+  "vfwnmsac_vf": {
+    "encoding": "111111-----------101-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xfc005057",
+    "mask": "0xfc00707f"
+  },
+  "vfadd_vv": {
+    "encoding": "000000-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x1057",
+    "mask": "0xfc00707f"
+  },
+  "vfredusum_vs": {
+    "encoding": "000001-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4001057",
+    "mask": "0xfc00707f"
+  },
+  "vfsub_vv": {
+    "encoding": "000010-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8001057",
+    "mask": "0xfc00707f"
+  },
+  "vfredosum_vs": {
+    "encoding": "000011-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc001057",
+    "mask": "0xfc00707f"
+  },
+  "vfmin_vv": {
+    "encoding": "000100-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x10001057",
+    "mask": "0xfc00707f"
+  },
+  "vfredmin_vs": {
+    "encoding": "000101-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x14001057",
+    "mask": "0xfc00707f"
+  },
+  "vfmax_vv": {
+    "encoding": "000110-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x18001057",
+    "mask": "0xfc00707f"
+  },
+  "vfredmax_vs": {
+    "encoding": "000111-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x1c001057",
+    "mask": "0xfc00707f"
+  },
+  "vfsgnj_vv": {
+    "encoding": "001000-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x20001057",
+    "mask": "0xfc00707f"
+  },
+  "vfsgnjn_vv": {
+    "encoding": "001001-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x24001057",
+    "mask": "0xfc00707f"
+  },
+  "vfsgnjx_vv": {
+    "encoding": "001010-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x28001057",
+    "mask": "0xfc00707f"
+  },
+  "vfmv_f_s": {
+    "encoding": "0100001-----00000001-----1010111",
+    "variable_fields": [
+      "vs2",
+      "rd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x42001057",
+    "mask": "0xfe0ff07f"
+  },
+  "vmfeq_vv": {
+    "encoding": "011000-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x60001057",
+    "mask": "0xfc00707f"
+  },
+  "vmfle_vv": {
+    "encoding": "011001-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x64001057",
+    "mask": "0xfc00707f"
+  },
+  "vmflt_vv": {
+    "encoding": "011011-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6c001057",
+    "mask": "0xfc00707f"
+  },
+  "vmfne_vv": {
+    "encoding": "011100-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x70001057",
+    "mask": "0xfc00707f"
+  },
+  "vfdiv_vv": {
+    "encoding": "100000-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80001057",
+    "mask": "0xfc00707f"
+  },
+  "vfmul_vv": {
+    "encoding": "100100-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x90001057",
+    "mask": "0xfc00707f"
+  },
+  "vfmadd_vv": {
+    "encoding": "101000-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa0001057",
+    "mask": "0xfc00707f"
+  },
+  "vfnmadd_vv": {
+    "encoding": "101001-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa4001057",
+    "mask": "0xfc00707f"
+  },
+  "vfmsub_vv": {
+    "encoding": "101010-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa8001057",
+    "mask": "0xfc00707f"
+  },
+  "vfnmsub_vv": {
+    "encoding": "101011-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xac001057",
+    "mask": "0xfc00707f"
+  },
+  "vfmacc_vv": {
+    "encoding": "101100-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb0001057",
+    "mask": "0xfc00707f"
+  },
+  "vfnmacc_vv": {
+    "encoding": "101101-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb4001057",
+    "mask": "0xfc00707f"
+  },
+  "vfmsac_vv": {
+    "encoding": "101110-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb8001057",
+    "mask": "0xfc00707f"
+  },
+  "vfnmsac_vv": {
+    "encoding": "101111-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xbc001057",
+    "mask": "0xfc00707f"
+  },
+  "vfcvt_xu_f_v": {
+    "encoding": "010010------00000001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48001057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfcvt_x_f_v": {
+    "encoding": "010010------00001001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48009057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfcvt_f_xu_v": {
+    "encoding": "010010------00010001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48011057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfcvt_f_x_v": {
+    "encoding": "010010------00011001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48019057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfcvt_rtz_xu_f_v": {
+    "encoding": "010010------00110001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48031057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfcvt_rtz_x_f_v": {
+    "encoding": "010010------00111001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48039057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfwcvt_xu_f_v": {
+    "encoding": "010010------01000001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48041057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfwcvt_x_f_v": {
+    "encoding": "010010------01001001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48049057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfwcvt_f_xu_v": {
+    "encoding": "010010------01010001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48051057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfwcvt_f_x_v": {
+    "encoding": "010010------01011001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48059057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfwcvt_f_f_v": {
+    "encoding": "010010------01100001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48061057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfwcvt_rtz_xu_f_v": {
+    "encoding": "010010------01110001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48071057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfwcvt_rtz_x_f_v": {
+    "encoding": "010010------01111001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48079057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfncvt_xu_f_w": {
+    "encoding": "010010------10000001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48081057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfncvt_x_f_w": {
+    "encoding": "010010------10001001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48089057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfncvt_f_xu_w": {
+    "encoding": "010010------10010001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48091057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfncvt_f_x_w": {
+    "encoding": "010010------10011001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48099057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfncvt_f_f_w": {
+    "encoding": "010010------10100001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x480a1057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfncvt_rod_f_f_w": {
+    "encoding": "010010------10101001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x480a9057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfncvt_rtz_xu_f_w": {
+    "encoding": "010010------10110001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x480b1057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfncvt_rtz_x_f_w": {
+    "encoding": "010010------10111001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x480b9057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfsqrt_v": {
+    "encoding": "010011------00000001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4c001057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfrsqrt7_v": {
+    "encoding": "010011------00100001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4c021057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfrec7_v": {
+    "encoding": "010011------00101001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4c029057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfclass_v": {
+    "encoding": "010011------10000001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4c081057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfwadd_vv": {
+    "encoding": "110000-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc0001057",
+    "mask": "0xfc00707f"
+  },
+  "vfwredusum_vs": {
+    "encoding": "110001-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc4001057",
+    "mask": "0xfc00707f"
+  },
+  "vfwsub_vv": {
+    "encoding": "110010-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc8001057",
+    "mask": "0xfc00707f"
+  },
+  "vfwredosum_vs": {
+    "encoding": "110011-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xcc001057",
+    "mask": "0xfc00707f"
+  },
+  "vfwadd_wv": {
+    "encoding": "110100-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xd0001057",
+    "mask": "0xfc00707f"
+  },
+  "vfwsub_wv": {
+    "encoding": "110110-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xd8001057",
+    "mask": "0xfc00707f"
+  },
+  "vfwmul_vv": {
+    "encoding": "111000-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe0001057",
+    "mask": "0xfc00707f"
+  },
+  "vfwmacc_vv": {
+    "encoding": "111100-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xf0001057",
+    "mask": "0xfc00707f"
+  },
+  "vfwnmacc_vv": {
+    "encoding": "111101-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xf4001057",
+    "mask": "0xfc00707f"
+  },
+  "vfwmsac_vv": {
+    "encoding": "111110-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xf8001057",
+    "mask": "0xfc00707f"
+  },
+  "vfwnmsac_vv": {
+    "encoding": "111111-----------001-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xfc001057",
+    "mask": "0xfc00707f"
+  },
+  "vadd_vx": {
+    "encoding": "000000-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4057",
+    "mask": "0xfc00707f"
+  },
+  "vsub_vx": {
+    "encoding": "000010-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8004057",
+    "mask": "0xfc00707f"
+  },
+  "vrsub_vx": {
+    "encoding": "000011-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc004057",
+    "mask": "0xfc00707f"
+  },
+  "vminu_vx": {
+    "encoding": "000100-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x10004057",
+    "mask": "0xfc00707f"
+  },
+  "vmin_vx": {
+    "encoding": "000101-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x14004057",
+    "mask": "0xfc00707f"
+  },
+  "vmaxu_vx": {
+    "encoding": "000110-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x18004057",
+    "mask": "0xfc00707f"
+  },
+  "vmax_vx": {
+    "encoding": "000111-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x1c004057",
+    "mask": "0xfc00707f"
+  },
+  "vand_vx": {
+    "encoding": "001001-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x24004057",
+    "mask": "0xfc00707f"
+  },
+  "vor_vx": {
+    "encoding": "001010-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x28004057",
+    "mask": "0xfc00707f"
+  },
+  "vxor_vx": {
+    "encoding": "001011-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2c004057",
+    "mask": "0xfc00707f"
+  },
+  "vrgather_vx": {
+    "encoding": "001100-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x30004057",
+    "mask": "0xfc00707f"
+  },
+  "vslideup_vx": {
+    "encoding": "001110-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x38004057",
+    "mask": "0xfc00707f"
+  },
+  "vslidedown_vx": {
+    "encoding": "001111-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x3c004057",
+    "mask": "0xfc00707f"
+  },
+  "vadc_vxm": {
+    "encoding": "0100000----------100-----1010111",
+    "variable_fields": [
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x40004057",
+    "mask": "0xfe00707f"
+  },
+  "vmadc_vxm": {
+    "encoding": "0100010----------100-----1010111",
+    "variable_fields": [
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x44004057",
+    "mask": "0xfe00707f"
+  },
+  "vmadc_vx": {
+    "encoding": "0100011----------100-----1010111",
+    "variable_fields": [
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x46004057",
+    "mask": "0xfe00707f"
+  },
+  "vsbc_vxm": {
+    "encoding": "0100100----------100-----1010111",
+    "variable_fields": [
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48004057",
+    "mask": "0xfe00707f"
+  },
+  "vmsbc_vxm": {
+    "encoding": "0100110----------100-----1010111",
+    "variable_fields": [
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4c004057",
+    "mask": "0xfe00707f"
+  },
+  "vmsbc_vx": {
+    "encoding": "0100111----------100-----1010111",
+    "variable_fields": [
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4e004057",
+    "mask": "0xfe00707f"
+  },
+  "vmerge_vxm": {
+    "encoding": "0101110----------100-----1010111",
+    "variable_fields": [
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x5c004057",
+    "mask": "0xfe00707f"
+  },
+  "vmv_v_x": {
+    "encoding": "010111100000-----100-----1010111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x5e004057",
+    "mask": "0xfff0707f"
+  },
+  "vmseq_vx": {
+    "encoding": "011000-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x60004057",
+    "mask": "0xfc00707f"
+  },
+  "vmsne_vx": {
+    "encoding": "011001-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x64004057",
+    "mask": "0xfc00707f"
+  },
+  "vmsltu_vx": {
+    "encoding": "011010-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x68004057",
+    "mask": "0xfc00707f"
+  },
+  "vmslt_vx": {
+    "encoding": "011011-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6c004057",
+    "mask": "0xfc00707f"
+  },
+  "vmsleu_vx": {
+    "encoding": "011100-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x70004057",
+    "mask": "0xfc00707f"
+  },
+  "vmsle_vx": {
+    "encoding": "011101-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x74004057",
+    "mask": "0xfc00707f"
+  },
+  "vmsgtu_vx": {
+    "encoding": "011110-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x78004057",
+    "mask": "0xfc00707f"
+  },
+  "vmsgt_vx": {
+    "encoding": "011111-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x7c004057",
+    "mask": "0xfc00707f"
+  },
+  "vsaddu_vx": {
+    "encoding": "100000-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80004057",
+    "mask": "0xfc00707f"
+  },
+  "vsadd_vx": {
+    "encoding": "100001-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x84004057",
+    "mask": "0xfc00707f"
+  },
+  "vssubu_vx": {
+    "encoding": "100010-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x88004057",
+    "mask": "0xfc00707f"
+  },
+  "vssub_vx": {
+    "encoding": "100011-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8c004057",
+    "mask": "0xfc00707f"
+  },
+  "vsll_vx": {
+    "encoding": "100101-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x94004057",
+    "mask": "0xfc00707f"
+  },
+  "vsmul_vx": {
+    "encoding": "100111-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x9c004057",
+    "mask": "0xfc00707f"
+  },
+  "vsrl_vx": {
+    "encoding": "101000-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa0004057",
+    "mask": "0xfc00707f"
+  },
+  "vsra_vx": {
+    "encoding": "101001-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa4004057",
+    "mask": "0xfc00707f"
+  },
+  "vssrl_vx": {
+    "encoding": "101010-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa8004057",
+    "mask": "0xfc00707f"
+  },
+  "vssra_vx": {
+    "encoding": "101011-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xac004057",
+    "mask": "0xfc00707f"
+  },
+  "vnsrl_wx": {
+    "encoding": "101100-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb0004057",
+    "mask": "0xfc00707f"
+  },
+  "vnsra_wx": {
+    "encoding": "101101-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb4004057",
+    "mask": "0xfc00707f"
+  },
+  "vnclipu_wx": {
+    "encoding": "101110-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb8004057",
+    "mask": "0xfc00707f"
+  },
+  "vnclip_wx": {
+    "encoding": "101111-----------100-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xbc004057",
+    "mask": "0xfc00707f"
+  },
+  "vadd_vv": {
+    "encoding": "000000-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x57",
+    "mask": "0xfc00707f"
+  },
+  "vsub_vv": {
+    "encoding": "000010-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8000057",
+    "mask": "0xfc00707f"
+  },
+  "vminu_vv": {
+    "encoding": "000100-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x10000057",
+    "mask": "0xfc00707f"
+  },
+  "vmin_vv": {
+    "encoding": "000101-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x14000057",
+    "mask": "0xfc00707f"
+  },
+  "vmaxu_vv": {
+    "encoding": "000110-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x18000057",
+    "mask": "0xfc00707f"
+  },
+  "vmax_vv": {
+    "encoding": "000111-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x1c000057",
+    "mask": "0xfc00707f"
+  },
+  "vand_vv": {
+    "encoding": "001001-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x24000057",
+    "mask": "0xfc00707f"
+  },
+  "vor_vv": {
+    "encoding": "001010-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x28000057",
+    "mask": "0xfc00707f"
+  },
+  "vxor_vv": {
+    "encoding": "001011-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2c000057",
+    "mask": "0xfc00707f"
+  },
+  "vrgather_vv": {
+    "encoding": "001100-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x30000057",
+    "mask": "0xfc00707f"
+  },
+  "vrgatherei16_vv": {
+    "encoding": "001110-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x38000057",
+    "mask": "0xfc00707f"
+  },
+  "vadc_vvm": {
+    "encoding": "0100000----------000-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x40000057",
+    "mask": "0xfe00707f"
+  },
+  "vmadc_vvm": {
+    "encoding": "0100010----------000-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x44000057",
+    "mask": "0xfe00707f"
+  },
+  "vmadc_vv": {
+    "encoding": "0100011----------000-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x46000057",
+    "mask": "0xfe00707f"
+  },
+  "vsbc_vvm": {
+    "encoding": "0100100----------000-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48000057",
+    "mask": "0xfe00707f"
+  },
+  "vmsbc_vvm": {
+    "encoding": "0100110----------000-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4c000057",
+    "mask": "0xfe00707f"
+  },
+  "vmsbc_vv": {
+    "encoding": "0100111----------000-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4e000057",
+    "mask": "0xfe00707f"
+  },
+  "vmerge_vvm": {
+    "encoding": "0101110----------000-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x5c000057",
+    "mask": "0xfe00707f"
+  },
+  "vmv_v_v": {
+    "encoding": "010111100000-----000-----1010111",
+    "variable_fields": [
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x5e000057",
+    "mask": "0xfff0707f"
+  },
+  "vmseq_vv": {
+    "encoding": "011000-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x60000057",
+    "mask": "0xfc00707f"
+  },
+  "vmsne_vv": {
+    "encoding": "011001-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x64000057",
+    "mask": "0xfc00707f"
+  },
+  "vmsltu_vv": {
+    "encoding": "011010-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x68000057",
+    "mask": "0xfc00707f"
+  },
+  "vmslt_vv": {
+    "encoding": "011011-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6c000057",
+    "mask": "0xfc00707f"
+  },
+  "vmsleu_vv": {
+    "encoding": "011100-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x70000057",
+    "mask": "0xfc00707f"
+  },
+  "vmsle_vv": {
+    "encoding": "011101-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x74000057",
+    "mask": "0xfc00707f"
+  },
+  "vsaddu_vv": {
+    "encoding": "100000-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80000057",
+    "mask": "0xfc00707f"
+  },
+  "vsadd_vv": {
+    "encoding": "100001-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x84000057",
+    "mask": "0xfc00707f"
+  },
+  "vssubu_vv": {
+    "encoding": "100010-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x88000057",
+    "mask": "0xfc00707f"
+  },
+  "vssub_vv": {
+    "encoding": "100011-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8c000057",
+    "mask": "0xfc00707f"
+  },
+  "vsll_vv": {
+    "encoding": "100101-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x94000057",
+    "mask": "0xfc00707f"
+  },
+  "vsmul_vv": {
+    "encoding": "100111-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x9c000057",
+    "mask": "0xfc00707f"
+  },
+  "vsrl_vv": {
+    "encoding": "101000-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa0000057",
+    "mask": "0xfc00707f"
+  },
+  "vsra_vv": {
+    "encoding": "101001-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa4000057",
+    "mask": "0xfc00707f"
+  },
+  "vssrl_vv": {
+    "encoding": "101010-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa8000057",
+    "mask": "0xfc00707f"
+  },
+  "vssra_vv": {
+    "encoding": "101011-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xac000057",
+    "mask": "0xfc00707f"
+  },
+  "vnsrl_wv": {
+    "encoding": "101100-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb0000057",
+    "mask": "0xfc00707f"
+  },
+  "vnsra_wv": {
+    "encoding": "101101-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb4000057",
+    "mask": "0xfc00707f"
+  },
+  "vnclipu_wv": {
+    "encoding": "101110-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb8000057",
+    "mask": "0xfc00707f"
+  },
+  "vnclip_wv": {
+    "encoding": "101111-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xbc000057",
+    "mask": "0xfc00707f"
+  },
+  "vwredsumu_vs": {
+    "encoding": "110000-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc0000057",
+    "mask": "0xfc00707f"
+  },
+  "vwredsum_vs": {
+    "encoding": "110001-----------000-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc4000057",
+    "mask": "0xfc00707f"
+  },
+  "vadd_vi": {
+    "encoding": "000000-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x3057",
+    "mask": "0xfc00707f"
+  },
+  "vrsub_vi": {
+    "encoding": "000011-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc003057",
+    "mask": "0xfc00707f"
+  },
+  "vand_vi": {
+    "encoding": "001001-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x24003057",
+    "mask": "0xfc00707f"
+  },
+  "vor_vi": {
+    "encoding": "001010-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x28003057",
+    "mask": "0xfc00707f"
+  },
+  "vxor_vi": {
+    "encoding": "001011-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2c003057",
+    "mask": "0xfc00707f"
+  },
+  "vrgather_vi": {
+    "encoding": "001100-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x30003057",
+    "mask": "0xfc00707f"
+  },
+  "vslideup_vi": {
+    "encoding": "001110-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x38003057",
+    "mask": "0xfc00707f"
+  },
+  "vslidedown_vi": {
+    "encoding": "001111-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x3c003057",
+    "mask": "0xfc00707f"
+  },
+  "vadc_vim": {
+    "encoding": "0100000----------011-----1010111",
+    "variable_fields": [
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x40003057",
+    "mask": "0xfe00707f"
+  },
+  "vmadc_vim": {
+    "encoding": "0100010----------011-----1010111",
+    "variable_fields": [
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x44003057",
+    "mask": "0xfe00707f"
+  },
+  "vmadc_vi": {
+    "encoding": "0100011----------011-----1010111",
+    "variable_fields": [
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x46003057",
+    "mask": "0xfe00707f"
+  },
+  "vmerge_vim": {
+    "encoding": "0101110----------011-----1010111",
+    "variable_fields": [
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x5c003057",
+    "mask": "0xfe00707f"
+  },
+  "vmv_v_i": {
+    "encoding": "010111100000-----011-----1010111",
+    "variable_fields": [
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x5e003057",
+    "mask": "0xfff0707f"
+  },
+  "vmseq_vi": {
+    "encoding": "011000-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x60003057",
+    "mask": "0xfc00707f"
+  },
+  "vmsne_vi": {
+    "encoding": "011001-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x64003057",
+    "mask": "0xfc00707f"
+  },
+  "vmsleu_vi": {
+    "encoding": "011100-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x70003057",
+    "mask": "0xfc00707f"
+  },
+  "vmsle_vi": {
+    "encoding": "011101-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x74003057",
+    "mask": "0xfc00707f"
+  },
+  "vmsgtu_vi": {
+    "encoding": "011110-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x78003057",
+    "mask": "0xfc00707f"
+  },
+  "vmsgt_vi": {
+    "encoding": "011111-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x7c003057",
+    "mask": "0xfc00707f"
+  },
+  "vsaddu_vi": {
+    "encoding": "100000-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80003057",
+    "mask": "0xfc00707f"
+  },
+  "vsadd_vi": {
+    "encoding": "100001-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x84003057",
+    "mask": "0xfc00707f"
+  },
+  "vsll_vi": {
+    "encoding": "100101-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x94003057",
+    "mask": "0xfc00707f"
+  },
+  "vmv1r_v": {
+    "encoding": "1001111-----00000011-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x9e003057",
+    "mask": "0xfe0ff07f"
+  },
+  "vmv2r_v": {
+    "encoding": "1001111-----00001011-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x9e00b057",
+    "mask": "0xfe0ff07f"
+  },
+  "vmv4r_v": {
+    "encoding": "1001111-----00011011-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x9e01b057",
+    "mask": "0xfe0ff07f"
+  },
+  "vmv8r_v": {
+    "encoding": "1001111-----00111011-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x9e03b057",
+    "mask": "0xfe0ff07f"
+  },
+  "vsrl_vi": {
+    "encoding": "101000-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa0003057",
+    "mask": "0xfc00707f"
+  },
+  "vsra_vi": {
+    "encoding": "101001-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa4003057",
+    "mask": "0xfc00707f"
+  },
+  "vssrl_vi": {
+    "encoding": "101010-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa8003057",
+    "mask": "0xfc00707f"
+  },
+  "vssra_vi": {
+    "encoding": "101011-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xac003057",
+    "mask": "0xfc00707f"
+  },
+  "vnsrl_wi": {
+    "encoding": "101100-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb0003057",
+    "mask": "0xfc00707f"
+  },
+  "vnsra_wi": {
+    "encoding": "101101-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb4003057",
+    "mask": "0xfc00707f"
+  },
+  "vnclipu_wi": {
+    "encoding": "101110-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb8003057",
+    "mask": "0xfc00707f"
+  },
+  "vnclip_wi": {
+    "encoding": "101111-----------011-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "simm5",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xbc003057",
+    "mask": "0xfc00707f"
+  },
+  "vredsum_vs": {
+    "encoding": "000000-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2057",
+    "mask": "0xfc00707f"
+  },
+  "vredand_vs": {
+    "encoding": "000001-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4002057",
+    "mask": "0xfc00707f"
+  },
+  "vredor_vs": {
+    "encoding": "000010-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8002057",
+    "mask": "0xfc00707f"
+  },
+  "vredxor_vs": {
+    "encoding": "000011-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc002057",
+    "mask": "0xfc00707f"
+  },
+  "vredminu_vs": {
+    "encoding": "000100-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x10002057",
+    "mask": "0xfc00707f"
+  },
+  "vredmin_vs": {
+    "encoding": "000101-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x14002057",
+    "mask": "0xfc00707f"
+  },
+  "vredmaxu_vs": {
+    "encoding": "000110-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x18002057",
+    "mask": "0xfc00707f"
+  },
+  "vredmax_vs": {
+    "encoding": "000111-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x1c002057",
+    "mask": "0xfc00707f"
+  },
+  "vaaddu_vv": {
+    "encoding": "001000-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x20002057",
+    "mask": "0xfc00707f"
+  },
+  "vaadd_vv": {
+    "encoding": "001001-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x24002057",
+    "mask": "0xfc00707f"
+  },
+  "vasubu_vv": {
+    "encoding": "001010-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x28002057",
+    "mask": "0xfc00707f"
+  },
+  "vasub_vv": {
+    "encoding": "001011-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2c002057",
+    "mask": "0xfc00707f"
+  },
+  "vmv_x_s": {
+    "encoding": "0100001-----00000010-----1010111",
+    "variable_fields": [
+      "vs2",
+      "rd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x42002057",
+    "mask": "0xfe0ff07f"
+  },
+  "vzext_vf8": {
+    "encoding": "010010------00010010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48012057",
+    "mask": "0xfc0ff07f"
+  },
+  "vsext_vf8": {
+    "encoding": "010010------00011010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4801a057",
+    "mask": "0xfc0ff07f"
+  },
+  "vzext_vf4": {
+    "encoding": "010010------00100010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48022057",
+    "mask": "0xfc0ff07f"
+  },
+  "vsext_vf4": {
+    "encoding": "010010------00101010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4802a057",
+    "mask": "0xfc0ff07f"
+  },
+  "vzext_vf2": {
+    "encoding": "010010------00110010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x48032057",
+    "mask": "0xfc0ff07f"
+  },
+  "vsext_vf2": {
+    "encoding": "010010------00111010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4803a057",
+    "mask": "0xfc0ff07f"
+  },
+  "vcompress_vm": {
+    "encoding": "0101111----------010-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x5e002057",
+    "mask": "0xfe00707f"
+  },
+  "vmandn_mm": {
+    "encoding": "0110001----------010-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x62002057",
+    "mask": "0xfe00707f"
+  },
+  "vmand_mm": {
+    "encoding": "0110011----------010-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x66002057",
+    "mask": "0xfe00707f"
+  },
+  "vmor_mm": {
+    "encoding": "0110101----------010-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6a002057",
+    "mask": "0xfe00707f"
+  },
+  "vmxor_mm": {
+    "encoding": "0110111----------010-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x6e002057",
+    "mask": "0xfe00707f"
+  },
+  "vmorn_mm": {
+    "encoding": "0111001----------010-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x72002057",
+    "mask": "0xfe00707f"
+  },
+  "vmnand_mm": {
+    "encoding": "0111011----------010-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x76002057",
+    "mask": "0xfe00707f"
+  },
+  "vmnor_mm": {
+    "encoding": "0111101----------010-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x7a002057",
+    "mask": "0xfe00707f"
+  },
+  "vmxnor_mm": {
+    "encoding": "0111111----------010-----1010111",
+    "variable_fields": [
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x7e002057",
+    "mask": "0xfe00707f"
+  },
+  "vmsbf_m": {
+    "encoding": "010100------00001010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x5000a057",
+    "mask": "0xfc0ff07f"
+  },
+  "vmsof_m": {
+    "encoding": "010100------00010010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x50012057",
+    "mask": "0xfc0ff07f"
+  },
+  "vmsif_m": {
+    "encoding": "010100------00011010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x5001a057",
+    "mask": "0xfc0ff07f"
+  },
+  "viota_m": {
+    "encoding": "010100------10000010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x50082057",
+    "mask": "0xfc0ff07f"
+  },
+  "vid_v": {
+    "encoding": "010100-0000010001010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x5008a057",
+    "mask": "0xfdfff07f"
+  },
+  "vcpop_m": {
+    "encoding": "010000------10000010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x40082057",
+    "mask": "0xfc0ff07f"
+  },
+  "vfirst_m": {
+    "encoding": "010000------10001010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x4008a057",
+    "mask": "0xfc0ff07f"
+  },
+  "vdivu_vv": {
+    "encoding": "100000-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80002057",
+    "mask": "0xfc00707f"
+  },
+  "vdiv_vv": {
+    "encoding": "100001-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x84002057",
+    "mask": "0xfc00707f"
+  },
+  "vremu_vv": {
+    "encoding": "100010-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x88002057",
+    "mask": "0xfc00707f"
+  },
+  "vrem_vv": {
+    "encoding": "100011-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8c002057",
+    "mask": "0xfc00707f"
+  },
+  "vmulhu_vv": {
+    "encoding": "100100-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x90002057",
+    "mask": "0xfc00707f"
+  },
+  "vmul_vv": {
+    "encoding": "100101-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x94002057",
+    "mask": "0xfc00707f"
+  },
+  "vmulhsu_vv": {
+    "encoding": "100110-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x98002057",
+    "mask": "0xfc00707f"
+  },
+  "vmulh_vv": {
+    "encoding": "100111-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x9c002057",
+    "mask": "0xfc00707f"
+  },
+  "vmadd_vv": {
+    "encoding": "101001-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa4002057",
+    "mask": "0xfc00707f"
+  },
+  "vnmsub_vv": {
+    "encoding": "101011-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xac002057",
+    "mask": "0xfc00707f"
+  },
+  "vmacc_vv": {
+    "encoding": "101101-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb4002057",
+    "mask": "0xfc00707f"
+  },
+  "vnmsac_vv": {
+    "encoding": "101111-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xbc002057",
+    "mask": "0xfc00707f"
+  },
+  "vwaddu_vv": {
+    "encoding": "110000-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc0002057",
+    "mask": "0xfc00707f"
+  },
+  "vwadd_vv": {
+    "encoding": "110001-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc4002057",
+    "mask": "0xfc00707f"
+  },
+  "vwsubu_vv": {
+    "encoding": "110010-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc8002057",
+    "mask": "0xfc00707f"
+  },
+  "vwsub_vv": {
+    "encoding": "110011-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xcc002057",
+    "mask": "0xfc00707f"
+  },
+  "vwaddu_wv": {
+    "encoding": "110100-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xd0002057",
+    "mask": "0xfc00707f"
+  },
+  "vwadd_wv": {
+    "encoding": "110101-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xd4002057",
+    "mask": "0xfc00707f"
+  },
+  "vwsubu_wv": {
+    "encoding": "110110-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xd8002057",
+    "mask": "0xfc00707f"
+  },
+  "vwsub_wv": {
+    "encoding": "110111-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xdc002057",
+    "mask": "0xfc00707f"
+  },
+  "vwmulu_vv": {
+    "encoding": "111000-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe0002057",
+    "mask": "0xfc00707f"
+  },
+  "vwmulsu_vv": {
+    "encoding": "111010-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe8002057",
+    "mask": "0xfc00707f"
+  },
+  "vwmul_vv": {
+    "encoding": "111011-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xec002057",
+    "mask": "0xfc00707f"
+  },
+  "vwmaccu_vv": {
+    "encoding": "111100-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xf0002057",
+    "mask": "0xfc00707f"
+  },
+  "vwmacc_vv": {
+    "encoding": "111101-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xf4002057",
+    "mask": "0xfc00707f"
+  },
+  "vwmaccsu_vv": {
+    "encoding": "111111-----------010-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "vs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xfc002057",
+    "mask": "0xfc00707f"
+  },
+  "vaaddu_vx": {
+    "encoding": "001000-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x20006057",
+    "mask": "0xfc00707f"
+  },
+  "vaadd_vx": {
+    "encoding": "001001-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x24006057",
+    "mask": "0xfc00707f"
+  },
+  "vasubu_vx": {
+    "encoding": "001010-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x28006057",
+    "mask": "0xfc00707f"
+  },
+  "vasub_vx": {
+    "encoding": "001011-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x2c006057",
+    "mask": "0xfc00707f"
+  },
+  "vmv_s_x": {
+    "encoding": "010000100000-----110-----1010111",
+    "variable_fields": [
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x42006057",
+    "mask": "0xfff0707f"
+  },
+  "vslide1up_vx": {
+    "encoding": "001110-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x38006057",
+    "mask": "0xfc00707f"
+  },
+  "vslide1down_vx": {
+    "encoding": "001111-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x3c006057",
+    "mask": "0xfc00707f"
+  },
+  "vdivu_vx": {
+    "encoding": "100000-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x80006057",
+    "mask": "0xfc00707f"
+  },
+  "vdiv_vx": {
+    "encoding": "100001-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x84006057",
+    "mask": "0xfc00707f"
+  },
+  "vremu_vx": {
+    "encoding": "100010-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x88006057",
+    "mask": "0xfc00707f"
+  },
+  "vrem_vx": {
+    "encoding": "100011-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x8c006057",
+    "mask": "0xfc00707f"
+  },
+  "vmulhu_vx": {
+    "encoding": "100100-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x90006057",
+    "mask": "0xfc00707f"
+  },
+  "vmul_vx": {
+    "encoding": "100101-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x94006057",
+    "mask": "0xfc00707f"
+  },
+  "vmulhsu_vx": {
+    "encoding": "100110-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x98006057",
+    "mask": "0xfc00707f"
+  },
+  "vmulh_vx": {
+    "encoding": "100111-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0x9c006057",
+    "mask": "0xfc00707f"
+  },
+  "vmadd_vx": {
+    "encoding": "101001-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xa4006057",
+    "mask": "0xfc00707f"
+  },
+  "vnmsub_vx": {
+    "encoding": "101011-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xac006057",
+    "mask": "0xfc00707f"
+  },
+  "vmacc_vx": {
+    "encoding": "101101-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xb4006057",
+    "mask": "0xfc00707f"
+  },
+  "vnmsac_vx": {
+    "encoding": "101111-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xbc006057",
+    "mask": "0xfc00707f"
+  },
+  "vwaddu_vx": {
+    "encoding": "110000-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc0006057",
+    "mask": "0xfc00707f"
+  },
+  "vwadd_vx": {
+    "encoding": "110001-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc4006057",
+    "mask": "0xfc00707f"
+  },
+  "vwsubu_vx": {
+    "encoding": "110010-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xc8006057",
+    "mask": "0xfc00707f"
+  },
+  "vwsub_vx": {
+    "encoding": "110011-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xcc006057",
+    "mask": "0xfc00707f"
+  },
+  "vwaddu_wx": {
+    "encoding": "110100-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xd0006057",
+    "mask": "0xfc00707f"
+  },
+  "vwadd_wx": {
+    "encoding": "110101-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xd4006057",
+    "mask": "0xfc00707f"
+  },
+  "vwsubu_wx": {
+    "encoding": "110110-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xd8006057",
+    "mask": "0xfc00707f"
+  },
+  "vwsub_wx": {
+    "encoding": "110111-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xdc006057",
+    "mask": "0xfc00707f"
+  },
+  "vwmulu_vx": {
+    "encoding": "111000-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe0006057",
+    "mask": "0xfc00707f"
+  },
+  "vwmulsu_vx": {
+    "encoding": "111010-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xe8006057",
+    "mask": "0xfc00707f"
+  },
+  "vwmul_vx": {
+    "encoding": "111011-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xec006057",
+    "mask": "0xfc00707f"
+  },
+  "vwmaccu_vx": {
+    "encoding": "111100-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xf0006057",
+    "mask": "0xfc00707f"
+  },
+  "vwmacc_vx": {
+    "encoding": "111101-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xf4006057",
+    "mask": "0xfc00707f"
+  },
+  "vwmaccus_vx": {
+    "encoding": "111110-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xf8006057",
+    "mask": "0xfc00707f"
+  },
+  "vwmaccsu_vx": {
+    "encoding": "111111-----------110-----1010111",
+    "variable_fields": [
+      "vm",
+      "vs2",
+      "rs1",
+      "vd"
+    ],
+    "extension": [
+      "rv_v"
+    ],
+    "match": "0xfc006057",
+    "mask": "0xfc00707f"
+  },
+  "mret": {
+    "encoding": "00110000001000000000000001110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_system"
+    ],
+    "match": "0x30200073",
+    "mask": "0xffffffff"
+  },
+  "wfi": {
+    "encoding": "00010000010100000000000001110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_system"
+    ],
+    "match": "0x10500073",
+    "mask": "0xffffffff"
+  },
+  "hinval_vvma": {
+    "encoding": "0010011----------000000001110011",
+    "variable_fields": [
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_svinval_h"
+    ],
+    "match": "0x26000073",
+    "mask": "0xfe007fff"
+  },
+  "hinval_gvma": {
+    "encoding": "0110011----------000000001110011",
+    "variable_fields": [
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_svinval_h"
+    ],
+    "match": "0x66000073",
+    "mask": "0xfe007fff"
+  },
+  "sinval_vma": {
+    "encoding": "0001011----------000000001110011",
+    "variable_fields": [
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_svinval"
+    ],
+    "match": "0x16000073",
+    "mask": "0xfe007fff"
+  },
+  "sfence_w_inval": {
+    "encoding": "00011000000000000000000001110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_svinval"
+    ],
+    "match": "0x18000073",
+    "mask": "0xffffffff"
+  },
+  "sfence_inval_ir": {
+    "encoding": "00011000000100000000000001110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_svinval"
+    ],
+    "match": "0x18100073",
+    "mask": "0xffffffff"
+  },
+  "mnret": {
+    "encoding": "01110000001000000000000001110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_smrnmi"
+    ],
+    "match": "0x70200073",
+    "mask": "0xffffffff"
+  },
+  "sctrclr": {
+    "encoding": "00010000010000000000000001110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_smdbltrp"
+    ],
+    "match": "0x10400073",
+    "mask": "0xffffffff"
+  },
+  "dret": {
+    "encoding": "01111011001000000000000001110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_sdext"
+    ],
+    "match": "0x7b200073",
+    "mask": "0xffffffff"
+  },
+  "sfence_vma": {
+    "encoding": "0001001----------000000001110011",
+    "variable_fields": [
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_s"
+    ],
+    "match": "0x12000073",
+    "mask": "0xfe007fff"
+  },
+  "sret": {
+    "encoding": "00010000001000000000000001110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_s"
+    ],
+    "match": "0x10200073",
+    "mask": "0xffffffff"
+  },
+  "fcvt_q_h": {
+    "encoding": "010001100010-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_q_zfh"
+    ],
+    "match": "0x46200053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_h_q": {
+    "encoding": "010001000011-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_q_zfh"
+    ],
+    "match": "0x44300053",
+    "mask": "0xfff0007f"
+  },
+  "fli_q": {
+    "encoding": "111101100001-----000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_q_zfa"
+    ],
+    "match": "0xf6100053",
+    "mask": "0xfff0707f"
+  },
+  "fminm_q": {
+    "encoding": "0010111----------010-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_q_zfa"
+    ],
+    "match": "0x2e002053",
+    "mask": "0xfe00707f"
+  },
+  "fmaxm_q": {
+    "encoding": "0010111----------011-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_q_zfa"
+    ],
+    "match": "0x2e003053",
+    "mask": "0xfe00707f"
+  },
+  "fround_q": {
+    "encoding": "010001100100-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_q_zfa"
+    ],
+    "match": "0x46400053",
+    "mask": "0xfff0007f"
+  },
+  "froundnx_q": {
+    "encoding": "010001100101-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_q_zfa"
+    ],
+    "match": "0x46500053",
+    "mask": "0xfff0007f"
+  },
+  "fleq_q": {
+    "encoding": "1010011----------100-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_q_zfa"
+    ],
+    "match": "0xa6004053",
+    "mask": "0xfe00707f"
+  },
+  "fltq_q": {
+    "encoding": "1010011----------101-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_q_zfa"
+    ],
+    "match": "0xa6005053",
+    "mask": "0xfe00707f"
+  },
+  "flq": {
+    "encoding": "-----------------100-----0000111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x4007",
+    "mask": "0x707f"
+  },
+  "fsq": {
+    "encoding": "-----------------100-----0100111",
+    "variable_fields": [
+      "imm12hi",
+      "rs1",
+      "rs2",
+      "imm12lo"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x4027",
+    "mask": "0x707f"
+  },
+  "fmadd_q": {
+    "encoding": "-----11------------------1000011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x6000043",
+    "mask": "0x600007f"
+  },
+  "fmsub_q": {
+    "encoding": "-----11------------------1000111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x6000047",
+    "mask": "0x600007f"
+  },
+  "fnmsub_q": {
+    "encoding": "-----11------------------1001011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x600004b",
+    "mask": "0x600007f"
+  },
+  "fnmadd_q": {
+    "encoding": "-----11------------------1001111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x600004f",
+    "mask": "0x600007f"
+  },
+  "fadd_q": {
+    "encoding": "0000011------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x6000053",
+    "mask": "0xfe00007f"
+  },
+  "fsub_q": {
+    "encoding": "0000111------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0xe000053",
+    "mask": "0xfe00007f"
+  },
+  "fmul_q": {
+    "encoding": "0001011------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x16000053",
+    "mask": "0xfe00007f"
+  },
+  "fdiv_q": {
+    "encoding": "0001111------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x1e000053",
+    "mask": "0xfe00007f"
+  },
+  "fsqrt_q": {
+    "encoding": "010111100000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x5e000053",
+    "mask": "0xfff0007f"
+  },
+  "fsgnj_q": {
+    "encoding": "0010011----------000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x26000053",
+    "mask": "0xfe00707f"
+  },
+  "fsgnjn_q": {
+    "encoding": "0010011----------001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x26001053",
+    "mask": "0xfe00707f"
+  },
+  "fsgnjx_q": {
+    "encoding": "0010011----------010-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x26002053",
+    "mask": "0xfe00707f"
+  },
+  "fmin_q": {
+    "encoding": "0010111----------000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x2e000053",
+    "mask": "0xfe00707f"
+  },
+  "fmax_q": {
+    "encoding": "0010111----------001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x2e001053",
+    "mask": "0xfe00707f"
+  },
+  "fcvt_s_q": {
+    "encoding": "010000000011-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x40300053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_q_s": {
+    "encoding": "010001100000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x46000053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_d_q": {
+    "encoding": "010000100011-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x42300053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_q_d": {
+    "encoding": "010001100001-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0x46100053",
+    "mask": "0xfff0007f"
+  },
+  "feq_q": {
+    "encoding": "1010011----------010-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0xa6002053",
+    "mask": "0xfe00707f"
+  },
+  "flt_q": {
+    "encoding": "1010011----------001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0xa6001053",
+    "mask": "0xfe00707f"
+  },
+  "fle_q": {
+    "encoding": "1010011----------000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0xa6000053",
+    "mask": "0xfe00707f"
+  },
+  "fclass_q": {
+    "encoding": "111001100000-----001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0xe6001053",
+    "mask": "0xfff0707f"
+  },
+  "fcvt_w_q": {
+    "encoding": "110001100000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0xc6000053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_wu_q": {
+    "encoding": "110001100001-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0xc6100053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_q_w": {
+    "encoding": "110101100000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0xd6000053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_q_wu": {
+    "encoding": "110101100001-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_q"
+    ],
+    "match": "0xd6100053",
+    "mask": "0xfff0007f"
+  },
+  "mul": {
+    "encoding": "0000001----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_m"
+    ],
+    "match": "0x2000033",
+    "mask": "0xfe00707f"
+  },
+  "mulh": {
+    "encoding": "0000001----------001-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_m"
+    ],
+    "match": "0x2001033",
+    "mask": "0xfe00707f"
+  },
+  "mulhsu": {
+    "encoding": "0000001----------010-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_m"
+    ],
+    "match": "0x2002033",
+    "mask": "0xfe00707f"
+  },
+  "mulhu": {
+    "encoding": "0000001----------011-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_m"
+    ],
+    "match": "0x2003033",
+    "mask": "0xfe00707f"
+  },
+  "div": {
+    "encoding": "0000001----------100-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_m"
+    ],
+    "match": "0x2004033",
+    "mask": "0xfe00707f"
+  },
+  "divu": {
+    "encoding": "0000001----------101-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_m"
+    ],
+    "match": "0x2005033",
+    "mask": "0xfe00707f"
+  },
+  "rem": {
+    "encoding": "0000001----------110-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_m"
+    ],
+    "match": "0x2006033",
+    "mask": "0xfe00707f"
+  },
+  "remu": {
+    "encoding": "0000001----------111-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_m"
+    ],
+    "match": "0x2007033",
+    "mask": "0xfe00707f"
+  },
+  "lui": {
+    "encoding": "-------------------------0110111",
+    "variable_fields": [
+      "rd",
+      "imm20"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x37",
+    "mask": "0x7f"
+  },
+  "auipc": {
+    "encoding": "-------------------------0010111",
+    "variable_fields": [
+      "rd",
+      "imm20"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x17",
+    "mask": "0x7f"
+  },
+  "jal": {
+    "encoding": "-------------------------1101111",
+    "variable_fields": [
+      "rd",
+      "jimm20"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x6f",
+    "mask": "0x7f"
+  },
+  "jalr": {
+    "encoding": "-----------------000-----1100111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x67",
+    "mask": "0x707f"
+  },
+  "beq": {
+    "encoding": "-----------------000-----1100011",
+    "variable_fields": [
+      "bimm12hi",
+      "rs1",
+      "rs2",
+      "bimm12lo"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x63",
+    "mask": "0x707f"
+  },
+  "bne": {
+    "encoding": "-----------------001-----1100011",
+    "variable_fields": [
+      "bimm12hi",
+      "rs1",
+      "rs2",
+      "bimm12lo"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x1063",
+    "mask": "0x707f"
+  },
+  "blt": {
+    "encoding": "-----------------100-----1100011",
+    "variable_fields": [
+      "bimm12hi",
+      "rs1",
+      "rs2",
+      "bimm12lo"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x4063",
+    "mask": "0x707f"
+  },
+  "bge": {
+    "encoding": "-----------------101-----1100011",
+    "variable_fields": [
+      "bimm12hi",
+      "rs1",
+      "rs2",
+      "bimm12lo"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x5063",
+    "mask": "0x707f"
+  },
+  "bltu": {
+    "encoding": "-----------------110-----1100011",
+    "variable_fields": [
+      "bimm12hi",
+      "rs1",
+      "rs2",
+      "bimm12lo"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x6063",
+    "mask": "0x707f"
+  },
+  "bgeu": {
+    "encoding": "-----------------111-----1100011",
+    "variable_fields": [
+      "bimm12hi",
+      "rs1",
+      "rs2",
+      "bimm12lo"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x7063",
+    "mask": "0x707f"
+  },
+  "lb": {
+    "encoding": "-----------------000-----0000011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x3",
+    "mask": "0x707f"
+  },
+  "lh": {
+    "encoding": "-----------------001-----0000011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x1003",
+    "mask": "0x707f"
+  },
+  "lw": {
+    "encoding": "-----------------010-----0000011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x2003",
+    "mask": "0x707f"
+  },
+  "lbu": {
+    "encoding": "-----------------100-----0000011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x4003",
+    "mask": "0x707f"
+  },
+  "lhu": {
+    "encoding": "-----------------101-----0000011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x5003",
+    "mask": "0x707f"
+  },
+  "sb": {
+    "encoding": "-----------------000-----0100011",
+    "variable_fields": [
+      "imm12hi",
+      "rs1",
+      "rs2",
+      "imm12lo"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x23",
+    "mask": "0x707f"
+  },
+  "sh": {
+    "encoding": "-----------------001-----0100011",
+    "variable_fields": [
+      "imm12hi",
+      "rs1",
+      "rs2",
+      "imm12lo"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x1023",
+    "mask": "0x707f"
+  },
+  "sw": {
+    "encoding": "-----------------010-----0100011",
+    "variable_fields": [
+      "imm12hi",
+      "rs1",
+      "rs2",
+      "imm12lo"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x2023",
+    "mask": "0x707f"
+  },
+  "addi": {
+    "encoding": "-----------------000-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x13",
+    "mask": "0x707f"
+  },
+  "slti": {
+    "encoding": "-----------------010-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x2013",
+    "mask": "0x707f"
+  },
+  "sltiu": {
+    "encoding": "-----------------011-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x3013",
+    "mask": "0x707f"
+  },
+  "xori": {
+    "encoding": "-----------------100-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x4013",
+    "mask": "0x707f"
+  },
+  "ori": {
+    "encoding": "-----------------110-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x6013",
+    "mask": "0x707f"
+  },
+  "andi": {
+    "encoding": "-----------------111-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x7013",
+    "mask": "0x707f"
+  },
+  "add": {
+    "encoding": "0000000----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x33",
+    "mask": "0xfe00707f"
+  },
+  "sub": {
+    "encoding": "0100000----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x40000033",
+    "mask": "0xfe00707f"
+  },
+  "sll": {
+    "encoding": "0000000----------001-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x1033",
+    "mask": "0xfe00707f"
+  },
+  "slt": {
+    "encoding": "0000000----------010-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x2033",
+    "mask": "0xfe00707f"
+  },
+  "sltu": {
+    "encoding": "0000000----------011-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x3033",
+    "mask": "0xfe00707f"
+  },
+  "xor": {
+    "encoding": "0000000----------100-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x4033",
+    "mask": "0xfe00707f"
+  },
+  "srl": {
+    "encoding": "0000000----------101-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x5033",
+    "mask": "0xfe00707f"
+  },
+  "sra": {
+    "encoding": "0100000----------101-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x40005033",
+    "mask": "0xfe00707f"
+  },
+  "or": {
+    "encoding": "0000000----------110-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x6033",
+    "mask": "0xfe00707f"
+  },
+  "and": {
+    "encoding": "0000000----------111-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x7033",
+    "mask": "0xfe00707f"
+  },
+  "fence": {
+    "encoding": "-----------------000-----0001111",
+    "variable_fields": [
+      "fm",
+      "pred",
+      "succ",
+      "rs1",
+      "rd"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0xf",
+    "mask": "0x707f"
+  },
+  "ecall": {
+    "encoding": "00000000000000000000000001110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x73",
+    "mask": "0xffffffff"
+  },
+  "ebreak": {
+    "encoding": "00000000000100000000000001110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x100073",
+    "mask": "0xffffffff"
+  },
+  "hfence_vvma": {
+    "encoding": "0010001----------000000001110011",
+    "variable_fields": [
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_h"
+    ],
+    "match": "0x22000073",
+    "mask": "0xfe007fff"
+  },
+  "hfence_gvma": {
+    "encoding": "0110001----------000000001110011",
+    "variable_fields": [
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_h"
+    ],
+    "match": "0x62000073",
+    "mask": "0xfe007fff"
+  },
+  "hlv_b": {
+    "encoding": "011000000000-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_h"
+    ],
+    "match": "0x60004073",
+    "mask": "0xfff0707f"
+  },
+  "hlv_bu": {
+    "encoding": "011000000001-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_h"
+    ],
+    "match": "0x60104073",
+    "mask": "0xfff0707f"
+  },
+  "hlv_h": {
+    "encoding": "011001000000-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_h"
+    ],
+    "match": "0x64004073",
+    "mask": "0xfff0707f"
+  },
+  "hlv_hu": {
+    "encoding": "011001000001-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_h"
+    ],
+    "match": "0x64104073",
+    "mask": "0xfff0707f"
+  },
+  "hlvx_hu": {
+    "encoding": "011001000011-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_h"
+    ],
+    "match": "0x64304073",
+    "mask": "0xfff0707f"
+  },
+  "hlv_w": {
+    "encoding": "011010000000-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_h"
+    ],
+    "match": "0x68004073",
+    "mask": "0xfff0707f"
+  },
+  "hlvx_wu": {
+    "encoding": "011010000011-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_h"
+    ],
+    "match": "0x68304073",
+    "mask": "0xfff0707f"
+  },
+  "hsv_b": {
+    "encoding": "0110001----------100000001110011",
+    "variable_fields": [
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_h"
+    ],
+    "match": "0x62004073",
+    "mask": "0xfe007fff"
+  },
+  "hsv_h": {
+    "encoding": "0110011----------100000001110011",
+    "variable_fields": [
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_h"
+    ],
+    "match": "0x66004073",
+    "mask": "0xfe007fff"
+  },
+  "hsv_w": {
+    "encoding": "0110101----------100000001110011",
+    "variable_fields": [
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_h"
+    ],
+    "match": "0x6a004073",
+    "mask": "0xfe007fff"
+  },
+  "fli_s": {
+    "encoding": "111100000001-----000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_f_zfa"
+    ],
+    "match": "0xf0100053",
+    "mask": "0xfff0707f"
+  },
+  "fminm_s": {
+    "encoding": "0010100----------010-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_f_zfa"
+    ],
+    "match": "0x28002053",
+    "mask": "0xfe00707f"
+  },
+  "fmaxm_s": {
+    "encoding": "0010100----------011-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_f_zfa"
+    ],
+    "match": "0x28003053",
+    "mask": "0xfe00707f"
+  },
+  "fround_s": {
+    "encoding": "010000000100-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_f_zfa"
+    ],
+    "match": "0x40400053",
+    "mask": "0xfff0007f"
+  },
+  "froundnx_s": {
+    "encoding": "010000000101-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_f_zfa"
+    ],
+    "match": "0x40500053",
+    "mask": "0xfff0007f"
+  },
+  "fleq_s": {
+    "encoding": "1010000----------100-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_f_zfa"
+    ],
+    "match": "0xa0004053",
+    "mask": "0xfe00707f"
+  },
+  "fltq_s": {
+    "encoding": "1010000----------101-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_f_zfa"
+    ],
+    "match": "0xa0005053",
+    "mask": "0xfe00707f"
+  },
+  "flw": {
+    "encoding": "-----------------010-----0000111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x2007",
+    "mask": "0x707f"
+  },
+  "fsw": {
+    "encoding": "-----------------010-----0100111",
+    "variable_fields": [
+      "imm12hi",
+      "rs1",
+      "rs2",
+      "imm12lo"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x2027",
+    "mask": "0x707f"
+  },
+  "fmadd_s": {
+    "encoding": "-----00------------------1000011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x43",
+    "mask": "0x600007f"
+  },
+  "fmsub_s": {
+    "encoding": "-----00------------------1000111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x47",
+    "mask": "0x600007f"
+  },
+  "fnmsub_s": {
+    "encoding": "-----00------------------1001011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x4b",
+    "mask": "0x600007f"
+  },
+  "fnmadd_s": {
+    "encoding": "-----00------------------1001111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x4f",
+    "mask": "0x600007f"
+  },
+  "fadd_s": {
+    "encoding": "0000000------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x53",
+    "mask": "0xfe00007f"
+  },
+  "fsub_s": {
+    "encoding": "0000100------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x8000053",
+    "mask": "0xfe00007f"
+  },
+  "fmul_s": {
+    "encoding": "0001000------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x10000053",
+    "mask": "0xfe00007f"
+  },
+  "fdiv_s": {
+    "encoding": "0001100------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x18000053",
+    "mask": "0xfe00007f"
+  },
+  "fsqrt_s": {
+    "encoding": "010110000000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x58000053",
+    "mask": "0xfff0007f"
+  },
+  "fsgnj_s": {
+    "encoding": "0010000----------000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x20000053",
+    "mask": "0xfe00707f"
+  },
+  "fsgnjn_s": {
+    "encoding": "0010000----------001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x20001053",
+    "mask": "0xfe00707f"
+  },
+  "fsgnjx_s": {
+    "encoding": "0010000----------010-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x20002053",
+    "mask": "0xfe00707f"
+  },
+  "fmin_s": {
+    "encoding": "0010100----------000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x28000053",
+    "mask": "0xfe00707f"
+  },
+  "fmax_s": {
+    "encoding": "0010100----------001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0x28001053",
+    "mask": "0xfe00707f"
+  },
+  "fcvt_w_s": {
+    "encoding": "110000000000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0xc0000053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_wu_s": {
+    "encoding": "110000000001-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0xc0100053",
+    "mask": "0xfff0007f"
+  },
+  "fmv_x_w": {
+    "encoding": "111000000000-----000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0xe0000053",
+    "mask": "0xfff0707f"
+  },
+  "feq_s": {
+    "encoding": "1010000----------010-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0xa0002053",
+    "mask": "0xfe00707f"
+  },
+  "flt_s": {
+    "encoding": "1010000----------001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0xa0001053",
+    "mask": "0xfe00707f"
+  },
+  "fle_s": {
+    "encoding": "1010000----------000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0xa0000053",
+    "mask": "0xfe00707f"
+  },
+  "fclass_s": {
+    "encoding": "111000000000-----001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0xe0001053",
+    "mask": "0xfff0707f"
+  },
+  "fcvt_s_w": {
+    "encoding": "110100000000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0xd0000053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_s_wu": {
+    "encoding": "110100000001-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0xd0100053",
+    "mask": "0xfff0007f"
+  },
+  "fmv_w_x": {
+    "encoding": "111100000000-----000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_f"
+    ],
+    "match": "0xf0000053",
+    "mask": "0xfff0707f"
+  },
+  "fcvt_d_h": {
+    "encoding": "010000100010-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_d_zfh"
+    ],
+    "match": "0x42200053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_h_d": {
+    "encoding": "010001000001-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_d_zfh"
+    ],
+    "match": "0x44100053",
+    "mask": "0xfff0007f"
+  },
+  "fli_d": {
+    "encoding": "111100100001-----000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_d_zfa"
+    ],
+    "match": "0xf2100053",
+    "mask": "0xfff0707f"
+  },
+  "fminm_d": {
+    "encoding": "0010101----------010-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_d_zfa"
+    ],
+    "match": "0x2a002053",
+    "mask": "0xfe00707f"
+  },
+  "fmaxm_d": {
+    "encoding": "0010101----------011-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_d_zfa"
+    ],
+    "match": "0x2a003053",
+    "mask": "0xfe00707f"
+  },
+  "fround_d": {
+    "encoding": "010000100100-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_d_zfa"
+    ],
+    "match": "0x42400053",
+    "mask": "0xfff0007f"
+  },
+  "froundnx_d": {
+    "encoding": "010000100101-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_d_zfa"
+    ],
+    "match": "0x42500053",
+    "mask": "0xfff0007f"
+  },
+  "fcvtmod_w_d": {
+    "encoding": "110000101000-----001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_d_zfa"
+    ],
+    "match": "0xc2801053",
+    "mask": "0xfff0707f"
+  },
+  "fleq_d": {
+    "encoding": "1010001----------100-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_d_zfa"
+    ],
+    "match": "0xa2004053",
+    "mask": "0xfe00707f"
+  },
+  "fltq_d": {
+    "encoding": "1010001----------101-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_d_zfa"
+    ],
+    "match": "0xa2005053",
+    "mask": "0xfe00707f"
+  },
+  "fld": {
+    "encoding": "-----------------011-----0000111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x3007",
+    "mask": "0x707f"
+  },
+  "fsd": {
+    "encoding": "-----------------011-----0100111",
+    "variable_fields": [
+      "imm12hi",
+      "rs1",
+      "rs2",
+      "imm12lo"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x3027",
+    "mask": "0x707f"
+  },
+  "fmadd_d": {
+    "encoding": "-----01------------------1000011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x2000043",
+    "mask": "0x600007f"
+  },
+  "fmsub_d": {
+    "encoding": "-----01------------------1000111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x2000047",
+    "mask": "0x600007f"
+  },
+  "fnmsub_d": {
+    "encoding": "-----01------------------1001011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x200004b",
+    "mask": "0x600007f"
+  },
+  "fnmadd_d": {
+    "encoding": "-----01------------------1001111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rs3",
+      "rm"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x200004f",
+    "mask": "0x600007f"
+  },
+  "fadd_d": {
+    "encoding": "0000001------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x2000053",
+    "mask": "0xfe00007f"
+  },
+  "fsub_d": {
+    "encoding": "0000101------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0xa000053",
+    "mask": "0xfe00007f"
+  },
+  "fmul_d": {
+    "encoding": "0001001------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x12000053",
+    "mask": "0xfe00007f"
+  },
+  "fdiv_d": {
+    "encoding": "0001101------------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "rm"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x1a000053",
+    "mask": "0xfe00007f"
+  },
+  "fsqrt_d": {
+    "encoding": "010110100000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x5a000053",
+    "mask": "0xfff0007f"
+  },
+  "fsgnj_d": {
+    "encoding": "0010001----------000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x22000053",
+    "mask": "0xfe00707f"
+  },
+  "fsgnjn_d": {
+    "encoding": "0010001----------001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x22001053",
+    "mask": "0xfe00707f"
+  },
+  "fsgnjx_d": {
+    "encoding": "0010001----------010-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x22002053",
+    "mask": "0xfe00707f"
+  },
+  "fmin_d": {
+    "encoding": "0010101----------000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x2a000053",
+    "mask": "0xfe00707f"
+  },
+  "fmax_d": {
+    "encoding": "0010101----------001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x2a001053",
+    "mask": "0xfe00707f"
+  },
+  "fcvt_s_d": {
+    "encoding": "010000000001-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x40100053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_d_s": {
+    "encoding": "010000100000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0x42000053",
+    "mask": "0xfff0007f"
+  },
+  "feq_d": {
+    "encoding": "1010001----------010-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0xa2002053",
+    "mask": "0xfe00707f"
+  },
+  "flt_d": {
+    "encoding": "1010001----------001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0xa2001053",
+    "mask": "0xfe00707f"
+  },
+  "fle_d": {
+    "encoding": "1010001----------000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0xa2000053",
+    "mask": "0xfe00707f"
+  },
+  "fclass_d": {
+    "encoding": "111000100000-----001-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0xe2001053",
+    "mask": "0xfff0707f"
+  },
+  "fcvt_w_d": {
+    "encoding": "110000100000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0xc2000053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_wu_d": {
+    "encoding": "110000100001-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0xc2100053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_d_w": {
+    "encoding": "110100100000-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0xd2000053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_d_wu": {
+    "encoding": "110100100001-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv_d"
+    ],
+    "match": "0xd2100053",
+    "mask": "0xfff0007f"
+  },
+  "c_fld": {
+    "encoding": "----------------001-----------00",
+    "variable_fields": [
+      "rd_p",
+      "rs1_p",
+      "c_uimm8lo",
+      "c_uimm8hi"
+    ],
+    "extension": [
+      "rv_c_d"
+    ],
+    "match": "0x2000",
+    "mask": "0xe003"
+  },
+  "c_fsd": {
+    "encoding": "----------------101-----------00",
+    "variable_fields": [
+      "rs1_p",
+      "rs2_p",
+      "c_uimm8lo",
+      "c_uimm8hi"
+    ],
+    "extension": [
+      "rv_c_d"
+    ],
+    "match": "0xa000",
+    "mask": "0xe003"
+  },
+  "c_fldsp": {
+    "encoding": "----------------001-----------10",
+    "variable_fields": [
+      "rd",
+      "c_uimm9sphi",
+      "c_uimm9splo"
+    ],
+    "extension": [
+      "rv_c_d"
+    ],
+    "match": "0x2002",
+    "mask": "0xe003"
+  },
+  "c_fsdsp": {
+    "encoding": "----------------101-----------10",
+    "variable_fields": [
+      "c_rs2",
+      "c_uimm9sp_s"
+    ],
+    "extension": [
+      "rv_c_d"
+    ],
+    "match": "0xa002",
+    "mask": "0xe003"
+  },
+  "c_addi4spn": {
+    "encoding": "----------------000-----------00",
+    "variable_fields": [
+      "rd_p",
+      "c_nzuimm10"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x0",
+    "mask": "0xe003"
+  },
+  "c_lw": {
+    "encoding": "----------------010-----------00",
+    "variable_fields": [
+      "rd_p",
+      "rs1_p",
+      "c_uimm7lo",
+      "c_uimm7hi"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x4000",
+    "mask": "0xe003"
+  },
+  "c_sw": {
+    "encoding": "----------------110-----------00",
+    "variable_fields": [
+      "rs1_p",
+      "rs2_p",
+      "c_uimm7lo",
+      "c_uimm7hi"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0xc000",
+    "mask": "0xe003"
+  },
+  "c_nop": {
+    "encoding": "----------------000-00000-----01",
+    "variable_fields": [
+      "c_nzimm6hi",
+      "c_nzimm6lo"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x1",
+    "mask": "0xef83"
+  },
+  "c_addi": {
+    "encoding": "----------------000-----------01",
+    "variable_fields": [
+      "rd_rs1_n0",
+      "c_nzimm6lo",
+      "c_nzimm6hi"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x1",
+    "mask": "0xe003"
+  },
+  "c_li": {
+    "encoding": "----------------010-----------01",
+    "variable_fields": [
+      "rd_n0",
+      "c_imm6lo",
+      "c_imm6hi"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x4001",
+    "mask": "0xe003"
+  },
+  "c_addi16sp": {
+    "encoding": "----------------011-00010-----01",
+    "variable_fields": [
+      "c_nzimm10hi",
+      "c_nzimm10lo"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x6101",
+    "mask": "0xef83"
+  },
+  "c_lui": {
+    "encoding": "----------------011-----------01",
+    "variable_fields": [
+      "rd_n2",
+      "c_nzimm18hi",
+      "c_nzimm18lo"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x6001",
+    "mask": "0xe003"
+  },
+  "c_andi": {
+    "encoding": "----------------100-10--------01",
+    "variable_fields": [
+      "rd_rs1_p",
+      "c_imm6hi",
+      "c_imm6lo"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x8801",
+    "mask": "0xec03"
+  },
+  "c_sub": {
+    "encoding": "----------------100011---00---01",
+    "variable_fields": [
+      "rd_rs1_p",
+      "rs2_p"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x8c01",
+    "mask": "0xfc63"
+  },
+  "c_xor": {
+    "encoding": "----------------100011---01---01",
+    "variable_fields": [
+      "rd_rs1_p",
+      "rs2_p"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x8c21",
+    "mask": "0xfc63"
+  },
+  "c_or": {
+    "encoding": "----------------100011---10---01",
+    "variable_fields": [
+      "rd_rs1_p",
+      "rs2_p"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x8c41",
+    "mask": "0xfc63"
+  },
+  "c_and": {
+    "encoding": "----------------100011---11---01",
+    "variable_fields": [
+      "rd_rs1_p",
+      "rs2_p"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x8c61",
+    "mask": "0xfc63"
+  },
+  "c_j": {
+    "encoding": "----------------101-----------01",
+    "variable_fields": [
+      "c_imm12"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0xa001",
+    "mask": "0xe003"
+  },
+  "c_beqz": {
+    "encoding": "----------------110-----------01",
+    "variable_fields": [
+      "rs1_p",
+      "c_bimm9lo",
+      "c_bimm9hi"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0xc001",
+    "mask": "0xe003"
+  },
+  "c_bnez": {
+    "encoding": "----------------111-----------01",
+    "variable_fields": [
+      "rs1_p",
+      "c_bimm9lo",
+      "c_bimm9hi"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0xe001",
+    "mask": "0xe003"
+  },
+  "c_lwsp": {
+    "encoding": "----------------010-----------10",
+    "variable_fields": [
+      "rd_n0",
+      "c_uimm8sphi",
+      "c_uimm8splo"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x4002",
+    "mask": "0xe003"
+  },
+  "c_jr": {
+    "encoding": "----------------1000-----0000010",
+    "variable_fields": [
+      "rs1_n0"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x8002",
+    "mask": "0xf07f"
+  },
+  "c_mv": {
+    "encoding": "----------------1000----------10",
+    "variable_fields": [
+      "rd_n0",
+      "c_rs2_n0"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x8002",
+    "mask": "0xf003"
+  },
+  "c_ebreak": {
+    "encoding": "----------------1001000000000010",
+    "variable_fields": [],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x9002",
+    "mask": "0xffff"
+  },
+  "c_jalr": {
+    "encoding": "----------------1001-----0000010",
+    "variable_fields": [
+      "c_rs1_n0"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x9002",
+    "mask": "0xf07f"
+  },
+  "c_add": {
+    "encoding": "----------------1001----------10",
+    "variable_fields": [
+      "rd_rs1_n0",
+      "c_rs2_n0"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0x9002",
+    "mask": "0xf003"
+  },
+  "c_swsp": {
+    "encoding": "----------------110-----------10",
+    "variable_fields": [
+      "c_rs2",
+      "c_uimm8sp_s"
+    ],
+    "extension": [
+      "rv_c"
+    ],
+    "match": "0xc002",
+    "mask": "0xe003"
+  },
+  "lr_w": {
+    "encoding": "00010--00000-----010-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_a"
+    ],
+    "match": "0x1000202f",
+    "mask": "0xf9f0707f"
+  },
+  "sc_w": {
+    "encoding": "00011------------010-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_a"
+    ],
+    "match": "0x1800202f",
+    "mask": "0xf800707f"
+  },
+  "amoswap_w": {
+    "encoding": "00001------------010-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_a"
+    ],
+    "match": "0x800202f",
+    "mask": "0xf800707f"
+  },
+  "amoadd_w": {
+    "encoding": "00000------------010-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_a"
+    ],
+    "match": "0x202f",
+    "mask": "0xf800707f"
+  },
+  "amoxor_w": {
+    "encoding": "00100------------010-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_a"
+    ],
+    "match": "0x2000202f",
+    "mask": "0xf800707f"
+  },
+  "amoand_w": {
+    "encoding": "01100------------010-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_a"
+    ],
+    "match": "0x6000202f",
+    "mask": "0xf800707f"
+  },
+  "amoor_w": {
+    "encoding": "01000------------010-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_a"
+    ],
+    "match": "0x4000202f",
+    "mask": "0xf800707f"
+  },
+  "amomin_w": {
+    "encoding": "10000------------010-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_a"
+    ],
+    "match": "0x8000202f",
+    "mask": "0xf800707f"
+  },
+  "amomax_w": {
+    "encoding": "10100------------010-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_a"
+    ],
+    "match": "0xa000202f",
+    "mask": "0xf800707f"
+  },
+  "amominu_w": {
+    "encoding": "11000------------010-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_a"
+    ],
+    "match": "0xc000202f",
+    "mask": "0xf800707f"
+  },
+  "amomaxu_w": {
+    "encoding": "11100------------010-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv_a"
+    ],
+    "match": "0xe000202f",
+    "mask": "0xf800707f"
+  },
+  "sha512sum0": {
+    "encoding": "000100000100-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv64_zknh",
+      "rv64_zkn",
+      "rv64_zk"
+    ],
+    "match": "0x10401013",
+    "mask": "0xfff0707f"
+  },
+  "sha512sum1": {
+    "encoding": "000100000101-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv64_zknh",
+      "rv64_zkn",
+      "rv64_zk"
+    ],
+    "match": "0x10501013",
+    "mask": "0xfff0707f"
+  },
+  "sha512sig0": {
+    "encoding": "000100000110-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv64_zknh",
+      "rv64_zkn",
+      "rv64_zk"
+    ],
+    "match": "0x10601013",
+    "mask": "0xfff0707f"
+  },
+  "sha512sig1": {
+    "encoding": "000100000111-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv64_zknh",
+      "rv64_zkn",
+      "rv64_zk"
+    ],
+    "match": "0x10701013",
+    "mask": "0xfff0707f"
+  },
+  "aes64esm": {
+    "encoding": "0011011----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_zkne",
+      "rv64_zkn",
+      "rv64_zk"
+    ],
+    "match": "0x36000033",
+    "mask": "0xfe00707f"
+  },
+  "aes64es": {
+    "encoding": "0011001----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_zkne",
+      "rv64_zkn",
+      "rv64_zk"
+    ],
+    "match": "0x32000033",
+    "mask": "0xfe00707f"
+  },
+  "aes64dsm": {
+    "encoding": "0011111----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_zknd",
+      "rv64_zkn",
+      "rv64_zk"
+    ],
+    "match": "0x3e000033",
+    "mask": "0xfe00707f"
+  },
+  "aes64ds": {
+    "encoding": "0011101----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_zknd",
+      "rv64_zkn",
+      "rv64_zk"
+    ],
+    "match": "0x3a000033",
+    "mask": "0xfe00707f"
+  },
+  "aes64ks1i": {
+    "encoding": "00110001---------001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rnum"
+    ],
+    "extension": [
+      "rv64_zknd",
+      "rv64_zkne",
+      "rv64_zkn",
+      "rv64_zk"
+    ],
+    "match": "0x31001013",
+    "mask": "0xff00707f"
+  },
+  "aes64im": {
+    "encoding": "001100000000-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv64_zknd",
+      "rv64_zkn",
+      "rv64_zk"
+    ],
+    "match": "0x30001013",
+    "mask": "0xfff0707f"
+  },
+  "aes64ks2": {
+    "encoding": "0111111----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_zknd",
+      "rv64_zkne",
+      "rv64_zkn",
+      "rv64_zk"
+    ],
+    "match": "0x7e000033",
+    "mask": "0xfe00707f"
+  },
+  "fcvt_l_h": {
+    "encoding": "110001000010-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_zfh"
+    ],
+    "match": "0xc4200053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_lu_h": {
+    "encoding": "110001000011-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_zfh"
+    ],
+    "match": "0xc4300053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_h_l": {
+    "encoding": "110101000010-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_zfh"
+    ],
+    "match": "0xd4200053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_h_lu": {
+    "encoding": "110101000011-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_zfh"
+    ],
+    "match": "0xd4300053",
+    "mask": "0xfff0007f"
+  },
+  "c_zext_w": {
+    "encoding": "----------------100111---1110001",
+    "variable_fields": [
+      "rd_rs1_p"
+    ],
+    "extension": [
+      "rv64_zcb"
+    ],
+    "match": "0x9c71",
+    "mask": "0xfc7f"
+  },
+  "bclri": {
+    "encoding": "010010-----------001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtd"
+    ],
+    "extension": [
+      "rv64_zbs"
+    ],
+    "match": "0x48001013",
+    "mask": "0xfc00707f"
+  },
+  "bexti": {
+    "encoding": "010010-----------101-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtd"
+    ],
+    "extension": [
+      "rv64_zbs"
+    ],
+    "match": "0x48005013",
+    "mask": "0xfc00707f"
+  },
+  "binvi": {
+    "encoding": "011010-----------001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtd"
+    ],
+    "extension": [
+      "rv64_zbs"
+    ],
+    "match": "0x68001013",
+    "mask": "0xfc00707f"
+  },
+  "bseti": {
+    "encoding": "001010-----------001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtd"
+    ],
+    "extension": [
+      "rv64_zbs"
+    ],
+    "match": "0x28001013",
+    "mask": "0xfc00707f"
+  },
+  "packw": {
+    "encoding": "0000100----------100-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_zbkb",
+      "rv64_zks",
+      "rv64_zkn",
+      "rv64_zk"
+    ],
+    "match": "0x800403b",
+    "mask": "0xfe00707f"
+  },
+  "clzw": {
+    "encoding": "011000000000-----001-----0011011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv64_zbb"
+    ],
+    "match": "0x6000101b",
+    "mask": "0xfff0707f"
+  },
+  "ctzw": {
+    "encoding": "011000000001-----001-----0011011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv64_zbb"
+    ],
+    "match": "0x6010101b",
+    "mask": "0xfff0707f"
+  },
+  "cpopw": {
+    "encoding": "011000000010-----001-----0011011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv64_zbb"
+    ],
+    "match": "0x6020101b",
+    "mask": "0xfff0707f"
+  },
+  "rolw": {
+    "encoding": "0110000----------001-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_zbb",
+      "rv64_zks",
+      "rv64_zkn",
+      "rv64_zk",
+      "rv64_zbkb"
+    ],
+    "match": "0x6000103b",
+    "mask": "0xfe00707f"
+  },
+  "rorw": {
+    "encoding": "0110000----------101-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_zbb",
+      "rv64_zks",
+      "rv64_zkn",
+      "rv64_zk",
+      "rv64_zbkb"
+    ],
+    "match": "0x6000503b",
+    "mask": "0xfe00707f"
+  },
+  "roriw": {
+    "encoding": "0110000----------101-----0011011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtw"
+    ],
+    "extension": [
+      "rv64_zbb",
+      "rv64_zks",
+      "rv64_zkn",
+      "rv64_zk",
+      "rv64_zbkb"
+    ],
+    "match": "0x6000501b",
+    "mask": "0xfe00707f"
+  },
+  "rori": {
+    "encoding": "011000-----------101-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtd"
+    ],
+    "extension": [
+      "rv64_zbb",
+      "rv64_zks",
+      "rv64_zkn",
+      "rv64_zk",
+      "rv64_zbkb"
+    ],
+    "match": "0x60005013",
+    "mask": "0xfc00707f"
+  },
+  "add_uw": {
+    "encoding": "0000100----------000-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_zba"
+    ],
+    "match": "0x800003b",
+    "mask": "0xfe00707f"
+  },
+  "sh1add_uw": {
+    "encoding": "0010000----------010-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_zba"
+    ],
+    "match": "0x2000203b",
+    "mask": "0xfe00707f"
+  },
+  "sh2add_uw": {
+    "encoding": "0010000----------100-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_zba"
+    ],
+    "match": "0x2000403b",
+    "mask": "0xfe00707f"
+  },
+  "sh3add_uw": {
+    "encoding": "0010000----------110-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_zba"
+    ],
+    "match": "0x2000603b",
+    "mask": "0xfe00707f"
+  },
+  "slli_uw": {
+    "encoding": "000010-----------001-----0011011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtd"
+    ],
+    "extension": [
+      "rv64_zba"
+    ],
+    "match": "0x800101b",
+    "mask": "0xfc00707f"
+  },
+  "amocas_q": {
+    "encoding": "00101------------100-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv64_zacas"
+    ],
+    "match": "0x2800402f",
+    "mask": "0xf800707f"
+  },
+  "fmvh_x_q": {
+    "encoding": "111001100001-----000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv64_q_zfa"
+    ],
+    "match": "0xe6100053",
+    "mask": "0xfff0707f"
+  },
+  "fmvp_q_x": {
+    "encoding": "1011011----------000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_q_zfa"
+    ],
+    "match": "0xb6000053",
+    "mask": "0xfe00707f"
+  },
+  "fcvt_l_q": {
+    "encoding": "110001100010-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_q"
+    ],
+    "match": "0xc6200053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_lu_q": {
+    "encoding": "110001100011-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_q"
+    ],
+    "match": "0xc6300053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_q_l": {
+    "encoding": "110101100010-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_q"
+    ],
+    "match": "0xd6200053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_q_lu": {
+    "encoding": "110101100011-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_q"
+    ],
+    "match": "0xd6300053",
+    "mask": "0xfff0007f"
+  },
+  "mulw": {
+    "encoding": "0000001----------000-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_m"
+    ],
+    "match": "0x200003b",
+    "mask": "0xfe00707f"
+  },
+  "divw": {
+    "encoding": "0000001----------100-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_m"
+    ],
+    "match": "0x200403b",
+    "mask": "0xfe00707f"
+  },
+  "divuw": {
+    "encoding": "0000001----------101-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_m"
+    ],
+    "match": "0x200503b",
+    "mask": "0xfe00707f"
+  },
+  "remw": {
+    "encoding": "0000001----------110-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_m"
+    ],
+    "match": "0x200603b",
+    "mask": "0xfe00707f"
+  },
+  "remuw": {
+    "encoding": "0000001----------111-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_m"
+    ],
+    "match": "0x200703b",
+    "mask": "0xfe00707f"
+  },
+  "lwu": {
+    "encoding": "-----------------110-----0000011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv64_i"
+    ],
+    "match": "0x6003",
+    "mask": "0x707f"
+  },
+  "ld": {
+    "encoding": "-----------------011-----0000011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv64_i"
+    ],
+    "match": "0x3003",
+    "mask": "0x707f"
+  },
+  "sd": {
+    "encoding": "-----------------011-----0100011",
+    "variable_fields": [
+      "imm12hi",
+      "rs1",
+      "rs2",
+      "imm12lo"
+    ],
+    "extension": [
+      "rv64_i"
+    ],
+    "match": "0x3023",
+    "mask": "0x707f"
+  },
+  "slli": {
+    "encoding": "000000-----------001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtd"
+    ],
+    "extension": [
+      "rv64_i"
+    ],
+    "match": "0x1013",
+    "mask": "0xfc00707f"
+  },
+  "srli": {
+    "encoding": "000000-----------101-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtd"
+    ],
+    "extension": [
+      "rv64_i"
+    ],
+    "match": "0x5013",
+    "mask": "0xfc00707f"
+  },
+  "srai": {
+    "encoding": "010000-----------101-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtd"
+    ],
+    "extension": [
+      "rv64_i"
+    ],
+    "match": "0x40005013",
+    "mask": "0xfc00707f"
+  },
+  "addiw": {
+    "encoding": "-----------------000-----0011011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv64_i"
+    ],
+    "match": "0x1b",
+    "mask": "0x707f"
+  },
+  "slliw": {
+    "encoding": "0000000----------001-----0011011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtw"
+    ],
+    "extension": [
+      "rv64_i"
+    ],
+    "match": "0x101b",
+    "mask": "0xfe00707f"
+  },
+  "srliw": {
+    "encoding": "0000000----------101-----0011011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtw"
+    ],
+    "extension": [
+      "rv64_i"
+    ],
+    "match": "0x501b",
+    "mask": "0xfe00707f"
+  },
+  "sraiw": {
+    "encoding": "0100000----------101-----0011011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtw"
+    ],
+    "extension": [
+      "rv64_i"
+    ],
+    "match": "0x4000501b",
+    "mask": "0xfe00707f"
+  },
+  "addw": {
+    "encoding": "0000000----------000-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_i"
+    ],
+    "match": "0x3b",
+    "mask": "0xfe00707f"
+  },
+  "subw": {
+    "encoding": "0100000----------000-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_i"
+    ],
+    "match": "0x4000003b",
+    "mask": "0xfe00707f"
+  },
+  "sllw": {
+    "encoding": "0000000----------001-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_i"
+    ],
+    "match": "0x103b",
+    "mask": "0xfe00707f"
+  },
+  "srlw": {
+    "encoding": "0000000----------101-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_i"
+    ],
+    "match": "0x503b",
+    "mask": "0xfe00707f"
+  },
+  "sraw": {
+    "encoding": "0100000----------101-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_i"
+    ],
+    "match": "0x4000503b",
+    "mask": "0xfe00707f"
+  },
+  "hlv_wu": {
+    "encoding": "011010000001-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv64_h"
+    ],
+    "match": "0x68104073",
+    "mask": "0xfff0707f"
+  },
+  "hlv_d": {
+    "encoding": "011011000000-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv64_h"
+    ],
+    "match": "0x6c004073",
+    "mask": "0xfff0707f"
+  },
+  "hsv_d": {
+    "encoding": "0110111----------100000001110011",
+    "variable_fields": [
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_h"
+    ],
+    "match": "0x6e004073",
+    "mask": "0xfe007fff"
+  },
+  "fcvt_l_s": {
+    "encoding": "110000000010-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_f"
+    ],
+    "match": "0xc0200053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_lu_s": {
+    "encoding": "110000000011-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_f"
+    ],
+    "match": "0xc0300053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_s_l": {
+    "encoding": "110100000010-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_f"
+    ],
+    "match": "0xd0200053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_s_lu": {
+    "encoding": "110100000011-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_f"
+    ],
+    "match": "0xd0300053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_l_d": {
+    "encoding": "110000100010-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_d"
+    ],
+    "match": "0xc2200053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_lu_d": {
+    "encoding": "110000100011-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_d"
+    ],
+    "match": "0xc2300053",
+    "mask": "0xfff0007f"
+  },
+  "fmv_x_d": {
+    "encoding": "111000100000-----000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv64_d"
+    ],
+    "match": "0xe2000053",
+    "mask": "0xfff0707f"
+  },
+  "fcvt_d_l": {
+    "encoding": "110100100010-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_d"
+    ],
+    "match": "0xd2200053",
+    "mask": "0xfff0007f"
+  },
+  "fcvt_d_lu": {
+    "encoding": "110100100011-------------1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rm"
+    ],
+    "extension": [
+      "rv64_d"
+    ],
+    "match": "0xd2300053",
+    "mask": "0xfff0007f"
+  },
+  "fmv_d_x": {
+    "encoding": "111100100000-----000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv64_d"
+    ],
+    "match": "0xf2000053",
+    "mask": "0xfff0707f"
+  },
+  "c_ld": {
+    "encoding": "----------------011-----------00",
+    "variable_fields": [
+      "rd_p",
+      "rs1_p",
+      "c_uimm8lo",
+      "c_uimm8hi"
+    ],
+    "extension": [
+      "rv64_c"
+    ],
+    "match": "0x6000",
+    "mask": "0xe003"
+  },
+  "c_sd": {
+    "encoding": "----------------111-----------00",
+    "variable_fields": [
+      "rs1_p",
+      "rs2_p",
+      "c_uimm8hi",
+      "c_uimm8lo"
+    ],
+    "extension": [
+      "rv64_c"
+    ],
+    "match": "0xe000",
+    "mask": "0xe003"
+  },
+  "c_addiw": {
+    "encoding": "----------------001-----------01",
+    "variable_fields": [
+      "rd_rs1_n0",
+      "c_imm6lo",
+      "c_imm6hi"
+    ],
+    "extension": [
+      "rv64_c"
+    ],
+    "match": "0x2001",
+    "mask": "0xe003"
+  },
+  "c_srli": {
+    "encoding": "----------------100-00--------01",
+    "variable_fields": [
+      "rd_rs1_p",
+      "c_nzuimm6lo",
+      "c_nzuimm6hi"
+    ],
+    "extension": [
+      "rv64_c"
+    ],
+    "match": "0x8001",
+    "mask": "0xec03"
+  },
+  "c_srai": {
+    "encoding": "----------------100-01--------01",
+    "variable_fields": [
+      "rd_rs1_p",
+      "c_nzuimm6lo",
+      "c_nzuimm6hi"
+    ],
+    "extension": [
+      "rv64_c"
+    ],
+    "match": "0x8401",
+    "mask": "0xec03"
+  },
+  "c_subw": {
+    "encoding": "----------------100111---00---01",
+    "variable_fields": [
+      "rd_rs1_p",
+      "rs2_p"
+    ],
+    "extension": [
+      "rv64_c"
+    ],
+    "match": "0x9c01",
+    "mask": "0xfc63"
+  },
+  "c_addw": {
+    "encoding": "----------------100111---01---01",
+    "variable_fields": [
+      "rd_rs1_p",
+      "rs2_p"
+    ],
+    "extension": [
+      "rv64_c"
+    ],
+    "match": "0x9c21",
+    "mask": "0xfc63"
+  },
+  "c_slli": {
+    "encoding": "----------------000-----------10",
+    "variable_fields": [
+      "rd_rs1_n0",
+      "c_nzuimm6hi",
+      "c_nzuimm6lo"
+    ],
+    "extension": [
+      "rv64_c"
+    ],
+    "match": "0x2",
+    "mask": "0xe003"
+  },
+  "c_ldsp": {
+    "encoding": "----------------011-----------10",
+    "variable_fields": [
+      "rd_n0",
+      "c_uimm9sphi",
+      "c_uimm9splo"
+    ],
+    "extension": [
+      "rv64_c"
+    ],
+    "match": "0x6002",
+    "mask": "0xe003"
+  },
+  "c_sdsp": {
+    "encoding": "----------------111-----------10",
+    "variable_fields": [
+      "c_rs2",
+      "c_uimm9sp_s"
+    ],
+    "extension": [
+      "rv64_c"
+    ],
+    "match": "0xe002",
+    "mask": "0xe003"
+  },
+  "lr_d": {
+    "encoding": "00010--00000-----011-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv64_a"
+    ],
+    "match": "0x1000302f",
+    "mask": "0xf9f0707f"
+  },
+  "sc_d": {
+    "encoding": "00011------------011-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv64_a"
+    ],
+    "match": "0x1800302f",
+    "mask": "0xf800707f"
+  },
+  "amoswap_d": {
+    "encoding": "00001------------011-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv64_a"
+    ],
+    "match": "0x800302f",
+    "mask": "0xf800707f"
+  },
+  "amoadd_d": {
+    "encoding": "00000------------011-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv64_a"
+    ],
+    "match": "0x302f",
+    "mask": "0xf800707f"
+  },
+  "amoxor_d": {
+    "encoding": "00100------------011-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv64_a"
+    ],
+    "match": "0x2000302f",
+    "mask": "0xf800707f"
+  },
+  "amoand_d": {
+    "encoding": "01100------------011-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv64_a"
+    ],
+    "match": "0x6000302f",
+    "mask": "0xf800707f"
+  },
+  "amoor_d": {
+    "encoding": "01000------------011-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv64_a"
+    ],
+    "match": "0x4000302f",
+    "mask": "0xf800707f"
+  },
+  "amomin_d": {
+    "encoding": "10000------------011-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv64_a"
+    ],
+    "match": "0x8000302f",
+    "mask": "0xf800707f"
+  },
+  "amomax_d": {
+    "encoding": "10100------------011-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv64_a"
+    ],
+    "match": "0xa000302f",
+    "mask": "0xf800707f"
+  },
+  "amominu_d": {
+    "encoding": "11000------------011-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv64_a"
+    ],
+    "match": "0xc000302f",
+    "mask": "0xf800707f"
+  },
+  "amomaxu_d": {
+    "encoding": "11100------------011-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "aq",
+      "rl"
+    ],
+    "extension": [
+      "rv64_a"
+    ],
+    "match": "0xe000302f",
+    "mask": "0xf800707f"
+  },
+  "sha512sum0r": {
+    "encoding": "0101000----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv32_zknh",
+      "rv32_zkn",
+      "rv32_zk"
+    ],
+    "match": "0x50000033",
+    "mask": "0xfe00707f"
+  },
+  "sha512sum1r": {
+    "encoding": "0101001----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv32_zknh",
+      "rv32_zkn",
+      "rv32_zk"
+    ],
+    "match": "0x52000033",
+    "mask": "0xfe00707f"
+  },
+  "sha512sig0l": {
+    "encoding": "0101010----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv32_zknh",
+      "rv32_zkn",
+      "rv32_zk"
+    ],
+    "match": "0x54000033",
+    "mask": "0xfe00707f"
+  },
+  "sha512sig0h": {
+    "encoding": "0101110----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv32_zknh",
+      "rv32_zkn",
+      "rv32_zk"
+    ],
+    "match": "0x5c000033",
+    "mask": "0xfe00707f"
+  },
+  "sha512sig1l": {
+    "encoding": "0101011----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv32_zknh",
+      "rv32_zkn",
+      "rv32_zk"
+    ],
+    "match": "0x56000033",
+    "mask": "0xfe00707f"
+  },
+  "sha512sig1h": {
+    "encoding": "0101111----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv32_zknh",
+      "rv32_zkn",
+      "rv32_zk"
+    ],
+    "match": "0x5e000033",
+    "mask": "0xfe00707f"
+  },
+  "aes32esmi": {
+    "encoding": "--10011----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "bs"
+    ],
+    "extension": [
+      "rv32_zkne",
+      "rv32_zkn",
+      "rv32_zk"
+    ],
+    "match": "0x26000033",
+    "mask": "0x3e00707f"
+  },
+  "aes32esi": {
+    "encoding": "--10001----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "bs"
+    ],
+    "extension": [
+      "rv32_zkne",
+      "rv32_zkn",
+      "rv32_zk"
+    ],
+    "match": "0x22000033",
+    "mask": "0x3e00707f"
+  },
+  "aes32dsmi": {
+    "encoding": "--10111----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "bs"
+    ],
+    "extension": [
+      "rv32_zknd",
+      "rv32_zkn",
+      "rv32_zk"
+    ],
+    "match": "0x2e000033",
+    "mask": "0x3e00707f"
+  },
+  "aes32dsi": {
+    "encoding": "--10101----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2",
+      "bs"
+    ],
+    "extension": [
+      "rv32_zknd",
+      "rv32_zkn",
+      "rv32_zk"
+    ],
+    "match": "0x2a000033",
+    "mask": "0x3e00707f"
+  },
+  "fmvh_x_d": {
+    "encoding": "111000100001-----000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv32_d_zfa"
+    ],
+    "match": "0xe2100053",
+    "mask": "0xfff0707f"
+  },
+  "fmvp_d_x": {
+    "encoding": "1011001----------000-----1010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv32_d_zfa"
+    ],
+    "match": "0xb2000053",
+    "mask": "0xfe00707f"
+  },
+  "c_flw": {
+    "encoding": "----------------011-----------00",
+    "variable_fields": [
+      "rd_p",
+      "rs1_p",
+      "c_uimm7lo",
+      "c_uimm7hi"
+    ],
+    "extension": [
+      "rv32_c_f"
+    ],
+    "match": "0x6000",
+    "mask": "0xe003"
+  },
+  "c_fsw": {
+    "encoding": "----------------111-----------00",
+    "variable_fields": [
+      "rs1_p",
+      "rs2_p",
+      "c_uimm7lo",
+      "c_uimm7hi"
+    ],
+    "extension": [
+      "rv32_c_f"
+    ],
+    "match": "0xe000",
+    "mask": "0xe003"
+  },
+  "c_flwsp": {
+    "encoding": "----------------011-----------10",
+    "variable_fields": [
+      "rd",
+      "c_uimm8sphi",
+      "c_uimm8splo"
+    ],
+    "extension": [
+      "rv32_c_f"
+    ],
+    "match": "0x6002",
+    "mask": "0xe003"
+  },
+  "c_fswsp": {
+    "encoding": "----------------111-----------10",
+    "variable_fields": [
+      "c_rs2",
+      "c_uimm8sp_s"
+    ],
+    "extension": [
+      "rv32_c_f"
+    ],
+    "match": "0xe002",
+    "mask": "0xe003"
+  },
+  "c_jal": {
+    "encoding": "----------------001-----------01",
+    "variable_fields": [
+      "c_imm12"
+    ],
+    "extension": [
+      "rv32_c"
+    ],
+    "match": "0x2001",
+    "mask": "0xe003"
+  },
+  "xperm16": {
+    "encoding": "0010100----------110-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zbp"
+    ],
+    "match": "0x28006033",
+    "mask": "0xfe00707f"
+  },
+  "lb_aq": {
+    "encoding": "001101-00000-----000-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rl"
+    ],
+    "extension": [
+      "rv_zalasr"
+    ],
+    "match": "0x3400002f",
+    "mask": "0xfdf0707f"
+  },
+  "lh_aq": {
+    "encoding": "001101-00000-----001-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rl"
+    ],
+    "extension": [
+      "rv_zalasr"
+    ],
+    "match": "0x3400102f",
+    "mask": "0xfdf0707f"
+  },
+  "lw_aq": {
+    "encoding": "001101-00000-----010-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rl"
+    ],
+    "extension": [
+      "rv_zalasr"
+    ],
+    "match": "0x3400202f",
+    "mask": "0xfdf0707f"
+  },
+  "ld_aq": {
+    "encoding": "001101-00000-----011-----0101111",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rl"
+    ],
+    "extension": [
+      "rv_zalasr"
+    ],
+    "match": "0x3400302f",
+    "mask": "0xfdf0707f"
+  },
+  "sb_rl": {
+    "encoding": "00111-1----------000000000101111",
+    "variable_fields": [
+      "rs1",
+      "rs2",
+      "aq"
+    ],
+    "extension": [
+      "rv_zalasr"
+    ],
+    "match": "0x3a00002f",
+    "mask": "0xfa007fff"
+  },
+  "sh_rl": {
+    "encoding": "00111-1----------001000000101111",
+    "variable_fields": [
+      "rs1",
+      "rs2",
+      "aq"
+    ],
+    "extension": [
+      "rv_zalasr"
+    ],
+    "match": "0x3a00102f",
+    "mask": "0xfa007fff"
+  },
+  "sw_rl": {
+    "encoding": "00111-1----------010000000101111",
+    "variable_fields": [
+      "rs1",
+      "rs2",
+      "aq"
+    ],
+    "extension": [
+      "rv_zalasr"
+    ],
+    "match": "0x3a00202f",
+    "mask": "0xfa007fff"
+  },
+  "sd_rl": {
+    "encoding": "00111-1----------011000000101111",
+    "variable_fields": [
+      "rs1",
+      "rs2",
+      "aq"
+    ],
+    "extension": [
+      "rv_zalasr"
+    ],
+    "match": "0x3a00302f",
+    "mask": "0xfa007fff"
+  },
+  "grevi": {
+    "encoding": "011010-----------101-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtd"
+    ],
+    "extension": [
+      "rv64_zbp"
+    ],
+    "match": "0x68005013",
+    "mask": "0xfc00707f"
+  },
+  "gorci": {
+    "encoding": "001010-----------101-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtd"
+    ],
+    "extension": [
+      "rv64_zbp"
+    ],
+    "match": "0x28005013",
+    "mask": "0xfc00707f"
+  },
+  "shfli": {
+    "encoding": "0000100----------001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtw"
+    ],
+    "extension": [
+      "rv64_zbp"
+    ],
+    "match": "0x8001013",
+    "mask": "0xfe00707f"
+  },
+  "unshfli": {
+    "encoding": "0000100----------101-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "shamtw"
+    ],
+    "extension": [
+      "rv64_zbp"
+    ],
+    "match": "0x8005013",
+    "mask": "0xfe00707f"
+  },
+  "xperm32": {
+    "encoding": "0010100----------000-----0110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv64_zbp"
+    ],
+    "match": "0x28000033",
+    "mask": "0xfe00707f"
+  }
+}

--- a/opcodes_maker/sorter.py
+++ b/opcodes_maker/sorter.py
@@ -1,0 +1,28 @@
+import json
+
+def sort_instr_json(dir_name, outname):
+    with open(dir_name, 'r') as file:
+        data = json.load(file)
+
+    sorted_data = {}
+    for key in sorted(data):
+        entry = data[key]
+        if "variable_fields" in entry:
+            entry["variable_fields"] = sorted(entry["variable_fields"])
+        if "extension" in entry:
+            entry["extension"] = sorted(entry["extension"])
+    
+        # Add the processed entry to the sorted data
+        sorted_data[key] = entry
+
+    with open(outname, 'w') as file:
+        json.dump(sorted_data, file, indent=4)
+    
+    print(json.dumps(sorted_data, indent=4))
+
+def main():
+    sort_instr_json("data.json", "udb_sorted_data.json")
+    sort_instr_json("instr_dict.json", "opcodes_sorted_data.json")
+
+
+main()


### PR DESCRIPTION
This is a draft PR for #300 

I included a `instr_dict.json` which I generated from riscv-opcodes which has data as of Nov 28, 2024

There's 2 main scripts involved here.
1. `generate_instr_dict.py`: This script generates a file called `data.json` which is equivalent of the `instr_dict.json` from riscv-opcodes but using the data from UDB.
2. `sorter.py`: This script generates 2 files which sorts `data.json` and `instr_dict.json` to make it easier to diff the 2 files.

**Known issues:**
I use this [site](https://www.jstoolset.com/diff) to diff the 2 files and here are some immediate issues
1. Sometimes there are more extensions in UDB than there are in riscv-opcodes. For example the instruction `add.uw`. Iirc, this is because 1 extension encapsulates the other extension.
2. Missing instructions #314 
3. Unknown ways to get `variable_fields`. I'm unsure on how to handle some cases like `imm` where it can range from either `immxx` where `xx` is just the size of the range but also deal with cases where `imm` turns into `bimm12hi` and `bimm12lo` for instructions like `beq`. There are more cases of these.
4. `rori` contains incorrect encoding. I'll open a separate pull request for this.

These are currently the roadblocks that I am facing and I can't seem to resolve them. Feel free to give feedback or modify the script if necessary. 

There's also some redundant functions such as `find_first_match` which I previously used but no longer require, but I kept it for now in case anyone finds it useful. I also tried adding types to most of these functions to make it easier to follow through.