### PR TITLE
Fixed rori.yaml encoding

### DIFF
--- a/arch/inst/B/rori.yaml
+++ b/arch/inst/B/rori.yaml
@@ -12,7 +12,7 @@ definedBy:
 assembly: xd, xs1, shamt
 encoding:
   RV32:
-    match: 0110000----------101-----0110011
+    match: 0110000----------101-----0010011
     variables:
     - name: shamt
       location: 24-20
@@ -21,7 +21,7 @@ encoding:
     - name: rd
       location: 11-7
   RV64:
-    match: 011000-----------101-----0110011
+    match: 011000-----------101-----0010011
     variables:
     - name: shamt
       location: 25-20


### PR DESCRIPTION
Fixed the encoding for `rori`.

<img width="700" alt="Screenshot 2024-11-28 at 11 21 04 PM" src="https://github.com/user-attachments/assets/4ffce2fb-f826-4314-894c-dbdcb032b54b">
