### PR TITLE
fix typos

### DIFF
--- a/arch/README.adoc
+++ b/arch/README.adoc
@@ -62,7 +62,7 @@ Each extension/instruction/CSR has its own file.
          |                                                      v
          |                                     +---------------------------------+
          |                                     | {s} Implementation-specific     |
-         |                                     |     Archiecture Spec            |
+         |                                     |     Architecture Spec            |
          |                                     | (gen/resolved_arch/NAME/*.yaml) |
          |                                     +---------------------------------+
          |                                                 |

--- a/arch/certificate_class/MC.yaml
+++ b/arch/certificate_class/MC.yaml
@@ -24,8 +24,8 @@ naming_scheme: |
   * Left & right square braces denote optional.
   * \<model> is a 3 digit integer. It is changed only when mandatory extensions are added to a CRD.
   ** The one's digit is incremented when a small mandatory extension is added (e.g., Zicond)
-  ** The ten's digit is incremented when a medium mandatory extension is addded (e.g., PMP)
-  ** The hundreds's digit is incremented when a large mandatory extension is addded (e.g., V or H)
+  ** The ten's digit is incremented when a medium mandatory extension is added (e.g., PMP)
+  ** The hundreds's digit is incremented when a large mandatory extension is added (e.g., V or H)
   * \<version> is a semantic version (see semver.org) formatted as <major>[.<minor>.[patch]]. If \<version> is omitted, the reference applies equally to all versions.
   ** A <major> release indicates support for a new optional extension.
   ** A <minor> release indicates one or more of the following changes to the certification tests associated with the CRD.

--- a/arch/csr/H/hcounteren.layout
+++ b/arch/csr/H/hcounteren.layout
@@ -24,7 +24,7 @@ fields:
       the `cycle` CSR (an alias of `mcycle`) is accessible to VS-mode.
 
       When `hcounteren.CY` is clear and `mcounteren.CY` is set, then any access to `cycle` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -62,7 +62,7 @@ fields:
       the `time` CSR (an alias of `mtime`) is accessible to VS-mode.
 
       When `hcounteren.TM` is clear and `mcounteren.TM` is set, then any access to `time` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -100,7 +100,7 @@ fields:
       the `instret` CSR (an alias of `minstret`) is accessible to VS-mode.
 
       When `hcounteren.IR` is clear and `mcounteren.IR` is set, then any access to `instret` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -138,7 +138,7 @@ fields:
       the `hpmcounter<%= hpm_num %>` CSR (an alias of `mhpmcounter<%= hpm_num %>`) is accessible to VS-mode.
 
       When `hcounteren.HPM<%= hpm_num %>` is clear and `mcounteren.HPM<%= hpm_num %>` is set, then any access to `hpmcounter<%= hpm_num %>` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 

--- a/arch/csr/H/hcounteren.yaml
+++ b/arch/csr/H/hcounteren.yaml
@@ -25,7 +25,7 @@ fields:
       the `cycle` CSR (an alias of `mcycle`) is accessible to VS-mode.
 
       When `hcounteren.CY` is clear and `mcounteren.CY` is set, then any access to `cycle` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -63,7 +63,7 @@ fields:
       the `time` CSR (an alias of `mtime`) is accessible to VS-mode.
 
       When `hcounteren.TM` is clear and `mcounteren.TM` is set, then any access to `time` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -101,7 +101,7 @@ fields:
       the `instret` CSR (an alias of `minstret`) is accessible to VS-mode.
 
       When `hcounteren.IR` is clear and `mcounteren.IR` is set, then any access to `instret` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -138,7 +138,7 @@ fields:
       the `hpmcounter3` CSR (an alias of `mhpmcounter3`) is accessible to VS-mode.
 
       When `hcounteren.HPM3` is clear and `mcounteren.HPM3` is set, then any access to `hpmcounter3` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -175,7 +175,7 @@ fields:
       the `hpmcounter4` CSR (an alias of `mhpmcounter4`) is accessible to VS-mode.
 
       When `hcounteren.HPM4` is clear and `mcounteren.HPM4` is set, then any access to `hpmcounter4` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -212,7 +212,7 @@ fields:
       the `hpmcounter5` CSR (an alias of `mhpmcounter5`) is accessible to VS-mode.
 
       When `hcounteren.HPM5` is clear and `mcounteren.HPM5` is set, then any access to `hpmcounter5` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -249,7 +249,7 @@ fields:
       the `hpmcounter6` CSR (an alias of `mhpmcounter6`) is accessible to VS-mode.
 
       When `hcounteren.HPM6` is clear and `mcounteren.HPM6` is set, then any access to `hpmcounter6` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -286,7 +286,7 @@ fields:
       the `hpmcounter7` CSR (an alias of `mhpmcounter7`) is accessible to VS-mode.
 
       When `hcounteren.HPM7` is clear and `mcounteren.HPM7` is set, then any access to `hpmcounter7` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -323,7 +323,7 @@ fields:
       the `hpmcounter8` CSR (an alias of `mhpmcounter8`) is accessible to VS-mode.
 
       When `hcounteren.HPM8` is clear and `mcounteren.HPM8` is set, then any access to `hpmcounter8` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -360,7 +360,7 @@ fields:
       the `hpmcounter9` CSR (an alias of `mhpmcounter9`) is accessible to VS-mode.
 
       When `hcounteren.HPM9` is clear and `mcounteren.HPM9` is set, then any access to `hpmcounter9` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -397,7 +397,7 @@ fields:
       the `hpmcounter10` CSR (an alias of `mhpmcounter10`) is accessible to VS-mode.
 
       When `hcounteren.HPM10` is clear and `mcounteren.HPM10` is set, then any access to `hpmcounter10` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -434,7 +434,7 @@ fields:
       the `hpmcounter11` CSR (an alias of `mhpmcounter11`) is accessible to VS-mode.
 
       When `hcounteren.HPM11` is clear and `mcounteren.HPM11` is set, then any access to `hpmcounter11` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -471,7 +471,7 @@ fields:
       the `hpmcounter12` CSR (an alias of `mhpmcounter12`) is accessible to VS-mode.
 
       When `hcounteren.HPM12` is clear and `mcounteren.HPM12` is set, then any access to `hpmcounter12` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -508,7 +508,7 @@ fields:
       the `hpmcounter13` CSR (an alias of `mhpmcounter13`) is accessible to VS-mode.
 
       When `hcounteren.HPM13` is clear and `mcounteren.HPM13` is set, then any access to `hpmcounter13` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -545,7 +545,7 @@ fields:
       the `hpmcounter14` CSR (an alias of `mhpmcounter14`) is accessible to VS-mode.
 
       When `hcounteren.HPM14` is clear and `mcounteren.HPM14` is set, then any access to `hpmcounter14` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -582,7 +582,7 @@ fields:
       the `hpmcounter15` CSR (an alias of `mhpmcounter15`) is accessible to VS-mode.
 
       When `hcounteren.HPM15` is clear and `mcounteren.HPM15` is set, then any access to `hpmcounter15` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -619,7 +619,7 @@ fields:
       the `hpmcounter16` CSR (an alias of `mhpmcounter16`) is accessible to VS-mode.
 
       When `hcounteren.HPM16` is clear and `mcounteren.HPM16` is set, then any access to `hpmcounter16` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -656,7 +656,7 @@ fields:
       the `hpmcounter17` CSR (an alias of `mhpmcounter17`) is accessible to VS-mode.
 
       When `hcounteren.HPM17` is clear and `mcounteren.HPM17` is set, then any access to `hpmcounter17` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -693,7 +693,7 @@ fields:
       the `hpmcounter18` CSR (an alias of `mhpmcounter18`) is accessible to VS-mode.
 
       When `hcounteren.HPM18` is clear and `mcounteren.HPM18` is set, then any access to `hpmcounter18` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -730,7 +730,7 @@ fields:
       the `hpmcounter19` CSR (an alias of `mhpmcounter19`) is accessible to VS-mode.
 
       When `hcounteren.HPM19` is clear and `mcounteren.HPM19` is set, then any access to `hpmcounter19` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -767,7 +767,7 @@ fields:
       the `hpmcounter20` CSR (an alias of `mhpmcounter20`) is accessible to VS-mode.
 
       When `hcounteren.HPM20` is clear and `mcounteren.HPM20` is set, then any access to `hpmcounter20` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -804,7 +804,7 @@ fields:
       the `hpmcounter21` CSR (an alias of `mhpmcounter21`) is accessible to VS-mode.
 
       When `hcounteren.HPM21` is clear and `mcounteren.HPM21` is set, then any access to `hpmcounter21` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -841,7 +841,7 @@ fields:
       the `hpmcounter22` CSR (an alias of `mhpmcounter22`) is accessible to VS-mode.
 
       When `hcounteren.HPM22` is clear and `mcounteren.HPM22` is set, then any access to `hpmcounter22` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -878,7 +878,7 @@ fields:
       the `hpmcounter23` CSR (an alias of `mhpmcounter23`) is accessible to VS-mode.
 
       When `hcounteren.HPM23` is clear and `mcounteren.HPM23` is set, then any access to `hpmcounter23` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -915,7 +915,7 @@ fields:
       the `hpmcounter24` CSR (an alias of `mhpmcounter24`) is accessible to VS-mode.
 
       When `hcounteren.HPM24` is clear and `mcounteren.HPM24` is set, then any access to `hpmcounter24` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -952,7 +952,7 @@ fields:
       the `hpmcounter25` CSR (an alias of `mhpmcounter25`) is accessible to VS-mode.
 
       When `hcounteren.HPM25` is clear and `mcounteren.HPM25` is set, then any access to `hpmcounter25` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -989,7 +989,7 @@ fields:
       the `hpmcounter26` CSR (an alias of `mhpmcounter26`) is accessible to VS-mode.
 
       When `hcounteren.HPM26` is clear and `mcounteren.HPM26` is set, then any access to `hpmcounter26` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -1026,7 +1026,7 @@ fields:
       the `hpmcounter27` CSR (an alias of `mhpmcounter27`) is accessible to VS-mode.
 
       When `hcounteren.HPM27` is clear and `mcounteren.HPM27` is set, then any access to `hpmcounter27` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -1063,7 +1063,7 @@ fields:
       the `hpmcounter28` CSR (an alias of `mhpmcounter28`) is accessible to VS-mode.
 
       When `hcounteren.HPM28` is clear and `mcounteren.HPM28` is set, then any access to `hpmcounter28` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -1100,7 +1100,7 @@ fields:
       the `hpmcounter29` CSR (an alias of `mhpmcounter29`) is accessible to VS-mode.
 
       When `hcounteren.HPM29` is clear and `mcounteren.HPM29` is set, then any access to `hpmcounter29` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -1137,7 +1137,7 @@ fields:
       the `hpmcounter30` CSR (an alias of `mhpmcounter30`) is accessible to VS-mode.
 
       When `hcounteren.HPM30` is clear and `mcounteren.HPM30` is set, then any access to `hpmcounter30` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 
@@ -1174,7 +1174,7 @@ fields:
       the `hpmcounter31` CSR (an alias of `mhpmcounter31`) is accessible to VS-mode.
 
       When `hcounteren.HPM31` is clear and `mcounteren.HPM31` is set, then any access to `hpmcounter31` in
-      VU-mode or VS-mode causes a VirtualInstruction execption.
+      VU-mode or VS-mode causes a VirtualInstruction exception.
 
       Summary:
 

--- a/arch/csr/I/mcounteren.layout
+++ b/arch/csr/I/mcounteren.layout
@@ -93,13 +93,13 @@ fields:
       <%%- end -%>
 
       <%%- if ext?(:S) -%>
-      When `scounteren.CY` is also set, `cycle` is futher accessible to U-mode.
+      When `scounteren.CY` is also set, `cycle` is further accessible to U-mode.
       <%%- end -%>
 
       <%%- if ext?(:H) -%>
-      When `hcounteren.CY` is also set, `cycle` is futher accessible to VS-mode.
+      When `hcounteren.CY` is also set, `cycle` is further accessible to VS-mode.
 
-      When `hcounteren.CY` && `scounteren.CY` are both set, `cycle` is futher accessible to VU-mode.
+      When `hcounteren.CY` && `scounteren.CY` are both set, `cycle` is further accessible to VU-mode.
       <%%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[0]) {
@@ -131,13 +131,13 @@ fields:
       <%%- end -%>
 
       <%%- if ext?(:S) -%>
-      When `scounteren.IR` is also set, `instret` is futher accessible to U-mode.
+      When `scounteren.IR` is also set, `instret` is further accessible to U-mode.
       <%%- end -%>
 
       <%%- if ext?(:H) -%>
-      When `hcounteren.IR` is also set, `instret` is futher accessible to VS-mode.
+      When `hcounteren.IR` is also set, `instret` is further accessible to VS-mode.
 
-      When `hcounteren.IR` && `scounteren.IR` are both set, `instret` is futher accessible to VU-mode.
+      When `hcounteren.IR` && `scounteren.IR` are both set, `instret` is further accessible to VU-mode.
       <%%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[2]) {
@@ -163,13 +163,13 @@ fields:
       <%%- end -%>
 
       <%%- if ext?(:S) -%>
-      When `scounteren.HPM<%= hpm_num %>` is also set, `hpmcounter<%= hpm_num %>` is futher accessible to U-mode.
+      When `scounteren.HPM<%= hpm_num %>` is also set, `hpmcounter<%= hpm_num %>` is further accessible to U-mode.
       <%%- end -%>
 
       <%%- if ext?(:H) -%>
-      When `hcounteren.HPM<%= hpm_num %>` is also set, `hpmcounter<%= hpm_num %>` is futher accessible to VS-mode.
+      When `hcounteren.HPM<%= hpm_num %>` is also set, `hpmcounter<%= hpm_num %>` is further accessible to VS-mode.
 
-      When `hcounteren.HPM<%= hpm_num %>` && `scounteren.HPM<%= hpm_num %>` are both set, `hpmcounter<%= hpm_num %>` is futher accessible to VU-mode.
+      When `hcounteren.HPM<%= hpm_num %>` && `scounteren.HPM<%= hpm_num %>` are both set, `hpmcounter<%= hpm_num %>` is further accessible to VU-mode.
       <%%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[<%= hpm_num %>]) {

--- a/arch/csr/I/mcounteren.yaml
+++ b/arch/csr/I/mcounteren.yaml
@@ -94,13 +94,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.CY` is also set, `cycle` is futher accessible to U-mode.
+      When `scounteren.CY` is also set, `cycle` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.CY` is also set, `cycle` is futher accessible to VS-mode.
+      When `hcounteren.CY` is also set, `cycle` is further accessible to VS-mode.
 
-      When `hcounteren.CY` && `scounteren.CY` are both set, `cycle` is futher accessible to VU-mode.
+      When `hcounteren.CY` && `scounteren.CY` are both set, `cycle` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[0]) {
@@ -132,13 +132,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.IR` is also set, `instret` is futher accessible to U-mode.
+      When `scounteren.IR` is also set, `instret` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.IR` is also set, `instret` is futher accessible to VS-mode.
+      When `hcounteren.IR` is also set, `instret` is further accessible to VS-mode.
 
-      When `hcounteren.IR` && `scounteren.IR` are both set, `instret` is futher accessible to VU-mode.
+      When `hcounteren.IR` && `scounteren.IR` are both set, `instret` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[2]) {
@@ -163,13 +163,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM3` is also set, `hpmcounter3` is futher accessible to U-mode.
+      When `scounteren.HPM3` is also set, `hpmcounter3` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM3` is also set, `hpmcounter3` is futher accessible to VS-mode.
+      When `hcounteren.HPM3` is also set, `hpmcounter3` is further accessible to VS-mode.
 
-      When `hcounteren.HPM3` && `scounteren.HPM3` are both set, `hpmcounter3` is futher accessible to VU-mode.
+      When `hcounteren.HPM3` && `scounteren.HPM3` are both set, `hpmcounter3` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[3]) {
@@ -194,13 +194,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM4` is also set, `hpmcounter4` is futher accessible to U-mode.
+      When `scounteren.HPM4` is also set, `hpmcounter4` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM4` is also set, `hpmcounter4` is futher accessible to VS-mode.
+      When `hcounteren.HPM4` is also set, `hpmcounter4` is further accessible to VS-mode.
 
-      When `hcounteren.HPM4` && `scounteren.HPM4` are both set, `hpmcounter4` is futher accessible to VU-mode.
+      When `hcounteren.HPM4` && `scounteren.HPM4` are both set, `hpmcounter4` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[4]) {
@@ -225,13 +225,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM5` is also set, `hpmcounter5` is futher accessible to U-mode.
+      When `scounteren.HPM5` is also set, `hpmcounter5` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM5` is also set, `hpmcounter5` is futher accessible to VS-mode.
+      When `hcounteren.HPM5` is also set, `hpmcounter5` is further accessible to VS-mode.
 
-      When `hcounteren.HPM5` && `scounteren.HPM5` are both set, `hpmcounter5` is futher accessible to VU-mode.
+      When `hcounteren.HPM5` && `scounteren.HPM5` are both set, `hpmcounter5` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[5]) {
@@ -256,13 +256,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM6` is also set, `hpmcounter6` is futher accessible to U-mode.
+      When `scounteren.HPM6` is also set, `hpmcounter6` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM6` is also set, `hpmcounter6` is futher accessible to VS-mode.
+      When `hcounteren.HPM6` is also set, `hpmcounter6` is further accessible to VS-mode.
 
-      When `hcounteren.HPM6` && `scounteren.HPM6` are both set, `hpmcounter6` is futher accessible to VU-mode.
+      When `hcounteren.HPM6` && `scounteren.HPM6` are both set, `hpmcounter6` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[6]) {
@@ -287,13 +287,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM7` is also set, `hpmcounter7` is futher accessible to U-mode.
+      When `scounteren.HPM7` is also set, `hpmcounter7` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM7` is also set, `hpmcounter7` is futher accessible to VS-mode.
+      When `hcounteren.HPM7` is also set, `hpmcounter7` is further accessible to VS-mode.
 
-      When `hcounteren.HPM7` && `scounteren.HPM7` are both set, `hpmcounter7` is futher accessible to VU-mode.
+      When `hcounteren.HPM7` && `scounteren.HPM7` are both set, `hpmcounter7` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[7]) {
@@ -318,13 +318,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM8` is also set, `hpmcounter8` is futher accessible to U-mode.
+      When `scounteren.HPM8` is also set, `hpmcounter8` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM8` is also set, `hpmcounter8` is futher accessible to VS-mode.
+      When `hcounteren.HPM8` is also set, `hpmcounter8` is further accessible to VS-mode.
 
-      When `hcounteren.HPM8` && `scounteren.HPM8` are both set, `hpmcounter8` is futher accessible to VU-mode.
+      When `hcounteren.HPM8` && `scounteren.HPM8` are both set, `hpmcounter8` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[8]) {
@@ -349,13 +349,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM9` is also set, `hpmcounter9` is futher accessible to U-mode.
+      When `scounteren.HPM9` is also set, `hpmcounter9` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM9` is also set, `hpmcounter9` is futher accessible to VS-mode.
+      When `hcounteren.HPM9` is also set, `hpmcounter9` is further accessible to VS-mode.
 
-      When `hcounteren.HPM9` && `scounteren.HPM9` are both set, `hpmcounter9` is futher accessible to VU-mode.
+      When `hcounteren.HPM9` && `scounteren.HPM9` are both set, `hpmcounter9` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[9]) {
@@ -380,13 +380,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM10` is also set, `hpmcounter10` is futher accessible to U-mode.
+      When `scounteren.HPM10` is also set, `hpmcounter10` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM10` is also set, `hpmcounter10` is futher accessible to VS-mode.
+      When `hcounteren.HPM10` is also set, `hpmcounter10` is further accessible to VS-mode.
 
-      When `hcounteren.HPM10` && `scounteren.HPM10` are both set, `hpmcounter10` is futher accessible to VU-mode.
+      When `hcounteren.HPM10` && `scounteren.HPM10` are both set, `hpmcounter10` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[10]) {
@@ -411,13 +411,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM11` is also set, `hpmcounter11` is futher accessible to U-mode.
+      When `scounteren.HPM11` is also set, `hpmcounter11` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM11` is also set, `hpmcounter11` is futher accessible to VS-mode.
+      When `hcounteren.HPM11` is also set, `hpmcounter11` is further accessible to VS-mode.
 
-      When `hcounteren.HPM11` && `scounteren.HPM11` are both set, `hpmcounter11` is futher accessible to VU-mode.
+      When `hcounteren.HPM11` && `scounteren.HPM11` are both set, `hpmcounter11` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[11]) {
@@ -442,13 +442,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM12` is also set, `hpmcounter12` is futher accessible to U-mode.
+      When `scounteren.HPM12` is also set, `hpmcounter12` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM12` is also set, `hpmcounter12` is futher accessible to VS-mode.
+      When `hcounteren.HPM12` is also set, `hpmcounter12` is further accessible to VS-mode.
 
-      When `hcounteren.HPM12` && `scounteren.HPM12` are both set, `hpmcounter12` is futher accessible to VU-mode.
+      When `hcounteren.HPM12` && `scounteren.HPM12` are both set, `hpmcounter12` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[12]) {
@@ -473,13 +473,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM13` is also set, `hpmcounter13` is futher accessible to U-mode.
+      When `scounteren.HPM13` is also set, `hpmcounter13` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM13` is also set, `hpmcounter13` is futher accessible to VS-mode.
+      When `hcounteren.HPM13` is also set, `hpmcounter13` is further accessible to VS-mode.
 
-      When `hcounteren.HPM13` && `scounteren.HPM13` are both set, `hpmcounter13` is futher accessible to VU-mode.
+      When `hcounteren.HPM13` && `scounteren.HPM13` are both set, `hpmcounter13` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[13]) {
@@ -504,13 +504,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM14` is also set, `hpmcounter14` is futher accessible to U-mode.
+      When `scounteren.HPM14` is also set, `hpmcounter14` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM14` is also set, `hpmcounter14` is futher accessible to VS-mode.
+      When `hcounteren.HPM14` is also set, `hpmcounter14` is further accessible to VS-mode.
 
-      When `hcounteren.HPM14` && `scounteren.HPM14` are both set, `hpmcounter14` is futher accessible to VU-mode.
+      When `hcounteren.HPM14` && `scounteren.HPM14` are both set, `hpmcounter14` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[14]) {
@@ -535,13 +535,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM15` is also set, `hpmcounter15` is futher accessible to U-mode.
+      When `scounteren.HPM15` is also set, `hpmcounter15` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM15` is also set, `hpmcounter15` is futher accessible to VS-mode.
+      When `hcounteren.HPM15` is also set, `hpmcounter15` is further accessible to VS-mode.
 
-      When `hcounteren.HPM15` && `scounteren.HPM15` are both set, `hpmcounter15` is futher accessible to VU-mode.
+      When `hcounteren.HPM15` && `scounteren.HPM15` are both set, `hpmcounter15` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[15]) {
@@ -566,13 +566,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM16` is also set, `hpmcounter16` is futher accessible to U-mode.
+      When `scounteren.HPM16` is also set, `hpmcounter16` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM16` is also set, `hpmcounter16` is futher accessible to VS-mode.
+      When `hcounteren.HPM16` is also set, `hpmcounter16` is further accessible to VS-mode.
 
-      When `hcounteren.HPM16` && `scounteren.HPM16` are both set, `hpmcounter16` is futher accessible to VU-mode.
+      When `hcounteren.HPM16` && `scounteren.HPM16` are both set, `hpmcounter16` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[16]) {
@@ -597,13 +597,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM17` is also set, `hpmcounter17` is futher accessible to U-mode.
+      When `scounteren.HPM17` is also set, `hpmcounter17` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM17` is also set, `hpmcounter17` is futher accessible to VS-mode.
+      When `hcounteren.HPM17` is also set, `hpmcounter17` is further accessible to VS-mode.
 
-      When `hcounteren.HPM17` && `scounteren.HPM17` are both set, `hpmcounter17` is futher accessible to VU-mode.
+      When `hcounteren.HPM17` && `scounteren.HPM17` are both set, `hpmcounter17` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[17]) {
@@ -628,13 +628,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM18` is also set, `hpmcounter18` is futher accessible to U-mode.
+      When `scounteren.HPM18` is also set, `hpmcounter18` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM18` is also set, `hpmcounter18` is futher accessible to VS-mode.
+      When `hcounteren.HPM18` is also set, `hpmcounter18` is further accessible to VS-mode.
 
-      When `hcounteren.HPM18` && `scounteren.HPM18` are both set, `hpmcounter18` is futher accessible to VU-mode.
+      When `hcounteren.HPM18` && `scounteren.HPM18` are both set, `hpmcounter18` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[18]) {
@@ -659,13 +659,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM19` is also set, `hpmcounter19` is futher accessible to U-mode.
+      When `scounteren.HPM19` is also set, `hpmcounter19` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM19` is also set, `hpmcounter19` is futher accessible to VS-mode.
+      When `hcounteren.HPM19` is also set, `hpmcounter19` is further accessible to VS-mode.
 
-      When `hcounteren.HPM19` && `scounteren.HPM19` are both set, `hpmcounter19` is futher accessible to VU-mode.
+      When `hcounteren.HPM19` && `scounteren.HPM19` are both set, `hpmcounter19` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[19]) {
@@ -690,13 +690,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM20` is also set, `hpmcounter20` is futher accessible to U-mode.
+      When `scounteren.HPM20` is also set, `hpmcounter20` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM20` is also set, `hpmcounter20` is futher accessible to VS-mode.
+      When `hcounteren.HPM20` is also set, `hpmcounter20` is further accessible to VS-mode.
 
-      When `hcounteren.HPM20` && `scounteren.HPM20` are both set, `hpmcounter20` is futher accessible to VU-mode.
+      When `hcounteren.HPM20` && `scounteren.HPM20` are both set, `hpmcounter20` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[20]) {
@@ -721,13 +721,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM21` is also set, `hpmcounter21` is futher accessible to U-mode.
+      When `scounteren.HPM21` is also set, `hpmcounter21` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM21` is also set, `hpmcounter21` is futher accessible to VS-mode.
+      When `hcounteren.HPM21` is also set, `hpmcounter21` is further accessible to VS-mode.
 
-      When `hcounteren.HPM21` && `scounteren.HPM21` are both set, `hpmcounter21` is futher accessible to VU-mode.
+      When `hcounteren.HPM21` && `scounteren.HPM21` are both set, `hpmcounter21` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[21]) {
@@ -752,13 +752,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM22` is also set, `hpmcounter22` is futher accessible to U-mode.
+      When `scounteren.HPM22` is also set, `hpmcounter22` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM22` is also set, `hpmcounter22` is futher accessible to VS-mode.
+      When `hcounteren.HPM22` is also set, `hpmcounter22` is further accessible to VS-mode.
 
-      When `hcounteren.HPM22` && `scounteren.HPM22` are both set, `hpmcounter22` is futher accessible to VU-mode.
+      When `hcounteren.HPM22` && `scounteren.HPM22` are both set, `hpmcounter22` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[22]) {
@@ -783,13 +783,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM23` is also set, `hpmcounter23` is futher accessible to U-mode.
+      When `scounteren.HPM23` is also set, `hpmcounter23` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM23` is also set, `hpmcounter23` is futher accessible to VS-mode.
+      When `hcounteren.HPM23` is also set, `hpmcounter23` is further accessible to VS-mode.
 
-      When `hcounteren.HPM23` && `scounteren.HPM23` are both set, `hpmcounter23` is futher accessible to VU-mode.
+      When `hcounteren.HPM23` && `scounteren.HPM23` are both set, `hpmcounter23` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[23]) {
@@ -814,13 +814,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM24` is also set, `hpmcounter24` is futher accessible to U-mode.
+      When `scounteren.HPM24` is also set, `hpmcounter24` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM24` is also set, `hpmcounter24` is futher accessible to VS-mode.
+      When `hcounteren.HPM24` is also set, `hpmcounter24` is further accessible to VS-mode.
 
-      When `hcounteren.HPM24` && `scounteren.HPM24` are both set, `hpmcounter24` is futher accessible to VU-mode.
+      When `hcounteren.HPM24` && `scounteren.HPM24` are both set, `hpmcounter24` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[24]) {
@@ -845,13 +845,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM25` is also set, `hpmcounter25` is futher accessible to U-mode.
+      When `scounteren.HPM25` is also set, `hpmcounter25` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM25` is also set, `hpmcounter25` is futher accessible to VS-mode.
+      When `hcounteren.HPM25` is also set, `hpmcounter25` is further accessible to VS-mode.
 
-      When `hcounteren.HPM25` && `scounteren.HPM25` are both set, `hpmcounter25` is futher accessible to VU-mode.
+      When `hcounteren.HPM25` && `scounteren.HPM25` are both set, `hpmcounter25` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[25]) {
@@ -876,13 +876,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM26` is also set, `hpmcounter26` is futher accessible to U-mode.
+      When `scounteren.HPM26` is also set, `hpmcounter26` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM26` is also set, `hpmcounter26` is futher accessible to VS-mode.
+      When `hcounteren.HPM26` is also set, `hpmcounter26` is further accessible to VS-mode.
 
-      When `hcounteren.HPM26` && `scounteren.HPM26` are both set, `hpmcounter26` is futher accessible to VU-mode.
+      When `hcounteren.HPM26` && `scounteren.HPM26` are both set, `hpmcounter26` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[26]) {
@@ -907,13 +907,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM27` is also set, `hpmcounter27` is futher accessible to U-mode.
+      When `scounteren.HPM27` is also set, `hpmcounter27` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM27` is also set, `hpmcounter27` is futher accessible to VS-mode.
+      When `hcounteren.HPM27` is also set, `hpmcounter27` is further accessible to VS-mode.
 
-      When `hcounteren.HPM27` && `scounteren.HPM27` are both set, `hpmcounter27` is futher accessible to VU-mode.
+      When `hcounteren.HPM27` && `scounteren.HPM27` are both set, `hpmcounter27` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[27]) {
@@ -938,13 +938,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM28` is also set, `hpmcounter28` is futher accessible to U-mode.
+      When `scounteren.HPM28` is also set, `hpmcounter28` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM28` is also set, `hpmcounter28` is futher accessible to VS-mode.
+      When `hcounteren.HPM28` is also set, `hpmcounter28` is further accessible to VS-mode.
 
-      When `hcounteren.HPM28` && `scounteren.HPM28` are both set, `hpmcounter28` is futher accessible to VU-mode.
+      When `hcounteren.HPM28` && `scounteren.HPM28` are both set, `hpmcounter28` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[28]) {
@@ -969,13 +969,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM29` is also set, `hpmcounter29` is futher accessible to U-mode.
+      When `scounteren.HPM29` is also set, `hpmcounter29` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM29` is also set, `hpmcounter29` is futher accessible to VS-mode.
+      When `hcounteren.HPM29` is also set, `hpmcounter29` is further accessible to VS-mode.
 
-      When `hcounteren.HPM29` && `scounteren.HPM29` are both set, `hpmcounter29` is futher accessible to VU-mode.
+      When `hcounteren.HPM29` && `scounteren.HPM29` are both set, `hpmcounter29` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[29]) {
@@ -1000,13 +1000,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM30` is also set, `hpmcounter30` is futher accessible to U-mode.
+      When `scounteren.HPM30` is also set, `hpmcounter30` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM30` is also set, `hpmcounter30` is futher accessible to VS-mode.
+      When `hcounteren.HPM30` is also set, `hpmcounter30` is further accessible to VS-mode.
 
-      When `hcounteren.HPM30` && `scounteren.HPM30` are both set, `hpmcounter30` is futher accessible to VU-mode.
+      When `hcounteren.HPM30` && `scounteren.HPM30` are both set, `hpmcounter30` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[30]) {
@@ -1031,13 +1031,13 @@ fields:
       <%- end -%>
 
       <%- if ext?(:S) -%>
-      When `scounteren.HPM31` is also set, `hpmcounter31` is futher accessible to U-mode.
+      When `scounteren.HPM31` is also set, `hpmcounter31` is further accessible to U-mode.
       <%- end -%>
 
       <%- if ext?(:H) -%>
-      When `hcounteren.HPM31` is also set, `hpmcounter31` is futher accessible to VS-mode.
+      When `hcounteren.HPM31` is also set, `hpmcounter31` is further accessible to VS-mode.
 
-      When `hcounteren.HPM31` && `scounteren.HPM31` are both set, `hpmcounter31` is futher accessible to VU-mode.
+      When `hcounteren.HPM31` && `scounteren.HPM31` are both set, `hpmcounter31` is further accessible to VU-mode.
       <%- end -%>
     type(): |
       if (MCOUNTENABLE_EN[31]) {

--- a/arch/csr/I/pmpcfg0.yaml
+++ b/arch/csr/I/pmpcfg0.yaml
@@ -32,17 +32,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -94,17 +94,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -156,17 +156,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -218,17 +218,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -281,17 +281,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 34 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 34 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 33 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 32 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -344,17 +344,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 42 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 42 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 41 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 40 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -407,17 +407,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 50 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 50 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 49 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 48 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -470,17 +470,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 58 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 58 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 57 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 56 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfg1.yaml
+++ b/arch/csr/I/pmpcfg1.yaml
@@ -33,17 +33,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -95,17 +95,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -157,17 +157,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -219,17 +219,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfg10.yaml
+++ b/arch/csr/I/pmpcfg10.yaml
@@ -32,17 +32,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -94,17 +94,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -156,17 +156,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -218,17 +218,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -281,17 +281,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 34 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 34 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 33 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 32 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -344,17 +344,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 42 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 42 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 41 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 40 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -407,17 +407,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 50 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 50 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 49 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 48 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -470,17 +470,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 58 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 58 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 57 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 56 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfg11.yaml
+++ b/arch/csr/I/pmpcfg11.yaml
@@ -33,17 +33,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -95,17 +95,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -157,17 +157,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -219,17 +219,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfg12.yaml
+++ b/arch/csr/I/pmpcfg12.yaml
@@ -32,17 +32,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -94,17 +94,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -156,17 +156,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -218,17 +218,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -281,17 +281,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 34 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 34 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 33 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 32 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -344,17 +344,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 42 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 42 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 41 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 40 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -407,17 +407,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 50 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 50 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 49 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 48 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -470,17 +470,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 58 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 58 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 57 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 56 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfg13.yaml
+++ b/arch/csr/I/pmpcfg13.yaml
@@ -33,17 +33,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -95,17 +95,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -157,17 +157,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -219,17 +219,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfg14.yaml
+++ b/arch/csr/I/pmpcfg14.yaml
@@ -32,17 +32,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -94,17 +94,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -156,17 +156,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -218,17 +218,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -281,17 +281,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 34 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 34 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 33 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 32 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -344,17 +344,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 42 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 42 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 41 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 40 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -407,17 +407,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 50 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 50 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 49 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 48 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -470,17 +470,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 58 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 58 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 57 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 56 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfg15.yaml
+++ b/arch/csr/I/pmpcfg15.yaml
@@ -33,17 +33,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -95,17 +95,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -157,17 +157,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -219,17 +219,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfg2.yaml
+++ b/arch/csr/I/pmpcfg2.yaml
@@ -32,17 +32,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -94,17 +94,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -156,17 +156,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -218,17 +218,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -281,17 +281,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 34 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 34 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 33 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 32 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -344,17 +344,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 42 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 42 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 41 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 40 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -407,17 +407,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 50 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 50 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 49 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 48 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -470,17 +470,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 58 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 58 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 57 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 56 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfg3.yaml
+++ b/arch/csr/I/pmpcfg3.yaml
@@ -33,17 +33,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -95,17 +95,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -157,17 +157,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -219,17 +219,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfg4.yaml
+++ b/arch/csr/I/pmpcfg4.yaml
@@ -32,17 +32,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -94,17 +94,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -156,17 +156,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -218,17 +218,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -281,17 +281,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 34 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 34 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 33 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 32 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -344,17 +344,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 42 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 42 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 41 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 40 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -407,17 +407,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 50 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 50 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 49 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 48 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -470,17 +470,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 58 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 58 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 57 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 56 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfg5.yaml
+++ b/arch/csr/I/pmpcfg5.yaml
@@ -33,17 +33,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -95,17 +95,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -157,17 +157,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -219,17 +219,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfg6.yaml
+++ b/arch/csr/I/pmpcfg6.yaml
@@ -32,17 +32,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -94,17 +94,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -156,17 +156,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -218,17 +218,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -281,17 +281,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 34 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 34 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 33 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 32 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -344,17 +344,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 42 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 42 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 41 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 40 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -407,17 +407,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 50 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 50 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 49 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 48 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -470,17 +470,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 58 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 58 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 57 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 56 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfg7.yaml
+++ b/arch/csr/I/pmpcfg7.yaml
@@ -33,17 +33,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -95,17 +95,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -157,17 +157,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -219,17 +219,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfg8.yaml
+++ b/arch/csr/I/pmpcfg8.yaml
@@ -32,17 +32,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -94,17 +94,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -156,17 +156,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -218,17 +218,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -281,17 +281,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 34 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 34 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 33 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 32 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -344,17 +344,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 42 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 42 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 41 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 40 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -407,17 +407,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 50 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 50 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 49 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 48 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -470,17 +470,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 58 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 58 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 57 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 56 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfg9.yaml
+++ b/arch/csr/I/pmpcfg9.yaml
@@ -33,17 +33,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 2 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 2 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 1 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 0 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -95,17 +95,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 10 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 10 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 9 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 8 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -157,17 +157,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 18 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 18 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 17 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 16 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===
@@ -219,17 +219,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! 26 ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! 26 ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! 25 ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! 24 ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/I/pmpcfgN.layout
+++ b/arch/csr/I/pmpcfgN.layout
@@ -39,17 +39,17 @@ fields:
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
           * *NA4* (2) - Naturally aligned four-byte region
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
           [when="PMP_GRANULARITY >= 2"]
           * *OFF* (0) - Null region (disabled)
           * *TOR* (1) - Top of range
-          * *NAPOT* (3) - Natrually aligned power of two
+          * *NAPOT* (3) - Naturally aligned power of two
 
       [when="PMP_GRANULARITY >= 2"]
       Naturally aligned four-byte region, *NA4* (2), is not valid (not needed when the PMP granularity is larger than 4 bytes).
 
-      h! X ! <%= ((i)*8)+2 %> ! When clear, instruction fetchs cause an `Access Fault` for the matching region and privilege mode.
+      h! X ! <%= ((i)*8)+2 %> ! When clear, instruction fetches cause an `Access Fault` for the matching region and privilege mode.
       h! W ! <%= ((i)*8)+1 %> ! When clear, stores and AMOs cause an `Access Fault` for the matching region and privilege mode.
       h! R ! <%= ((i)*8)+0 %> ! When clear, loads cause an `Access Fault` for the matching region and privilege mode.
       !===

--- a/arch/csr/Zihpm/mhpmevent10.yaml
+++ b/arch/csr/Zihpm/mhpmevent10.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter10 overflows.

--- a/arch/csr/Zihpm/mhpmevent11.yaml
+++ b/arch/csr/Zihpm/mhpmevent11.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter11 overflows.

--- a/arch/csr/Zihpm/mhpmevent12.yaml
+++ b/arch/csr/Zihpm/mhpmevent12.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter12 overflows.

--- a/arch/csr/Zihpm/mhpmevent13.yaml
+++ b/arch/csr/Zihpm/mhpmevent13.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter13 overflows.

--- a/arch/csr/Zihpm/mhpmevent14.yaml
+++ b/arch/csr/Zihpm/mhpmevent14.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter14 overflows.

--- a/arch/csr/Zihpm/mhpmevent15.yaml
+++ b/arch/csr/Zihpm/mhpmevent15.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter15 overflows.

--- a/arch/csr/Zihpm/mhpmevent16.yaml
+++ b/arch/csr/Zihpm/mhpmevent16.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter16 overflows.

--- a/arch/csr/Zihpm/mhpmevent17.yaml
+++ b/arch/csr/Zihpm/mhpmevent17.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter17 overflows.

--- a/arch/csr/Zihpm/mhpmevent18.yaml
+++ b/arch/csr/Zihpm/mhpmevent18.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter18 overflows.

--- a/arch/csr/Zihpm/mhpmevent19.yaml
+++ b/arch/csr/Zihpm/mhpmevent19.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter19 overflows.

--- a/arch/csr/Zihpm/mhpmevent20.yaml
+++ b/arch/csr/Zihpm/mhpmevent20.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter20 overflows.

--- a/arch/csr/Zihpm/mhpmevent21.yaml
+++ b/arch/csr/Zihpm/mhpmevent21.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter21 overflows.

--- a/arch/csr/Zihpm/mhpmevent22.yaml
+++ b/arch/csr/Zihpm/mhpmevent22.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter22 overflows.

--- a/arch/csr/Zihpm/mhpmevent23.yaml
+++ b/arch/csr/Zihpm/mhpmevent23.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter23 overflows.

--- a/arch/csr/Zihpm/mhpmevent24.yaml
+++ b/arch/csr/Zihpm/mhpmevent24.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter24 overflows.

--- a/arch/csr/Zihpm/mhpmevent25.yaml
+++ b/arch/csr/Zihpm/mhpmevent25.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter25 overflows.

--- a/arch/csr/Zihpm/mhpmevent26.yaml
+++ b/arch/csr/Zihpm/mhpmevent26.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter26 overflows.

--- a/arch/csr/Zihpm/mhpmevent27.yaml
+++ b/arch/csr/Zihpm/mhpmevent27.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter27 overflows.

--- a/arch/csr/Zihpm/mhpmevent28.yaml
+++ b/arch/csr/Zihpm/mhpmevent28.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter28 overflows.

--- a/arch/csr/Zihpm/mhpmevent29.yaml
+++ b/arch/csr/Zihpm/mhpmevent29.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter29 overflows.

--- a/arch/csr/Zihpm/mhpmevent3.yaml
+++ b/arch/csr/Zihpm/mhpmevent3.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter3 overflows.

--- a/arch/csr/Zihpm/mhpmevent30.yaml
+++ b/arch/csr/Zihpm/mhpmevent30.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter30 overflows.

--- a/arch/csr/Zihpm/mhpmevent31.yaml
+++ b/arch/csr/Zihpm/mhpmevent31.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter31 overflows.

--- a/arch/csr/Zihpm/mhpmevent4.yaml
+++ b/arch/csr/Zihpm/mhpmevent4.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter4 overflows.

--- a/arch/csr/Zihpm/mhpmevent5.yaml
+++ b/arch/csr/Zihpm/mhpmevent5.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter5 overflows.

--- a/arch/csr/Zihpm/mhpmevent6.yaml
+++ b/arch/csr/Zihpm/mhpmevent6.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter6 overflows.

--- a/arch/csr/Zihpm/mhpmevent7.yaml
+++ b/arch/csr/Zihpm/mhpmevent7.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter7 overflows.

--- a/arch/csr/Zihpm/mhpmevent8.yaml
+++ b/arch/csr/Zihpm/mhpmevent8.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter8 overflows.

--- a/arch/csr/Zihpm/mhpmevent9.yaml
+++ b/arch/csr/Zihpm/mhpmevent9.yaml
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter9 overflows.

--- a/arch/csr/Zihpm/mhpmeventN.layout
+++ b/arch/csr/Zihpm/mhpmeventN.layout
@@ -23,7 +23,7 @@ fields:
       software. Since hpmcounter values are unsigned values, overflow is defined as unsigned
       overflow of the implemented counter bits.
 
-      The OF bit is sticky; it stays set until explictly cleared by a CSR write.
+      The OF bit is sticky; it stays set until explicitly cleared by a CSR write.
 
       A Local Counter Overflow Interrupt (LCOFI) is generated when OF is clear and
       mhpmcounter<%= hpm_num %> overflows.

--- a/arch/csr/hedeleg.yaml
+++ b/arch/csr/hedeleg.yaml
@@ -122,7 +122,7 @@ fields:
     description: |
       *Environment Call from VU-mode*
 
-      Controls delegation of Enviornment Call from VU-mode exceptions to VS-mode.
+      Controls delegation of Environment Call from VU-mode exceptions to VS-mode.
 
       See `medeleg.EU` for details.
 
@@ -133,7 +133,7 @@ fields:
     description: |
       *Environment Call from HS-mode*
 
-      Enviornment Call from HS-mode exceptions _cannot be delegated to VS-mode_,
+      Environment Call from HS-mode exceptions _cannot be delegated to VS-mode_,
       so this field is read-only 0.
 
       See `medeleg.ES` for details.
@@ -144,7 +144,7 @@ fields:
     description: |
       *Environment Call from VS-mode*
 
-      Enviornment Call from VS-mode exceptions _cannot be delegated to VS-mode_,
+      Environment Call from VS-mode exceptions _cannot be delegated to VS-mode_,
       so this field is read-only 0.
 
       See `medeleg.EVS` for details.
@@ -155,7 +155,7 @@ fields:
     description: |
       *Environment Call from M-mode*
 
-      Enviornment Call from M-mode exceptions _cannot be delegated to VS-mode_,
+      Environment Call from M-mode exceptions _cannot be delegated to VS-mode_,
       so this field is read-only 0.
 
       See `medeleg.EM` for details.

--- a/arch/csr/hstatus.yaml
+++ b/arch/csr/hstatus.yaml
@@ -134,7 +134,7 @@ fields:
       When `hstatus.VGEIN` != 0, it selects which bit of `hgeip` is currently active in VS-mode.
 
     type(): |
-      # if NUM_EXTERNAL_GUEST_INTERRUPTS+1 is 63 (beacuse indexing in `hgeip` starts at 1),
+      # if NUM_EXTERNAL_GUEST_INTERRUPTS+1 is 63 (because indexing in `hgeip` starts at 1),
       # then the field accepts any value.
       # Otherwise, it accepts a restricted set of values
       if (NUM_EXTERNAL_GUEST_INTERRUPTS == 63) {
@@ -169,7 +169,7 @@ fields:
 
       Written by hardware:
 
-      * When taking a trap into HS-mode from VS-mode or VU-mode, `hstatus.SPVP` is written with the nominal privlege mode
+      * When taking a trap into HS-mode from VS-mode or VU-mode, `hstatus.SPVP` is written with the nominal privilege mode
 
       Notably, unlike its analog `mstatus.SPP`, `hstatus.SPVP` is *not* cleared when returning from a trap.
 
@@ -223,7 +223,7 @@ fields:
       Since the CPU does not support big endian in VS-mode, this is hardwired to 0.
 
       [when,"VS_MODE_ENDIANESS == bit"]
-      Since the CPU does not support litte endian in VS-mode, this is hardwired to 1.
+      Since the CPU does not support little endian in VS-mode, this is hardwired to 1.
     type(): |
       if (VS_MODE_ENDIANESS == "dynamic") {
         # mode is mutable

--- a/arch/csr/mconfigptr.yaml
+++ b/arch/csr/mconfigptr.yaml
@@ -50,5 +50,5 @@ fields:
     reset_value(): |
       return CONFIG_PTR_ADDRESS;
     legal?(csr_value): |
-      # pointer must be natrually aligned to XLEN
+      # pointer must be naturally aligned to XLEN
       return ((XLEN-1) | csr_value.ADDRESS) == 0;

--- a/arch/csr/medeleg.yaml
+++ b/arch/csr/medeleg.yaml
@@ -33,7 +33,7 @@ description: |
   Otherwise, an exception cause is handled by M-mode.
 
   See xref:prose:interrupts.adoc[interrupt documentation] for more details.
-definedBy: S # medeleg does not exist whe S-mode is not implemented
+definedBy: S # medeleg does not exist when S-mode is not implemented
 fields:
   IAM:
     location: 0
@@ -42,7 +42,7 @@ fields:
 
       Delegates Instruction Address Misaligned exceptions to (H)S-mode.
       <%- if ext?(:H) -%>
-      Instruction Address Misaligned exceptions may be futher delegated to VS-mode if `hedeleg.IAM` is also set.
+      Instruction Address Misaligned exceptions may be further delegated to VS-mode if `hedeleg.IAM` is also set.
       <%- end -%>
 
       Exceptions are never taken into a less-privileged mode, regardless of `medeleg`.
@@ -79,7 +79,7 @@ fields:
 
       Delegates Instruction Access Fault exceptions to (H)S-mode.
       <%- if ext?(:H) -%>
-      Instruction Access Fault exceptions may be futher delegated to VS-mode if `hedeleg.IAM` is also set.
+      Instruction Access Fault exceptions may be further delegated to VS-mode if `hedeleg.IAM` is also set.
       <%- end -%>
 
       Exceptions are never taken into a less-privileged mode, regardless of `medeleg`.
@@ -117,7 +117,7 @@ fields:
 
       Delegates Illegal Instruction exceptions to (H)S-mode.
       <%- if ext?(:H) -%>
-      Illegal Instruction exceptions may be futher delegated to VS-mode if `hedeleg.II` is also set.
+      Illegal Instruction exceptions may be further delegated to VS-mode if `hedeleg.II` is also set.
       <%- end -%>
 
       Exceptions are never taken into a less-privileged mode, regardless of `medeleg`.
@@ -154,7 +154,7 @@ fields:
 
       Delegates Breakpoint exceptions to (H)S-mode.
       <%- if ext?(:H) -%>
-      Breakpoint exceptions may be futher delegated to VS-mode if `hedeleg.B` is also set.
+      Breakpoint exceptions may be further delegated to VS-mode if `hedeleg.B` is also set.
       <%- end -%>
 
       Exceptions are never taken into a less-privileged mode, regardless of `medeleg`.
@@ -191,7 +191,7 @@ fields:
 
       Delegates Load Address Misaligned exceptions to (H)S-mode.
       <%- if ext?(:H) -%>
-      Load Address Misaligned exceptions may be futher delegated to VS-mode if `hedeleg.LAM` is also set.
+      Load Address Misaligned exceptions may be further delegated to VS-mode if `hedeleg.LAM` is also set.
       <%- end -%>
 
       Exceptions are never taken into a less-privileged mode, regardless of `medeleg`.
@@ -233,7 +233,7 @@ fields:
 
       Delegates Load Access Fault exceptions to (H)S-mode.
       <%- if ext?(:H) -%>
-      Load Access Fault exceptions may be futher delegated to VS-mode if `hedeleg.LAF` is also set.
+      Load Access Fault exceptions may be further delegated to VS-mode if `hedeleg.LAF` is also set.
       <%- end -%>
 
       Exceptions are never taken into a less-privileged mode, regardless of `medeleg`.
@@ -271,13 +271,13 @@ fields:
 
       Delegates Store/AMO Address Misaligned exceptions to (H)S-mode.
       <%- if ext?(:H) -%>
-      Store/AMO Address Misaligned exceptions may be futher delegated to VS-mode if `hedeleg.SAM` is also set.
+      Store/AMO Address Misaligned exceptions may be further delegated to VS-mode if `hedeleg.SAM` is also set.
       <%- end -%>
 
       Exceptions are never taken into a less-privileged mode, regardless of `medeleg`.
 
       [when,"MISALIGNED_LDST == true && MISALIGNED_AMO == true"]
-      Note that beause the implementation supports misaligned stores and misaligned AMOs (or no AMOs), this exception will never occur.
+      Note that because the implementation supports misaligned stores and misaligned AMOs (or no AMOs), this exception will never occur.
       Even so, the writeable bit should be presented anyway.
 
       The handling mode is determined as follows:
@@ -313,7 +313,7 @@ fields:
 
       Delegates Store/AMO Access Fault exceptions to (H)S-mode.
       <%- if ext?(:H) -%>
-      Store/AMO Access Fault exceptions may be futher delegated to VS-mode if `hedeleg.SAM` is also set.
+      Store/AMO Access Fault exceptions may be further delegated to VS-mode if `hedeleg.SAM` is also set.
       <%- end -%>
 
       Exceptions are never taken into a less-privileged mode, regardless of `medeleg`.
@@ -350,7 +350,7 @@ fields:
 
       Delegates Environment Call from U-mode exceptions to (H)S-mode.
       <%- if ext?(:H) -%>
-      Enviornment Call from U-mode exceptions may be futher delegated to VS-mode if `hedeleg.EU` is also set.
+      Environment Call from U-mode exceptions may be further delegated to VS-mode if `hedeleg.EU` is also set.
       <%- end -%>
 
       Exceptions are never taken into a less-privileged mode, regardless of `medeleg`.
@@ -388,7 +388,7 @@ fields:
 
       Delegates Environment Call from S-mode exceptions to (H)S-mode.
       <%- if ext?(:H) -%>
-      Enviornment Call from S-mode exceptions _cannot be delegated to VS-mode_.
+      Environment Call from S-mode exceptions _cannot be delegated to VS-mode_.
       <%- end -%>
 
       Exceptions are never taken into a less-privileged mode, regardless of `medeleg`.
@@ -412,7 +412,7 @@ fields:
 
       Delegates Environment Call from VS-mode exceptions to (H)S-mode.
       <%- if ext?(:H) -%>
-      Enviornment Call from S-mode exceptions _cannot be delegated to VS-mode_.
+      Environment Call from S-mode exceptions _cannot be delegated to VS-mode_.
       <%- end -%>
 
       Exceptions are never taken into a less-privileged mode, regardless of `medeleg`.
@@ -437,7 +437,7 @@ fields:
 
       An Environment Call from M-mode cannot be delegated, so this is a read-only field.
 
-      All Enviornment Call from M-mode exceptions are taken by M-mode.
+      All Environment Call from M-mode exceptions are taken by M-mode.
     type: RO
     reset_value: 0
   IPF:
@@ -447,7 +447,7 @@ fields:
 
       Delegates Instruction Page Fault exceptions to (H)S-mode.
       <%- if ext?(:H) -%>
-      Instruction Page Fault exceptions may be futher delegated to VS-mode if `hedeleg.IPF` is also set.
+      Instruction Page Fault exceptions may be further delegated to VS-mode if `hedeleg.IPF` is also set.
       <%- end -%>
 
       Exceptions are never taken into a less-privileged mode, regardless of `medeleg`.
@@ -484,7 +484,7 @@ fields:
 
       Delegates Load Page Fault exceptions to (H)S-mode.
       <%- if ext?(:H) -%>
-      Load Page Fault exceptions may be futher delegated to VS-mode if `hedeleg.LPF` is also set.
+      Load Page Fault exceptions may be further delegated to VS-mode if `hedeleg.LPF` is also set.
       <%- end -%>
 
       Exceptions are never taken into a less-privileged mode, regardless of `medeleg`.
@@ -522,7 +522,7 @@ fields:
 
       Delegates Store/AMO Page Fault exceptions to (H)S-mode.
       <%- if ext?(:H) -%>
-      Store/AMO Page Fault exceptions may be futher delegated to VS-mode if `hedeleg.SPF` is also set.
+      Store/AMO Page Fault exceptions may be further delegated to VS-mode if `hedeleg.SPF` is also set.
       <%- end -%>
 
       Exceptions are never taken into a less-privileged mode, regardless of `medeleg`.

--- a/arch/csr/mepc.yaml
+++ b/arch/csr/mepc.yaml
@@ -22,7 +22,7 @@ fields:
       Otherwise, `mepc.PC` is never written by the implementation, though it may be explicitly written
       by software.
 
-      On an exception retun from M-mode (from the MRET instruction),
+      On an exception return from M-mode (from the MRET instruction),
       control transfers to the virtual address read out of `mepc.PC`.
 
       [when,"ext?(:C)"]

--- a/arch/csr/mideleg.yaml
+++ b/arch/csr/mideleg.yaml
@@ -8,7 +8,7 @@ address: 0x303
 priv_mode: M
 length: MXLEN
 definedBy:
-  # after 1.9.1, mideleg does not exist whe S-mode is not implemented
+  # after 1.9.1, mideleg does not exist when S-mode is not implemented
   # we can represent that by making mideleg an S extension CSR post 1.9.1
   oneOf:
     - name: Sm
@@ -128,7 +128,7 @@ fields:
   VSTI:
     location: 6
     description: |
-      *Virutal Supervisor Timer interrupt delegation*
+      *Virtual Supervisor Timer interrupt delegation*
 
       When 1, Virtual Supervisor Timer interrupts are delegated to HS-mode.
 

--- a/arch/csr/mip.yaml
+++ b/arch/csr/mip.yaml
@@ -218,7 +218,7 @@ fields:
       Unused field.
 
       <%- if ext?(:Smaia) -%>
-      With AIA/IMSIC, IPIs are delievered as external interrupts. As a result, this bit is
+      With AIA/IMSIC, IPIs are delivered as external interrupts. As a result, this bit is
       unused and hardwired to 0.
       <%- end -%>
     type: RO

--- a/arch/csr/mstatus.yaml
+++ b/arch/csr/mstatus.yaml
@@ -10,7 +10,7 @@ priv_mode: M
 # length is MXLEN-bit
 #
 # MXLEN cannot change dynamically, so this will be converted to an integer
-# in the genrated, configuration-dependent spec
+# in the generated, configuration-dependent spec
 length: MXLEN
 description: The mstatus register tracks and controls the hart's current operating state.
 definedBy: Sm
@@ -104,11 +104,11 @@ fields:
       Since the CPU does not support big endian, this is hardwired to 0.
 
       [when,"S_MODE_ENDIANESS == big"]
-      Since the CPU does not support litte endian, this is hardwired to 1.
+      Since the CPU does not support little endian, this is hardwired to 1.
     type(): |
       return (S_MODE_ENDIANESS == "dynamic") ? CsrFieldType::RW : CsrFieldType::RO;
 
-    # if endianess is mutable, MBE comes out of reset in little-endian mode
+    # if endianness is mutable, MBE comes out of reset in little-endian mode
     reset_value(): |
       if (S_MODE_ENDIANESS == "little") {
         return 0;
@@ -322,7 +322,7 @@ fields:
     description: |
       Modify PRiVilege.
 
-      When 1, loads and stores behave as if the current virutalization mode:privilege level was
+      When 1, loads and stores behave as if the current virtualization mode:privilege level was
       `mstatus.MPV`:`mstatus.MPP`.
 
       `mstatus.MPRV` is cleared on any exception return (`mret` or `sret` instruction, regardless of the trap handler privilege mode).
@@ -398,7 +398,7 @@ fields:
 
       * On a return from an exception from M-mode, the machine will
       enter the privilege level stored in MPP before clearing the field.
-      * When `mstatus.MPRV` is set, loads and stores behave as if the current privlege level were MPP.
+      * When `mstatus.MPRV` is set, loads and stores behave as if the current privilege level were MPP.
     type: RW-H
     reset_value: UNDEFINED_LEGAL
     sw_write(csr_value): |
@@ -419,7 +419,7 @@ fields:
         return false;
       } else if (csr_value.MPP == 2'b10) {
         # never a valid value
-        return flase;
+        return false;
       } else {
         return true;
       }
@@ -502,7 +502,7 @@ fields:
       Written by hardware in two cases:
 
       * Written with prior value of `mstatus.MIE` when entering M-mode from an exception/interrupt.
-      * Writen with the value 1 when returning from an exception in M-mode (via the `mret` instruction).
+      * Written with the value 1 when returning from an exception in M-mode (via the `mret` instruction).
 
       Can also be written by software without immediate side effect.
 
@@ -523,7 +523,7 @@ fields:
       Since the CPU does not support big endian in U-mode, this is hardwired to 0.
 
       [when,"U_MODE_ENDIANESS == 'big'"]
-      Since the CPU does not support litte endian in U-mode, this is hardwired to 1.
+      Since the CPU does not support little endian in U-mode, this is hardwired to 1.
     type(): |
       return (U_MODE_ENDIANESS == "dynamic") ? CsrFieldType::RW : CsrFieldType::RO;
 
@@ -544,7 +544,7 @@ fields:
       Written by hardware in two cases:
 
       * Written with prior value of `mstatus.SIE` when entering (H)S-mode from an exception/interrupt.
-      * Writen with the value 1 when returning from an exception via the `sret` instruction in (H)S-mode or (unlikely) M-mode.
+      * Written with the value 1 when returning from an exception via the `sret` instruction in (H)S-mode or (unlikely) M-mode.
 
       Can also be written by software without immediate side effect.
 
@@ -562,7 +562,7 @@ fields:
       Written by hardware in two cases:
 
       * Written with the value 0 when entering M-mode from an exception/interrupt.
-      * Written with the prior value of `mstatus.MPIE` when returning from an exeception in M-mode (via `mret`).
+      * Written with the prior value of `mstatus.MPIE` when returning from an exception in M-mode (via `mret`).
 
       Affects execution by:
 
@@ -579,7 +579,7 @@ fields:
       Written by hardware in two cases:
 
       * Written with the value 0 when entering (H)S-mode from an exception/interrupt.
-      * Written with the prior value of `mstatus.SPIE` when returning from an exeception via `sret` in (H)S-mode or (unlikely) M-mode.
+      * Written with the prior value of `mstatus.SPIE` when returning from an exception via `sret` in (H)S-mode or (unlikely) M-mode.
 
       Affects execution by:
 

--- a/arch/csr/mtval.yaml
+++ b/arch/csr/mtval.yaml
@@ -83,7 +83,7 @@ fields:
         (_e.g._, if an 8-byte load is equally split across a page and the fault occurs on the second page, address + 4 is reported).
 
         The guest physical address is reported in `mtval2`.
-      ! [22] Virutal instruction
+      ! [22] Virtual instruction
       ! The encoding of the faulting virtual instruction.
       ! [23] Store/AMO guest-page fault
       ! The part of the virtual address causing the fault.

--- a/arch/csr/sepc.yaml
+++ b/arch/csr/sepc.yaml
@@ -21,7 +21,7 @@ fields:
       Otherwise, `sepc.PC` is never written by the implementation, though it may be explicitly written
       by software.
 
-      On an exception retun from S-mode (from the SRET instruction),
+      On an exception return from S-mode (from the SRET instruction),
       control transfers to the virtual address read out of `sepc.PC`.
 
       Because PCs are always <% if ext?(:C) %>halfword<% else %>word<% end %>-aligned,

--- a/arch/csr/stval.yaml
+++ b/arch/csr/stval.yaml
@@ -81,7 +81,7 @@ fields:
         (_e.g._, if an 8-byte load is equally split across a page and the fault occurs on the second page, address + 4 is reported).
 
         The guest physical address is reported in `mtval2`.
-      ! [22] Virutal instruction
+      ! [22] Virtual instruction
       ! The encoding of the faulting virtual instruction.
       ! [23] Store/AMO guest-page fault
       ! The part of the virtual address causing the fault.

--- a/arch/csr/vsepc.yaml
+++ b/arch/csr/vsepc.yaml
@@ -22,7 +22,7 @@ fields:
       Otherwise, `vsepc.PC` is never written by the implementation, though it may be explicitly written
       by software.
 
-      On an exception retun from VS-mode (from the SRET instruction),
+      On an exception return from VS-mode (from the SRET instruction),
       control transfers to the virtual address read out of `vsepc.PC`.
 
       Because PCs are always <% if ext?(:C) %>halfword<% else %>word<% end %>-aligned,

--- a/arch/csr/vsstatus.yaml
+++ b/arch/csr/vsstatus.yaml
@@ -93,7 +93,7 @@ fields:
 
       When `vsstatus.SUM` is 0, the loads and stores from the above categories cause an
       `Illegal Instruction` exception if they access a user page during VS-level translation.
-      Otherwise, a load or store from the above categories is permitted to acess a user page
+      Otherwise, a load or store from the above categories is permitted to access a user page
       during VS-level translation.
 
     type: RW
@@ -187,7 +187,7 @@ fields:
       Written by hardware in two cases:
 
       * Written with prior value of `vsstatus.SIE` when entering VS-mode from an exception/interrupt.
-      * Writen with the value 1 when returning from an exception in VS-mode (via the `sret` instruction).
+      * Written with the value 1 when returning from an exception in VS-mode (via the `sret` instruction).
 
       Can also be written by software without immediate side effect.
 
@@ -203,7 +203,7 @@ fields:
       Written by hardware in two cases:
 
       * Written with the value 0 when entering VS-mode from an exception/interrupt.
-      * Written with the prior value of `vsstatus.SPIE` when returning from an exeception in VS-mode (via `sret`).
+      * Written with the prior value of `vsstatus.SPIE` when returning from an exception in VS-mode (via `sret`).
 
       Affects execution by:
 

--- a/arch/csr/vstval.yaml
+++ b/arch/csr/vstval.yaml
@@ -83,7 +83,7 @@ fields:
         (_e.g._, if an 8-byte load is equally split across a page and the fault occurs on the second page, address + 4 is reported).
 
         The guest physical address is reported in `mtval2`.
-      ! [22] Virutal instruction
+      ! [22] Virtual instruction
       ! The encoding of the faulting virtual instruction.
       ! [23] Store/AMO guest-page fault
       ! The part of the virtual address causing the fault.

--- a/arch/ext/C.yaml
+++ b/arch/ext/C.yaml
@@ -211,7 +211,7 @@ description: |
   floating-point registers to registers `f8` to `f15`, which allows the
   same register decompression decoding as for integer register numbers._
   ====
-  ((((register source spcifiers, c-ext))))
+  ((((register source specifiers, c-ext))))
   The formats were designed to keep bits for the two register source
   specifiers in the same place in all instructions, while the destination
   register field can move. When the full 5-bit destination register

--- a/arch/ext/F.yaml
+++ b/arch/ext/F.yaml
@@ -205,7 +205,7 @@ description: |
   Moreover, since this feature is optional in the standard, it cannot be
   used in portable code.
 
-  Implementors are free to provide a NaN payload propagation scheme as a
+  Implementers are free to provide a NaN payload propagation scheme as a
   nonstandard extension enabled by a nonstandard operating mode. However, the canonical NaN scheme described above must always be supported and should be the default mode.
   ====
   '''

--- a/arch/ext/H.yaml
+++ b/arch/ext/H.yaml
@@ -169,7 +169,7 @@ params:
       maximum: 63
   VS_MODE_ENDIANESS:
     description: |
-      Endianess of data in VS-mode. Can be one of:
+      Endianness of data in VS-mode. Can be one of:
 
        * little:  M-mode data is always little endian
        * big:     M-mode data is always big endian
@@ -180,7 +180,7 @@ params:
       enum: [little, big, dynamic]
   VU_MODE_ENDIANESS:
     description: |
-      Endianess of data in VU-mode. Can be one of:
+      Endianness of data in VU-mode. Can be one of:
 
        * little:  M-mode data is always little endian
        * big:     M-mode data is always big endian
@@ -504,7 +504,7 @@ params:
 
       Possible values:
         * "always zero": Always write the value zero
-        * "custom": Write a custom value, which resuls in UNPREDICTABLE
+        * "custom": Write a custom value, which results in UNPREDICTABLE
     schema:
       type: string
       enum:
@@ -516,7 +516,7 @@ params:
 
       Possible values:
         * "always zero": Always write the value zero
-        * "custom": Write a custom value, which resuls in UNPREDICTABLE
+        * "custom": Write a custom value, which results in UNPREDICTABLE
     schema:
       type: string
       enum: ["always zero", "custom"]
@@ -526,7 +526,7 @@ params:
 
       Possible values:
         * "always zero": Always write the value zero
-        * "custom": Write a custom value, which resuls in UNPREDICTABLE
+        * "custom": Write a custom value, which results in UNPREDICTABLE
     schema:
       type: string
       enum: ["always zero", "custom"]
@@ -537,7 +537,7 @@ params:
       Possible values:
         * "always zero": Always write the value zero
         * "always transformed standard instruction": Always write a transformed standard instruction as defined by H
-        * "custom": Write a custom value, which resuls in UNPREDICTABLE
+        * "custom": Write a custom value, which results in UNPREDICTABLE
     schema:
       type: string
       enum: ["always zero", "always transformed standard instruction", "custom"]
@@ -548,7 +548,7 @@ params:
       Possible values:
         * "always zero": Always write the value zero
         * "always transformed standard instruction": Always write a transformed standard instruction as defined by H
-        * "custom": Write a custom value, which resuls in UNPREDICTABLE
+        * "custom": Write a custom value, which results in UNPREDICTABLE
     schema:
       type: string
       enum: ["always zero", "always transformed standard instruction", "custom"]
@@ -559,7 +559,7 @@ params:
       Possible values:
         * "always zero": Always write the value zero
         * "always transformed standard instruction": Always write a transformed standard instruction as defined by H
-        * "custom": Write a custom value, which resuls in UNPREDICTABLE
+        * "custom": Write a custom value, which results in UNPREDICTABLE
     schema:
       type: string
       enum: ["always zero", "always transformed standard instruction", "custom"]
@@ -570,7 +570,7 @@ params:
       Possible values:
         * "always zero": Always write the value zero
         * "always transformed standard instruction": Always write a transformed standard instruction as defined by H
-        * "custom": Write a custom value, which resuls in UNPREDICTABLE
+        * "custom": Write a custom value, which results in UNPREDICTABLE
     schema:
       type: string
       enum: ["always zero", "always transformed standard instruction", "custom"]
@@ -580,7 +580,7 @@ params:
 
       Possible values:
         * "always zero": Always write the value zero
-        * "custom": Write a custom value, which resuls in UNPREDICTABLE
+        * "custom": Write a custom value, which results in UNPREDICTABLE
     schema:
       type: string
       enum: ["always zero", "custom"]
@@ -590,7 +590,7 @@ params:
 
       Possible values:
         * "always zero": Always write the value zero
-        * "custom": Write a custom value, which resuls in UNPREDICTABLE
+        * "custom": Write a custom value, which results in UNPREDICTABLE
     schema:
       type: string
       enum: ["always zero", "custom"]
@@ -600,7 +600,7 @@ params:
 
       Possible values:
         * "always zero": Always write the value zero
-        * "custom": Write a custom value, which resuls in UNPREDICTABLE
+        * "custom": Write a custom value, which results in UNPREDICTABLE
     schema:
       type: string
       enum: ["always zero", "custom"]
@@ -610,7 +610,7 @@ params:
 
       Possible values:
         * "always zero": Always write the value zero
-        * "custom": Write a custom value, which resuls in UNPREDICTABLE
+        * "custom": Write a custom value, which results in UNPREDICTABLE
     schema:
       type: string
       enum: ["always zero", "custom"]
@@ -621,7 +621,7 @@ params:
       Possible values:
         * "always zero": Always write the value zero
         * "always transformed standard instruction": Always write a transformed standard instruction as defined by H
-        * "custom": Write a custom value, which resuls in UNPREDICTABLE
+        * "custom": Write a custom value, which results in UNPREDICTABLE
     schema:
       type: string
       enum: ["always zero", "always transformed standard instruction", "custom"]
@@ -632,7 +632,7 @@ params:
       Possible values:
         * "always zero": Always write the value zero
         * "always transformed standard instruction": Always write a transformed standard instruction as defined by H
-        * "custom": Write a custom value, which resuls in UNPREDICTABLE
+        * "custom": Write a custom value, which results in UNPREDICTABLE
     schema:
       type: string
       enum: ["always zero", "always transformed standard instruction", "custom"]

--- a/arch/ext/S.yaml
+++ b/arch/ext/S.yaml
@@ -56,7 +56,7 @@ params:
       assert ASID_WIDTH <= 9 if XLEN == 32
   S_MODE_ENDIANESS:
     description: |
-      Endianess of data in S-mode. Can be one of:
+      Endianness of data in S-mode. Can be one of:
 
        * little:  M-mode data is always little endian
        * big:     M-mode data is always big endian

--- a/arch/ext/Sm.yaml
+++ b/arch/ext/Sm.yaml
@@ -444,11 +444,11 @@ params:
       Number of bits in the physical address space.
     schema:
       type: integer
-      mimimum: 1
+      minimum: 1
       maximum: 64
   M_MODE_ENDIANESS:
     description: |
-      Endianess of data in M-mode. Can be one of:
+      Endianness of data in M-mode. Can be one of:
 
       [separator="!"]
       !===

--- a/arch/ext/U.yaml
+++ b/arch/ext/U.yaml
@@ -6,7 +6,7 @@ name: U
 long_name: User-mode privilege level
 description: |
   User-mode privilege level is supported by an implementation if the U extension is present.
-  Note that the RISC-V ISA doens't formally define a U extension and it is only discussed in the Privileged ISA manual.
+  Note that the RISC-V ISA doesn't formally define a U extension and it is only discussed in the Privileged ISA manual.
 type: privileged
 versions:
 - version: "1.0.0"
@@ -20,7 +20,7 @@ params:
       type: boolean
   U_MODE_ENDIANESS:
     description: |
-      Endianess of data in U-mode. Can be one of:
+      Endianness of data in U-mode. Can be one of:
 
        * little:  M-mode data is always little endian
        * big:     M-mode data is always big endian

--- a/arch/ext/Zicfilp.yaml
+++ b/arch/ext/Zicfilp.yaml
@@ -12,21 +12,21 @@ versions:
 params:
   REPORT_CAUSE_IN_MTVAL_ON_LANDING_PAD_SOFTWARE_CHECK:
     description: |
-      When true, `mtval` is written with the shadow stack casue (code=18) when a SoftwareCheck exception is raised into M-mode due to a landing pad error.
+      When true, `mtval` is written with the shadow stack cause (code=18) when a SoftwareCheck exception is raised into M-mode due to a landing pad error.
 
       When false, `mtval` is written with 0.
     schema:
       type: boolean
   REPORT_CAUSE_IN_STVAL_ON_LANDING_PAD_SOFTWARE_CHECK:
     description: |
-      When true, `stval` is written with the shadow stack casue (code=18) when a SoftwareCheck exception is raised into S-mode due to a landing pad error.
+      When true, `stval` is written with the shadow stack cause (code=18) when a SoftwareCheck exception is raised into S-mode due to a landing pad error.
 
       When false, `stval` is written with 0.
     schema:
       type: boolean
   REPORT_CAUSE_IN_VSTVAL_ON_LANDING_PAD_SOFTWARE_CHECK:
     description: |
-      When true, `vstval` is written with the shadow stack casue (code=18) when a SoftwareCheck exception is raised into VS-mode due to a landing pad error.
+      When true, `vstval` is written with the shadow stack cause (code=18) when a SoftwareCheck exception is raised into VS-mode due to a landing pad error.
 
       When false, `vstval` is written with 0.
     schema:

--- a/arch/ext/Zicfiss.yaml
+++ b/arch/ext/Zicfiss.yaml
@@ -14,21 +14,21 @@ versions:
 params:
   REPORT_CAUSE_IN_MTVAL_ON_SHADOW_STACK_SOFTWARE_CHECK:
     description: |
-      When true, `mtval` is written with the shadow stack casue (code=3) when a SoftwareCheck exception is raised into M-mode due to a shadow stack pop check instruction.
+      When true, `mtval` is written with the shadow stack cause (code=3) when a SoftwareCheck exception is raised into M-mode due to a shadow stack pop check instruction.
 
       When false, `mtval` is written with 0.
     schema:
       type: boolean
   REPORT_CAUSE_IN_STVAL_ON_SHADOW_STACK_SOFTWARE_CHECK:
     description: |
-      When true, `stval` is written with the shadow stack casue (code=3) when a SoftwareCheck exception is raised into S-mode due to a shadow stack pop check instruction.
+      When true, `stval` is written with the shadow stack cause (code=3) when a SoftwareCheck exception is raised into S-mode due to a shadow stack pop check instruction.
 
       When false, `stval` is written with 0.
     schema:
       type: boolean
   REPORT_CAUSE_IN_VSTVAL_ON_SHADOW_STACK_SOFTWARE_CHECK:
     description: |
-      When true, `vstval` is written with the shadow stack casue (code=3) when a SoftwareCheck exception is raised into VS-mode due to a shadow stack pop check instruction.
+      When true, `vstval` is written with the shadow stack cause (code=3) when a SoftwareCheck exception is raised into VS-mode due to a shadow stack pop check instruction.
 
       When false, `vstval` is written with 0.
     schema:

--- a/arch/inst/A/amomin.d.yaml
+++ b/arch/inst/A/amomin.d.yaml
@@ -9,7 +9,7 @@ description: |
 
     * Load the doubleword at address _rs1_
     * Write the loaded value into _rd_
-    * Signed compare the value of register _rs2_ to the loaded value, and select the mimimum value
+    * Signed compare the value of register _rs2_ to the loaded value, and select the minimum value
     * Write the minimum to the address in _rs1_
 definedBy:
   anyOf: [A, Zaamo]

--- a/arch/inst/A/amomin.w.yaml
+++ b/arch/inst/A/amomin.w.yaml
@@ -9,7 +9,7 @@ description: |
 
     * Load the word at address _rs1_
     * Write the sign-extended value into _rd_
-    * Signed compare the least-significant word of register _rs2_ to the loaded value, and select the mimimum value
+    * Signed compare the least-significant word of register _rs2_ to the loaded value, and select the minimum value
     * Write the result to the address in _rs1_
 definedBy:
   anyOf: [A, Zaamo]

--- a/arch/inst/A/amominu.d.yaml
+++ b/arch/inst/A/amominu.d.yaml
@@ -9,7 +9,7 @@ description: |
 
     * Load the doubleword at address _rs1_
     * Write the loaded value into _rd_
-    * Unsigned compare the value of register _rs2_ to the loaded value, and select the mimimum value
+    * Unsigned compare the value of register _rs2_ to the loaded value, and select the minimum value
     * Write the minimum to the address in _rs1_
 definedBy:
   anyOf: [A, Zaamo]

--- a/arch/inst/A/amominu.w.yaml
+++ b/arch/inst/A/amominu.w.yaml
@@ -9,7 +9,7 @@ description: |
 
     * Load the word at address _rs1_
     * Write the sign-extended value into _rd_
-    * Unsigned compare the least-significant word of register _rs2_ to the loaded word, and select the mimimum value
+    * Unsigned compare the least-significant word of register _rs2_ to the loaded word, and select the minimum value
     * Write the result to the address in _rs1_
 definedBy:
   anyOf: [A, Zaamo]

--- a/arch/inst/B/cpopw.yaml
+++ b/arch/inst/B/cpopw.yaml
@@ -5,7 +5,7 @@ kind: instruction
 name: cpopw
 long_name: Count set bits in word
 description: |
-  This instructions counts the number of 1's (i.e., set bits) in the least-significant word of the source egister.
+  This instructions counts the number of 1's (i.e., set bits) in the least-significant word of the source register.
 
   .Software Hint
   [NOTE]

--- a/arch/inst/B/minu.yaml
+++ b/arch/inst/B/minu.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: minu
-long_name: Unsigned minumum
+long_name: Unsigned minimum
 description: |
   This instruction returns the smaller of two unsigned integers.
 definedBy:

--- a/arch/inst/B/sh1add.uw.yaml
+++ b/arch/inst/B/sh1add.uw.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: sh1add.uw
-long_name: Shift unsigend word left by 1 and add
+long_name: Shift unsigned word left by 1 and add
 description: |
   This instruction performs an XLEN-wide addition of two addends. The first addend is rs2.
   The second addend is the unsigned value formed by extracting the least-significant word of rs1

--- a/arch/inst/B/sh2add.uw.yaml
+++ b/arch/inst/B/sh2add.uw.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: sh2add.uw
-long_name: Shift unsigend word left by 2 and add
+long_name: Shift unsigned word left by 2 and add
 description: |
   This instruction performs an XLEN-wide addition of two addends. The first addend is rs2.
   The second addend is the unsigned value formed by extracting the least-significant word of rs1

--- a/arch/inst/B/sh3add.uw.yaml
+++ b/arch/inst/B/sh3add.uw.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: sh3add.uw
-long_name: Shift unsigend word left by 3 and add
+long_name: Shift unsigned word left by 3 and add
 description: |
   This instruction performs an XLEN-wide addition of two addends. The first addend is rs2.
   The second addend is the unsigned value formed by extracting the least-significant word of rs1

--- a/arch/inst/S/sret.yaml
+++ b/arch/inst/S/sret.yaml
@@ -10,11 +10,11 @@ description: |
   When `sret` is allowed to execute, its behavior depends on whether or not the current privilege
   mode is virtualized.
 
-  *When the current privlege mode is (H)S-mode or M-mode*
+  *When the current privilege mode is (H)S-mode or M-mode*
 
   `sret` sets  `hstatus.HPV` = 0, `mstatus.SPP` = 0,
   `mstatus.SIE` = `mstatus.SPIE`, and `mstatus.SPIE` = 1,
-  changes the privlege mode according to the table below,
+  changes the privilege mode according to the table below,
   and then jumps to the address in `sepc`.
 
   .Next privilege mode following an `sret` in (H)S-mode or M-mode
@@ -28,11 +28,11 @@ description: |
   | 1 | 1 | VS-mode
   |===
 
-  *When the current privlege mode is VS-mode*
+  *When the current privilege mode is VS-mode*
 
   `sret` sets
   `vsstatus.SPP` = 0, `vsstatus.SIE` = `vstatus.SPIE`, and `vsstatus.SPIE` = 1,
-  changes the privlege mode according to the table below,
+  changes the privilege mode according to the table below,
   and then jumps to the address in `vsepc`.
 
   .Next privilege mode following an `sret` in (H)S-mode or M-mode

--- a/arch/inst/Zicbom/cbo.clean.yaml
+++ b/arch/inst/Zicbom/cbo.clean.yaml
@@ -11,7 +11,7 @@ description: |
   operation():
 
     * The cache block will be in the clean (not dirty) state in any coherent cache holding a valid copy of the line.
-    * The data will be cleaned to a point such that an incoherent load can observe the cleaed data.
+    * The data will be cleaned to a point such that an incoherent load can observe the cleaned data.
 
   `cbo.clean` is ordered by `FENCE` instructions but not `FENCE.I` or `SFENCE.VMA`.
 
@@ -49,7 +49,7 @@ access:
   vs: sometimes
   vu: sometimes
 access_detail: |
-  Access is controled through `menvcfg.CBZE`, `senvcfg.CBZE`, and `henvcfg.CBZE`.
+  Access is controlled through `menvcfg.CBZE`, `senvcfg.CBZE`, and `henvcfg.CBZE`.
   When access is denied, the instruction either raises an `Illegal Instruction`
   or `Virtual Instruction` exception according to the table below.
 

--- a/arch/inst/Zicbom/cbo.flush.yaml
+++ b/arch/inst/Zicbom/cbo.flush.yaml
@@ -42,7 +42,7 @@ access:
   vs: sometimes
   vu: sometimes
 access_detail: |
-  Access is controled through `menvcfg.CBZE`, `senvcfg.CBZE`, and `henvcfg.CBZE`.
+  Access is controlled through `menvcfg.CBZE`, `senvcfg.CBZE`, and `henvcfg.CBZE`.
   When access is denied, the instruction either raises an `Illegal Instruction`
   or `Virtual Instruction` exception according to the table below.
 

--- a/arch/inst/Zicbom/cbo.inval.yaml
+++ b/arch/inst/Zicbom/cbo.inval.yaml
@@ -81,7 +81,7 @@ access:
   vs: sometimes
   vu: sometimes
 access_detail: |
-  Access is controled through `menvcfg.CBIE`, `senvcfg.CBIE`, and `henvcfg.CBIE`.
+  Access is controlled through `menvcfg.CBIE`, `senvcfg.CBIE`, and `henvcfg.CBIE`.
   When access is denied, the instruction either raises an `Illegal Instruction`
   or `Virtual Instruction` exception according to the table below.
 

--- a/arch/inst/Zicboz/cbo.zero.yaml
+++ b/arch/inst/Zicboz/cbo.zero.yaml
@@ -44,7 +44,7 @@ access:
   vs: sometimes
   vu: sometimes
 access_detail: |
-  Access is controled through `menvcfg.CBZE`, `senvcfg.CBZE`, and `henvcfg.CBZE`.
+  Access is controlled through `menvcfg.CBZE`, `senvcfg.CBZE`, and `henvcfg.CBZE`.
   When access is denied, the instruction either raises an `Illegal Instruction`
   or `Virtual Instruction` exception according to the table below.
 

--- a/arch/isa/fp.idl
+++ b/arch/isa/fp.idl
@@ -115,7 +115,7 @@ function nan_box {
     of smaller size by adding all 1's to the upper bits.
   }
   body {
-    assert(FROM_SIZE < TO_SIZE, "Bad template arugments; FROM_SIZE must be less than TO_SIZE");
+    assert(FROM_SIZE < TO_SIZE, "Bad template arguments; FROM_SIZE must be less than TO_SIZE");
 
     return {{TO_SIZE - FROM_SIZE{1'b1}}, from_value};
   }

--- a/arch/isa/globals.isa
+++ b/arch/isa/globals.isa
@@ -47,7 +47,7 @@ enum MemoryOperation {
   Fetch
 }
 
-# Types of Atmoic Read-modify-write operations
+# Types of Atomic Read-modify-write operations
 enum AmoOperation {
   Swap
   Add
@@ -62,8 +62,8 @@ enum AmoOperation {
 
 enum PmaAttribute {
   RsrvNone         # LR/SC not allowed
-  RsrvNonEventual  # LR/SC allowed, but no gaurantee it will ever succeed
-  RsrvEventual     # LR/SC with forward-progress gaurantees
+  RsrvNonEventual  # LR/SC allowed, but no guarantee it will ever succeed
+  RsrvEventual     # LR/SC with forward-progress guarantees
 
   MAG16            # Misaligned Atomicity Granule = 16-byte
   MAG8             # Misaligned Atomicity Granule = 8-byte
@@ -103,13 +103,13 @@ enum CsrFieldType {
   RWRH 5
 }
 
-# generated from extension information in arch defintion
+# generated from extension information in arch definition
 builtin enum ExtensionName;
 
-# generated from extension information in arch defintion
+# generated from extension information in arch definition
 builtin enum InterruptCode;
 
-# generated from extension information in arch defintion
+# generated from extension information in arch definition
 builtin enum ExceptionCode;
 
 # XLEN encoding, as defined in CSR[mstatus].mxl, etc.
@@ -570,7 +570,7 @@ function raise {
   description {
     Raise synchronous exception number `exception_code`.
 
-    The exception may be imprecise, and will cause exectuion to enter an
+    The exception may be imprecise, and will cause execution to enter an
     unpredictable state, if PRECISE_SYNCHRONOUS_EXCEPTIONS is false.
 
     Otherwise, the exception will be precise.
@@ -1123,7 +1123,7 @@ function pmp_check {
     } else {
       assert(match_result == PmpMatchResult::PartialMatch, "PMP matching logic error");
 
-      # by defintion, any partial match fails the access, regardless of the config settings
+      # by definition, any partial match fails the access, regardless of the config settings
       return false;
     }
 
@@ -1201,7 +1201,7 @@ function current_translation_mode {
     Returns the current first-stage translation mode for an explicit load or store
     from +mode+ given the machine state (e.g., value of `satp` or `vsatp` csr).
 
-    Returns SatpMode::Reserved if the setting fouund in `satp` or `vsatp` is invalid.
+    Returns SatpMode::Reserved if the setting found in `satp` or `vsatp` is invalid.
   }
   body {
     PrivilegeMode effective_mode = effective_ldst_mode();
@@ -1776,7 +1776,7 @@ function gstage_page_walk {
         } else if ((op == MemoryOperation::Read) || (op == MemoryOperation::ReadModifyWrite)) {
           if (((!mxr) && (pte_flags.R == 0))
               || ((mxr) && (pte_flags.X == 0 && pte_flags.R == 0))) {
-            # no read permision
+            # no read permission
             raise_guest_page_fault(op, gpaddr, vaddr, tinst, effective_mode);
           }
         }
@@ -2494,7 +2494,7 @@ function invalidate_reservation_set {
     This function may be called by the platform, independent of any actions
     occurring in the local hart, for any or no reason.
 
-    The platorm *must* call this function if an external hart or device accesses
+    The platform *must* call this function if an external hart or device accesses
     part of this reservation set while reservation_set_valid could be true.
     --
   }
@@ -2506,7 +2506,7 @@ function invalidate_reservation_set {
 function register_reservation_set {
   arguments
     Bits<XLEN> physical_address,   # The (always aligned) physical address to reserve.
-    Bits<XLEN> length              # mimimum length of the reservation. actual reservation may be larger
+    Bits<XLEN> length              # minimum length of the reservation. actual reservation may be larger
   description {
     Register a reservation for a physical address range that subsumes
     [physical_address, physical_address + N).
@@ -2594,7 +2594,7 @@ function store_conditional {
      * it covers the region addressed by this store
      * the address setting the reservation set matches virtual address
 
-    If the preceeding are met, perform the store and return 0.
+    If the preceding are met, perform the store and return 0.
     Otherwise, return 1.
   }
   body {

--- a/arch/isa/util.idl
+++ b/arch/isa/util.idl
@@ -85,7 +85,7 @@ function lowest_set_bit {
 function count_leading_zeros {
   template U32 N
   returns
-    Bits<bit_length(N)>  # Number of leading zeros in +vlaue+
+    Bits<bit_length(N)>  # Number of leading zeros in +value+
   arguments
     Bits<N> value        # value to count zero in
   description {

--- a/arch/profile/RVA22U64.yaml
+++ b/arch/profile/RVA22U64.yaml
@@ -23,7 +23,7 @@ extensions:
       NOP and hence trivially supported by hardware implementers, its
       inclusion in the mandatory extension list signifies that software
       should use the instruction whenever it would make sense and that
-      implementors are expected to exploit this information to optimize
+      implementers are expected to exploit this information to optimize
       hardware execution.
   Zba:
     presence: mandatory

--- a/arch/profile_class/RVA.yaml
+++ b/arch/profile_class/RVA.yaml
@@ -111,7 +111,7 @@ description: |
   broken and are now deprecated.  RVIA used this mechanism to enable
   scalar crypto until vector crypto was ready.  Software security
   features may also be in this category, with examples of deprecated
-  security features occuring in other architectures.  As another
+  security features occurring in other architectures.  As another
   example, the recent avalanche of new numeric datatypes for AI/ML may
   eventually subside with a few survivors actually being used longer
   term.  Denoting an option as transitory signals to the community that

--- a/arch/prose/idl.adoc
+++ b/arch/prose/idl.adoc
@@ -207,7 +207,7 @@ Bits<2> op = $bits(MemoryOperation::Fetch); # op gets 2'd3, see <<Casting>>
 
 ==== Bitfields
 
-Bitfields represent named ranges within a contiguous vector of bits. They are useful, for example, to describe the fields in a page table entry. Bitfield names and members must begin with a capital letter. Bitfields are explictly declared with a compile-time-known bit width. Bitfield members specify the range they occupy in the bitfield. Members may overlap, which enables aliasing. Gaps may exist in a bitfield (where no member exists); such gaps are read-only zero bits.
+Bitfields represent named ranges within a contiguous vector of bits. They are useful, for example, to describe the fields in a page table entry. Bitfield names and members must begin with a capital letter. Bitfields are explicitly declared with a compile-time-known bit width. Bitfield members specify the range they occupy in the bitfield. Members may overlap, which enables aliasing. Gaps may exist in a bitfield (where no member exists); such gaps are read-only zero bits.
 
 [source,idl]
 ----
@@ -274,7 +274,7 @@ Boolean  array_of_bools[12];      # array of twelve booleans
 Bits<32> matrix_of_words[32][32]; # array of arrays of 32 words
 ----
 
-Array elements are refenced using the bracket operator:
+Array elements are referenced using the bracket operator:
 
 .Array element references
 [source,idl]
@@ -308,7 +308,7 @@ When one or more values in a tuple is not needed, it can be assigned to the don'
 
 === Integer literals
 
-Integer literal values can be expressed using either C style or Verilog style. When using Verilog style, the literal bit width can be specified. If the width is omitted using the verilog style, the bit width will be XLEN. When using C style, the bitwidth is the minimum number of bits needed to represent the value.
+Integer literal values can be expressed using either C style or Verilog style. When using Verilog style, the literal bit width can be specified. If the width is omitted using the Verilog style, the bit width will be XLEN. When using C style, the bitwidth is the minimum number of bits needed to represent the value.
 
 A signed literal is allocated an extra bit to support negation. The literal itself is always positive, but may be immediately negated to get a negative value. For that reason, be careful
 constructing negative literals (see example below).
@@ -398,7 +398,7 @@ Bits<32> matrix_of_words[32][32] =
 
 == String literals
 
-String literals are enclosed in double quotes. There is no escape charater; as such, it is impossible to represent a double quote, newline, etc. in a string literal.
+String literals are enclosed in double quotes. There is no escape character; as such, it is impossible to represent a double quote, newline, etc. in a string literal.
 
 [source,idl]
 ----
@@ -703,7 +703,7 @@ $array_size(array) # => 13
 
 IDL provides if/else and for loops for control flow.
 
-An if statement condition must be a Boolean type; integers are not implictly converted to Booleans (_e.g._, testing whether an integer is 0).
+An if statement condition must be a Boolean type; integers are not implicitly converted to Booleans (_e.g._, testing whether an integer is 0).
 
 [source,idl]
 ----
@@ -773,7 +773,7 @@ Functions must live in global scope. Functions cannot be nested.
 
 A function may return zero or more values of any valid type. A function may accept zero or more arguments of any valid type.
 
-Functions have no address. They can only be called, and function objects cannot be assigned to a variable (no functin pointers).
+Functions have no address. They can only be called, and function objects cannot be assigned to a variable (no function pointers).
 
 As IDL is intended to represent hardware implementations, recursive functions are not allowed.
 
@@ -785,7 +785,7 @@ IDL only supports template values (_i.e._, you cannot pass a type as a template 
 
 Template functions are called using C++-style syntax, with the template argument enclosed in angle brackets.
 
-IDL cannot infer template arguments; they must be provided explictly.
+IDL cannot infer template arguments; they must be provided explicitly.
 
 .Example of template function
 [example]
@@ -807,7 +807,7 @@ function popcount {
 [source,idl]
 ----
 Bits<5> cnt = popcount<32, 5>(32'haaaaaaaa); # cnt = 16
-# Bits<5> cnt = popcount(32'haaaaaaaa); # compilation error: no template arugments given
+# Bits<5> cnt = popcount(32'haaaaaaaa); # compilation error: no template arguments given
 ----
 ====
 
@@ -898,7 +898,7 @@ The file `globals.idl` is implicitly treated as the top-level source file. Other
 
 === Instruction definitions
 
-Instruction defintions in `arch/inst` use IDL to formally specify the execution behavior via the "operation()" key. The IDL executes at Instruction scope when the instruction executes on a hart.
+Instruction definitions in `arch/inst` use IDL to formally specify the execution behavior via the "operation()" key. The IDL executes at Instruction scope when the instruction executes on a hart.
 
 "operation()" has no arguments (though decode variables are populated prior to execution) and no return value.
 
@@ -922,7 +922,7 @@ add:
 
 === CSR definitions
 
-IDL is used in several places of a CSR defintion in `arch/csr`:
+IDL is used in several places of a CSR definition in `arch/csr`:
 
 sw_read()::
 
@@ -941,7 +941,7 @@ instret:
 
 field.sw_write(csr_value)::
 
-The "sw_write(csr_value)" function of a CSR field executes when a software write (via a `Zicsr` instruction) occurs. It takes a single value, `csr_value`, that is an implicitly-defined bitfield of the CSR populated with the values software is trying to write. It returns a Bits<N> value repsenting what hardware is actually going to write into the field, where N is the width of the field. sw_write may also return the special value `UNDEFINED_LEGAL_DETERMINISTIC` to indicate that the written value is undefined, but it will be a legal value for the field and is deterministically determined based on the sequence of instructions leading to the write.
+The "sw_write(csr_value)" function of a CSR field executes when a software write (via a `Zicsr` instruction) occurs. It takes a single value, `csr_value`, that is an implicitly-defined bitfield of the CSR populated with the values software is trying to write. It returns a Bits<N> value representing what hardware is actually going to write into the field, where N is the width of the field. sw_write may also return the special value `UNDEFINED_LEGAL_DETERMINISTIC` to indicate that the written value is undefined, but it will be a legal value for the field and is deterministically determined based on the sequence of instructions leading to the write.
 
 [NOTE]
 Note that the sw_read is specified for the entire CSR and the sw_write is specified for a CSR field.
@@ -980,7 +980,7 @@ mstatus:
 
 field.reset_value()::
 
-The "reset_value()" function is used to specify the reset value of a CSR field when the value is configuration-dependent. It takes not arguments and returns a Bits<N> type, where N is the width of field. It may also return the special value `UNDEFINED_LEGAL` to indica       te that the reset value is unpredictable, but is gauranteed to be a legal value for the field.
+The "reset_value()" function is used to specify the reset value of a CSR field when the value is configuration-dependent. It takes not arguments and returns a Bits<N> type, where N is the width of field. It may also return the special value `UNDEFINED_LEGAL` to indicate that the reset value is unpredictable, but is guaranteed to be a legal value for the field.
 
 .Example field.reset_value()
 [source,yaml]
@@ -991,7 +991,7 @@ mstatus:
     # ...
     MBE:
       # ...
-      # if endianess is mutable, MBE comes out of reset in little-endian mode
+      # if endianness is mutable, MBE comes out of reset in little-endian mode
       reset_value(): |
         return (M_MODE_ENDIANESS == "big") ? 1 : 0;
 ----

--- a/backends/cfg_html_doc/adoc_gen.rake
+++ b/backends/cfg_html_doc/adoc_gen.rake
@@ -83,22 +83,22 @@ require "ruby-prof"
 
     case type
     when "csr"
-      puts "Generting full CSR list"
+      puts "Generating full CSR list"
       cfg_arch.transitive_implemented_csrs.each do |csr|
         lines << " * `#{csr.name}` #{csr.long_name}"
       end
     when "ext"
-      puts "Generting full extension list"
+      puts "Generating full extension list"
       cfg_arch.transitive_implemented_extensions.each do |ext_version|
         lines << " * `#{ext_version.name}` #{ext_version.ext.long_name}"
       end
     when "inst"
-      puts "Generting full instruction list"
+      puts "Generating full instruction list"
       cfg_arch.transitive_implemented_instructions.each do |inst|
         lines << " * `#{inst.name}` #{inst.long_name}"
       end
     when "func"
-      puts "Generting function list"
+      puts "Generating function list"
       cfg_arch.implemented_functions.each do |func|
         lines << " * `#{func.name}`"
       end

--- a/backends/cfg_html_doc/templates/config.adoc.erb
+++ b/backends/cfg_html_doc/templates/config.adoc.erb
@@ -16,7 +16,7 @@
 
 [cols="1,4,1"]
 |===
-| Value | Description | From Exension
+| Value | Description | From Extension
 
 | <%= param.value %>
 a| <%= param.desc %>

--- a/backends/cfg_html_doc/templates/func.adoc.erb
+++ b/backends/cfg_html_doc/templates/func.adoc.erb
@@ -1,6 +1,6 @@
 :tabs-sync-option:
 
-// defintions and helper functions for ISA definitions
+// definitions and helper functions for ISA definitions
 
 = Functions
 

--- a/backends/cfg_html_doc/templates/toc.adoc.erb
+++ b/backends/cfg_html_doc/templates/toc.adoc.erb
@@ -16,7 +16,7 @@
 <%- end -%>
 
 .IDL functions
-* xref:funcs:funcs.adoc[Global function defintions]
+* xref:funcs:funcs.adoc[Global function definitions]
 
 .Appendix
 * xref:prose:idl.adoc[IDL guide]

--- a/backends/ext_pdf_doc/tasks.rake
+++ b/backends/ext_pdf_doc/tasks.rake
@@ -201,7 +201,7 @@ namespace :gen do
   end
 
   desc <<~DESC
-    Generate HTML documentation for :extension that is defined or overlayed in :cfg
+    Generate HTML documentation for :extension that is defined or overlaid in :cfg
 
     The latest version will be used, but can be overloaded by setting the EXT_VERSION environment variable.
   DESC

--- a/backends/manual/templates/func.adoc.erb
+++ b/backends/manual/templates/func.adoc.erb
@@ -1,6 +1,6 @@
 :tabs-sync-option:
 
-// defintions and helper functions for ISA definitions
+// definitions and helper functions for ISA definitions
 
 = Functions
 

--- a/cfgs/config_validation.rb
+++ b/cfgs/config_validation.rb
@@ -2,9 +2,9 @@
 
 # This file contains validation checks above and beyond what is checked
 # by the schema. It can use the entire configuration (params, extension list, etc)
-# to check for invalid scenerios.
+# to check for invalid scenarios.
 #
-# It should only be used for scenerios too complex to express in JSONSchema
+# It should only be used for scenarios too complex to express in JSONSchema
 
 # SXLEN must be specified if S is used
 require_param :SXLEN if ext?(:S)

--- a/cfgs/generic_rv64/cfg.yaml
+++ b/cfgs/generic_rv64/cfg.yaml
@@ -415,35 +415,35 @@ params:
   # corresponds to the `GEILEN` parameter in the RVI specs
   NUM_EXTERNAL_GUEST_INTERRUPTS: 4
 
-  # Endianess of data in M-mode. Can be one of:
+  # Endianness of data in M-mode. Can be one of:
   #
   #  * little:  M-mode data is always little endian
   #  * big:     M-mode data is always big endian
   #  * dynamic: M-mode data can be either little or big endian, depending on the RW CSR field mstatus.MBE
   M_MODE_ENDIANESS: little
 
-  # Endianess of data in M-mode. Can be one of:
+  # Endianness of data in M-mode. Can be one of:
   #
   #  * little:  S-mode data is always little endian
   #  * big:     S-mode data is always big endian
   #  * dynamic: S-mode data can be either little or big endian, depending on the RW CSR field mstatus.SBE
   S_MODE_ENDIANESS: little
 
-  # Endianess of data in M-mode. Can be one of:
+  # Endianness of data in M-mode. Can be one of:
   #
-  #  * litte:   U-mode data is always little endian
+  #  * little:   U-mode data is always little endian
   #  * big:     U-mode data is always big endian
   #  * dynamic: U-mode data can be either little or big endian, depending on the RW CSR field mstatus.UBE
   U_MODE_ENDIANESS: little
 
-  # Endianess of data in VU-mode. Can be one of:
+  # Endianness of data in VU-mode. Can be one of:
   #
   #  * little: VU-mode data is always little endian
   #  * big: VU-mode data is always big endian
   #  * dynamic: VU-mode data can be either little or big endian, depending on the RW CSR field vsstatus.UBE
   VU_MODE_ENDIANESS: little
 
-  # Endianess of data in VS-mode. Can be one of:
+  # Endianness of data in VS-mode. Can be one of:
   #
   #  * little: VS-mode data is always little endian
   #  * big: VS-mode data is always big endian

--- a/cfgs/qc_iu/arch_overlay/ext/Xqci.yaml
+++ b/cfgs/qc_iu/arch_overlay/ext/Xqci.yaml
@@ -99,7 +99,7 @@ description: |
   Long immediates::
   --
   This extension provides wide-immediate versions of
-  loads, stores, branches, jumps, and several arithemtic operations.
+  loads, stores, branches, jumps, and several arithmetic operations.
   --
 
   Addressing modes::
@@ -139,7 +139,7 @@ description: |
   enable/disable interrupts and instructions to automatically save an interrupt frame.
   --
 
-  Saturating arithemtic::
+  Saturating arithmetic::
   --
   Xqci adds saturating arithmetic instructions to improve performance of fixed-point calculations.
   --

--- a/cfgs/qc_iu/qc_theme.yml
+++ b/cfgs/qc_iu/qc_theme.yml
@@ -216,7 +216,7 @@ example:
   border_radius: $base_border_radius
   border_width: 0.2
   background_color: ffffff
-  # FIXME reenable padding bottom once margin collapsing is implemented
+  # FIXME re-enable padding bottom once margin collapsing is implemented
   padding: [$vertical_rhythm, $horizontal_rhythm, 0, $horizontal_rhythm]
 image:
   align: left

--- a/lib/DB_MODEL.README.adoc
+++ b/lib/DB_MODEL.README.adoc
@@ -14,7 +14,7 @@ A configuration consists of a folder under `cfgs`. Inside that folder, there are
 A YAML object (hash) that currently contains only one field `type`. `type` can be one of:
 
 * "partially configured": The configuration has some parameters and/or implemented extensions known, but others are not known. Examples of a _partially configured_ configuration are the generic _32/_64 configs and a profile (which has some known/mandatory extensions, but also many unknown/optional extensions).
-* "fully configured": The configuration exhaustively lists a set of implmented extensions and parameters. An example of a _fully configured_ configuration is the `generic_rv64` example, which represents a theoritical implementation of RV64. In a _fully configured_ configuration, any extension that isn't known to be implemented is treated as unimplmented, and will be pruned out of the database for certain operations.
+* "fully configured": The configuration exhaustively lists a set of implemented extensions and parameters. An example of a _fully configured_ configuration is the `generic_rv64` example, which represents a theoretical implementation of RV64. In a _fully configured_ configuration, any extension that isn't known to be implemented is treated as unimplemented, and will be pruned out of the database for certain operations.
 
 `implemented_exts.yaml`::
 
@@ -55,7 +55,7 @@ The `arch_overlay` directory is treated as an overlay on the standard `arch` dir
 
 == ArchDef interface
 
-An `ArchDef` is most easily obtained by using the convience function `arch_def_for(String)`, which takes the name of a folder under `cfgs`. Once you have an `ArchDef`, you can begin to query the database.
+An `ArchDef` is most easily obtained by using the convenience function `arch_def_for(String)`, which takes the name of a folder under `cfgs`. Once you have an `ArchDef`, you can begin to query the database.
 
 .Architecture queries
 [source,ruby]

--- a/lib/arch_obj_models/csr.rb
+++ b/lib/arch_obj_models/csr.rb
@@ -142,7 +142,7 @@ class Csr < DatabaseObjectect
     end
   end
 
-  # @param cfg_arch [ConfiguredArchitecture] A configuration (can be nil if the lenth is not dependent on a config parameter)
+  # @param cfg_arch [ConfiguredArchitecture] A configuration (can be nil if the length is not dependent on a config parameter)
   # @param effective_xlen [Integer] The effective xlen, needed since some fields change location with XLEN. If the field location is not determined by XLEN, then this parameter can be nil
   # @return [Integer] Length, in bits, of the CSR, given effective_xlen
   # @return [nil] if the length cannot be determined from the cfg_arch (e.g., because SXLEN is unknown and +effective_xlen+ was not provided)

--- a/lib/arch_obj_models/csr_field.rb
+++ b/lib/arch_obj_models/csr_field.rb
@@ -256,7 +256,7 @@ class CsrField < DatabaseObjectect
     @alias
   end
 
-  # @return [Array<Idl::FunctionDefAst>] List of functions called thorugh this field
+  # @return [Array<Idl::FunctionDefAst>] List of functions called through this field
   # @param cfg_arch [ConfiguredArchitecture] a configuration
   # @Param effective_xlen [Integer] 32 or 64; needed because fields can change in different XLENs
   def reachable_functions(cfg_arch, effective_xlen)
@@ -301,7 +301,7 @@ class CsrField < DatabaseObjectect
     @reachable_functions = fns.uniq
   end
 
-  # @return [Array<Idl::FunctionDefAst>] List of functions called thorugh this field, irrespective of context
+  # @return [Array<Idl::FunctionDefAst>] List of functions called through this field, irrespective of context
   # @param symtab [SymbolTable]
   def reachable_functions_unevaluated(symtab)
     raise ArgumentError, "Argument should be a symtab" unless symtab.is_a?(Idl::SymbolTable)
@@ -492,7 +492,7 @@ class CsrField < DatabaseObjectect
     )
     symtab.add(
       "__expected_return_type",
-      Idl::Type.new(:bits, width: 128) # to accomodate special return values (e.g., UNDEFIEND_LEGAL_DETERMINISITIC)
+      Idl::Type.new(:bits, width: 128) # to accommodate special return values (e.g., UNDEFIEND_LEGAL_DETERMINISITIC)
     )
     symtab.add(
       "csr_value",

--- a/lib/arch_obj_models/exception_code.rb
+++ b/lib/arch_obj_models/exception_code.rb
@@ -23,5 +23,5 @@ class ExceptionCode
   end
 end
 
-# all the same informatin as ExceptinCode, but for interrupts
+# all the same information as ExceptinCode, but for interrupts
 InterruptCode = Class.new(ExceptionCode)

--- a/lib/arch_obj_models/extension.rb
+++ b/lib/arch_obj_models/extension.rb
@@ -19,13 +19,13 @@ class ExtensionParameter
   attr_reader :schema
 
   # @return [String] Ruby code to perform validation above and beyond JSON schema
-  # @return [nil] If there is no extra validatino
+  # @return [nil] If there is no extra validation
   attr_reader :extra_validation
 
   # @return [Array<Extension>] The extension(s) that define this parameter
   #
   # Some parameters are defined by multiple extensions (e.g., CACHE_BLOCK_SIZE by Zicbom and Zicboz).
-  # When defined in multiple places, the parameter *must* mean the extact same thing.
+  # When defined in multiple places, the parameter *must* mean the exact same thing.
   attr_reader :exts
 
   # @returns [Idl::Type] Type of the parameter
@@ -126,7 +126,7 @@ end
 
 # Extension definition
 class Extension < DatabaseObjectect
-  # @return [ConfiguredArchitecture] The architecture defintion
+  # @return [ConfiguredArchitecture] The architecture definition
   attr_reader :cfg_arch
 
   # @return [String] Long name of the extension
@@ -480,7 +480,7 @@ class ExtensionVersion
 
   # @param ext_name [String] Extension name
   # @param ext_version_requirements [String,Array<String>] Extension version requirements
-  # @return [Boolean] whether or not this ExtensionVersion is named `ext_name` and satifies the version requirements
+  # @return [Boolean] whether or not this ExtensionVersion is named `ext_name` and satisfies the version requirements
   def satisfies?(ext_name, *ext_version_requirements)
     ExtensionRequirement.new(ext_name, ext_version_requirements).satisfied_by?(self)
   end

--- a/lib/arch_obj_models/instruction.rb
+++ b/lib/arch_obj_models/instruction.rb
@@ -312,7 +312,7 @@ class Instruction < DatabaseObjectect
 
     # alias of this field, or nil if none
     #
-    # used, e.g., when a field reprsents more than one variable (like rs1/rd for destructive instructions)
+    # used, e.g., when a field represents more than one variable (like rs1/rd for destructive instructions)
     attr_reader :alias
 
     # amount the field is left shifted before use, or nil is there is no left shift
@@ -531,7 +531,7 @@ class Instruction < DatabaseObjectect
 
     # represents an encoding field (contiguous set of bits that form an opcode or decode variable slot)
     class Field
-      # @return [String] Either string of 0's ans 1's or a bunch of dashses
+      # @return [String] Either string of 0's and 1's or a bunch of dashes
       # @example Field of a decode variable
       #   encoding.opcode_fields[0] #=> '-----' (for imm5)
       # @example Field of an opcode
@@ -541,7 +541,7 @@ class Instruction < DatabaseObjectect
       # @return [Range] Range of bits in the parent corresponding to this field
       attr_reader :range
 
-      # @param name [#to_s] Either string of 0's ans 1's or a bunch of dashses
+      # @param name [#to_s] Either string of 0's and 1's or a bunch of dashes
       # @param range [Range] Range of the field in the parent CSR
       def initialize(name, range)
         @name = name.to_s
@@ -559,7 +559,7 @@ class Instruction < DatabaseObjectect
     end
 
     # @param format [String] Format of the encoding, as 0's, 1's and -'s (for decode variables)
-    # @param decode_vars [Array<Hash<String,Object>>] List of decode variable defintions from the arch spec
+    # @param decode_vars [Array<Hash<String,Object>>] List of decode variable definitions from the arch spec
     def initialize(format, decode_vars)
       @format = format
 
@@ -712,7 +712,7 @@ class Instruction < DatabaseObjectect
   # @overload excluded_by?(ext_name, ext_version)
   #   @param ext_name [#to_s] An extension name
   #   @param ext_version [#to_s] A specific extension version
-  #   @return [Boolean] Whether or not the instruction is excluded by extesion `ext`, version `version`
+  #   @return [Boolean] Whether or not the instruction is excluded by extension `ext`, version `version`
   # @overload excluded_by?(ext_version)
   #   @param ext_version [ExtensionVersion] An extension version
   #   @return [Boolean] Whether or not the instruction is excluded by ext_version

--- a/lib/arch_obj_models/obj.rb
+++ b/lib/arch_obj_models/obj.rb
@@ -140,7 +140,7 @@ class DatabaseObjectect
       end
 
       # convert through JSON to handle anything supported in YAML but not JSON
-      # (e.g., integer object keys will be coverted to strings)
+      # (e.g., integer object keys will be converted to strings)
       jsonified_obj = JSON.parse(JSON.generate(@data))
 
       raise "Nothing there?" if jsonified_obj.nil?
@@ -216,7 +216,7 @@ class DatabaseObjectect
   # @overload defined_by?(ext_name, ext_version)
   #   @param ext_name [#to_s] An extension name
   #   @param ext_version [#to_s] A specific extension version
-  #   @return [Boolean] Whether or not the instruction is defined by extesion `ext`, version `version`
+  #   @return [Boolean] Whether or not the instruction is defined by extension `ext`, version `version`
   # @overload defined_by?(ext_version)
   #   @param ext_version [ExtensionVersion] An extension version
   #   @return [Boolean] Whether or not the instruction is defined by ext_version

--- a/lib/arch_obj_models/portfolio.rb
+++ b/lib/arch_obj_models/portfolio.rb
@@ -5,7 +5,7 @@
 #   RVA and MC are examples of portfolio classes
 #
 # Many classes inherit from the DatabaseObjectect class. This provides facilities for accessing the contents of a
-# Portfolio Class YAML or Portfolio Model YAML file via the "data" member (hash holding releated YAML file contents).
+# Portfolio Class YAML or Portfolio Model YAML file via the "data" member (hash holding related YAML file contents).
 #
 # A variable name with a "_data" suffix indicates it is the raw hash data from the porfolio YAML file.
 
@@ -401,7 +401,7 @@ class PortfolioInstance < DatabaseObjectect
 
     exts = []
 
-    # Interate through all the extensions in the architecture database that define this parameter.
+    # Iterate through all the extensions in the architecture database that define this parameter.
     param.exts.each do |ext|
       found = false
 
@@ -430,7 +430,7 @@ class PortfolioInstance < DatabaseObjectect
 
     exts = []   # Local variable, no caching
 
-    # Interate through all the extensions in the architecture database that define this parameter.
+    # Iterate through all the extensions in the architecture database that define this parameter.
     param.exts.each do |ext|
       found = false
 

--- a/lib/architecture.rb
+++ b/lib/architecture.rb
@@ -27,7 +27,7 @@ class Architecture
   # @return [Pathname] Path to the directory with the standard YAML files
   attr_reader :path
 
-  # @param arch_dir [Sting,Pathname] Path to a directory with a fully merged/resolved architecture defintion
+  # @param arch_dir [String,Pathname] Path to a directory with a fully merged/resolved architecture definition
   def initialize(arch_dir)
     @arch_dir = Pathname.new(arch_dir)
     raise "Arch directory not found: #{arch_dir}" unless @arch_dir.exist?

--- a/lib/cfg_arch.rb
+++ b/lib/cfg_arch.rb
@@ -344,7 +344,7 @@ class ConfiguredArchitecture < Architecture
   def transitive_implemented_extensions
     return @transitive_implemented_extensions unless @transitive_implemented_extensions.nil?
 
-    raise "implemented_extensions is only valid for a fully configured defintion" unless @config.fully_configured?
+    raise "implemented_extensions is only valid for a fully configured definition" unless @config.fully_configured?
 
     list = implemented_extensions
     list.each do |e|
@@ -387,7 +387,7 @@ class ConfiguredArchitecture < Architecture
             @prohibited_extensions << conflict
           else
             # pick whichever requirement is more expansive
-            p = @prohibited_extensions.find { |prohibited_ext| prohibited_ext.name == confict.name }
+            p = @prohibited_extensions.find { |prohibited_ext| prohibited_ext.name == conflict.name }
             if p.version_requirement.subsumes?(conflict.version_requirement)
               @prohibited_extensions.delete(p)
               @prohibited_extensions << conflict

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -75,13 +75,13 @@ class Unconfig < Config
 
   def mxlen = nil
 
-  def implemented_extensions = raise "implemented_extensions is only availabe for a FullConfig"
-  def mandatory_extensions = raise "mandatory_extensions is only availabe for a PartialConfig"
-  def prohibited_extensions = raise "prohibited_extensions is only availabe for a PartialConfig"
+  def implemented_extensions = raise "implemented_extensions is only available for a FullConfig"
+  def mandatory_extensions = raise "mandatory_extensions is only available for a PartialConfig"
+  def prohibited_extensions = raise "prohibited_extensions is only available for a PartialConfig"
 end
 
 # this class represents a configuration file (e.g., cfgs/*/cfg.yaml) that is "partially configured"
-# (i.e., we have a list of mandatory/prohibited extensions and a paritial list of parameter values)
+# (i.e., we have a list of mandatory/prohibited extensions and a partial list of parameter values)
 #
 # This would, for example, represent a Profile or configurable IP
 class PartialConfig < Config
@@ -98,7 +98,7 @@ class PartialConfig < Config
     @mxlen.freeze
   end
 
-  def implemented_extensions = raise "implemented_extensions is only availabe for a FullConfig"
+  def implemented_extensions = raise "implemented_extensions is only available for a FullConfig"
 
   # @return [Array<Hash{String => String,Array<String}>]
   #    List of all extensions that must be implemented, as specified in the config file
@@ -175,8 +175,8 @@ class FullConfig < Config
       end
   end
 
-  def mandatory_extensions = raise "mandatory_extensions is only availabe for a PartialConfig"
-  def prohibited_extensions = raise "prohibited_extensions is only availabe for a PartialConfig"
+  def mandatory_extensions = raise "mandatory_extensions is only available for a PartialConfig"
+  def prohibited_extensions = raise "prohibited_extensions is only available for a PartialConfig"
 
   # def prohibited_ext?(ext_name, cfg_arch) = !ext?(ext_name, cfg_arch)
   # def ext?(ext_name, cfg_arch) = implemented_extensions(cfg_arch).any? { |e| e.name == ext_name.to_s }

--- a/lib/idl/ast.rb
+++ b/lib/idl/ast.rb
@@ -63,14 +63,14 @@ module Idl
     # @return [String] Source string
     attr_reader :input
 
-    # @retrun [Range] Range within the input for this node
+    # @return [Range] Range within the input for this node
     attr_reader :interval
 
     # @return [String] The IDL source of this node
     attr_reader :text_value
 
-    # @retrun [AstNode] The parent node
-    # @retrun [nil] if this is the root of the tree
+    # @return [AstNode] The parent node
+    # @return [nil] if this is the root of the tree
     attr_reader :parent
 
     # @return [Array<AstNode>] Children of this node
@@ -143,7 +143,7 @@ module Idl
         <<~WHAT
           In file #{file}
           On line #{lineno}
-            A value error occured
+            A value error occurred
             #{reason}
         WHAT
       end
@@ -291,7 +291,7 @@ module Idl
 
           #{lines.gsub("\n", "\n  ")}
 
-        A type error occured
+        A type error occurred
           #{$stdout.isatty ? "\u001b[31m#{reason}\u001b[0m" : reason}
       WHAT
       raise AstNode::TypeError, msg
@@ -305,7 +305,7 @@ module Idl
       msg = <<~WHAT
         In file #{input_file}
         On line #{lineno}
-          An internal error occured
+          An internal error occurred
           #{reason}
       WHAT
       raise AstNode::InternalError, msg
@@ -431,13 +431,13 @@ module Idl
 
   # interface for nodes that *might* return a value in a function body
   module Returns
-    # @!macro [new] retrun_value
+    # @!macro [new] return_value
     #   Evaluate the compile-time return value of this node, or, if the node does not return
     #   (e.g., because it is an IfAst but there is no return on the taken path), execute the node
     #   and update the symtab
     #
     #   @param symtab [SymbolTable] The symbol table for the context
-    #   @raise ValueError if, during evaulation, a node without a compile-time value is found
+    #   @raise ValueError if, during evaluation, a node without a compile-time value is found
     #   @return [Integer] The return value, if it is integral
     #   @return [Boolean] The return value, if it is boolean
     #   @return [nil]     if the return value is not compile-time-known
@@ -445,13 +445,13 @@ module Idl
     # @!macro return_value
     def return_value(symtab) = raise NotImplementedError, "#{self.class.name} must implement return_value"
 
-    # @!macro [new] retrun_values
+    # @!macro [new] return_values
     #   Evaluate all possible compile-time return values of this node, or, if the node does not return
     #   (e.g., because it is an IfAst but there is no return on a possible path), execute the node
     #   and update the symtab
     #
     #   @param symtab [SymbolTable] The symbol table for the context
-    #   @raise ValueError if, during evaulation, a node without a compile-time value is found
+    #   @raise ValueError if, during evaluation, a node without a compile-time value is found
     #   @return [Array<Integer>] The possible return values. Will be an empty array if there are no return values
     #   @return [Array<Boolean>] The possible return values. Will be an empty array if there are no return values
 
@@ -509,7 +509,7 @@ module Idl
     #
     #  For most AstNodes, this will just be a single-entry array
     #
-    #  @param symtab [SymbolTable] The context for the evaulation
+    #  @param symtab [SymbolTable] The context for the evaluation
     #  @return [Array<Integer>] The complete list of compile-time-known values, when they are integral
     #  @return [Array<Boolean>] The complete list of compile-time-known values, when they are booleans
     #  @return [AstNode::ValueError] if the list of values is not knowable at compile time
@@ -524,7 +524,7 @@ module Idl
     #  Add symbol(s) at the outermost scope of the symbol table
     #
     #  @param symtab [SymbolTable] Symbol table at the scope that the symbol(s) will be inserted
-    def add_symbol(symtab) = raise NotImplementedError, "#{self.class.name} must implment add_symbol"
+    def add_symbol(symtab) = raise NotImplementedError, "#{self.class.name} must implement add_symbol"
   end
 
   class IncludeStatementSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -985,7 +985,7 @@ module Idl
     end
   end
 
-  # Node representing an IDL enum defintion
+  # Node representing an IDL enum definition
   #
   #  # this will result in an EnumDefinitionAst
   #  enum PrivilegeMode {
@@ -1063,7 +1063,7 @@ module Idl
     end
 
     # @!macro value_no_args
-    def value(_symtab, _cfg_arch) = raise InternalError, "Enum defintions have no value"
+    def value(_symtab, _cfg_arch) = raise InternalError, "Enum definitions have no value"
 
     # @return [String] enum name
     def name = @user_type.text_value
@@ -1229,7 +1229,7 @@ module Idl
     end
   end
 
-  # represents a bitfield defintion
+  # represents a bitfield definition
   #
   #  # this will result in a BitfieldDefinitionAst
   #  bitfield (64) Sv39PageTableEntry {
@@ -1328,7 +1328,7 @@ module Idl
     def name = @name.text_value
 
     # @!macro value_no_args
-    def value(_symtab, _cfg_arch) = raise AstNode::InternalError, "Bitfield defintions have no value"
+    def value(_symtab, _cfg_arch) = raise AstNode::InternalError, "Bitfield definitions have no value"
 
     # @!macro to_idl
     def to_idl
@@ -1739,7 +1739,7 @@ module Idl
     end
   end
 
-  # represents an array element assignement
+  # represents an array element assignment
   #
   # for example:
   #   X[rs1] = XLEN'd0
@@ -1781,7 +1781,7 @@ module Idl
         end
       when :bits
         unless rhs.type(symtab).convertable_to?(Bits1Type)
-          type_error "Incompatible type in integer slice assignement"
+          type_error "Incompatible type in integer slice assignment"
         end
       else
         internal_error "Unexpected type on array element assignment"
@@ -1861,7 +1861,7 @@ module Idl
     end
   end
 
-  # represents an array range assignement
+  # represents an array range assignment
   #
   # for example:
   #   vec[8:0] = 8'd0
@@ -1880,8 +1880,8 @@ module Idl
     # @!macro type_check
     def type_check(symtab)
       variable.type_check(symtab)
-      type_error "#{varible.text_value} must be integral" unless variable.type(symtab).kind == :bits
-      type_errpr "Assigning to a constant" if variable.type(symtab).const?
+      type_error "#{variable.text_value} must be integral" unless variable.type(symtab).kind == :bits
+      type_error "Assigning to a constant" if variable.type(symtab).const?
 
       msb.type_check(symtab)
       lsb.type_check(symtab)
@@ -1933,7 +1933,7 @@ module Idl
       end
       value_else(value_result) do
         symtab.add(variable.name, Var.new(variable.name, variable.type(symtab)))
-        value_error "Either the range or right-hand side of an array range assignemnt is unknown"
+        value_error "Either the range or right-hand side of an array range assignment is unknown"
       end
     end
 
@@ -1952,7 +1952,7 @@ module Idl
     end
   end
 
-  # represents a bitfield or struct assignement
+  # represents a bitfield or struct assignment
   #
   # for example:
   #   Sv39PageTableEntry entry;
@@ -1992,7 +1992,7 @@ module Idl
         struct_val[field_access.field_name] = write_value.value(symtab)
         symtab.add(field_access.obj.name, Var.new(field_access.obj.name, field_access.obj.type(symtab), struct_val))
       else
-        value_error "TODO: Field assignement execution"
+        value_error "TODO: Field assignment execution"
       end
     end
 
@@ -2071,7 +2071,7 @@ module Idl
     end
   end
 
-  # represents assignement of multiple variable from a function call that returns multiple values
+  # represents assignment of multiple variable from a function call that returns multiple values
   #
   # for example:
   #   (match_result, cfg) = pmp_match<access_size>(paddr);
@@ -2229,7 +2229,7 @@ module Idl
     end
   end
 
-  # represents a single variable declaration (without assignement)
+  # represents a single variable declaration (without assignment)
   #
   # for example:
   #   Bits<64> doubleword
@@ -2346,7 +2346,7 @@ module Idl
     end
   end
 
-  # reprents a single variable declaration with initialization
+  # represents a single variable declaration with initialization
   #
   # for example:
   #   Bits<64> doubleword = 64'hdeadbeef
@@ -2946,7 +2946,7 @@ module Idl
           value_result = value_try do
             return 0 if lhs.value(symtab).zero?
           end
-          # ok, trye rhs
+          # ok, try rhs
 
           return 0 if rhs.value(symtab).zero?
 
@@ -3842,7 +3842,7 @@ module Idl
 
   # represents a don't care return value
   #
-  # for exaple:
+  # for example:
   #   return -;
   class DontCareReturnAst < AstNode
     include Rvalue
@@ -3934,7 +3934,7 @@ module Idl
       return_expression.return_types(symtab)
     end
 
-    # @retrun [Type] The actual return type
+    # @return [Type] The actual return type
     def return_type(symtab)
       return_expression.retrun_type(symtab)
     end
@@ -3994,7 +3994,7 @@ module Idl
       end
     end
 
-    # @retrun [Type] The actual return type
+    # @return [Type] The actual return type
     def return_type(symtab)
       types = return_types(symtab)
       if types.size > 1
@@ -4104,7 +4104,7 @@ module Idl
       return_expression.type_check(symtab)
     end
 
-    # @retrun [Type] The actual return type
+    # @return [Type] The actual return type
     def return_type(symtab)
       return_expression.return_type(symtab)
     end
@@ -4537,8 +4537,8 @@ module Idl
     def args = children[@num_targs..]
 
     def initialize(input, interval, function_name, targs, args)
-      raise ArgumentError, "targs shoudl be an array" unless targs.is_a?(Array)
-      raise ArgumentError, "args shoudl be an array" unless args.is_a?(Array)
+      raise ArgumentError, "targs should be an array" unless targs.is_a?(Array)
+      raise ArgumentError, "args should be an array" unless args.is_a?(Array)
 
       super(input, interval, targs + args)
       @num_targs = targs.size
@@ -4782,7 +4782,7 @@ module Idl
         # begin
         #   if s.is_a?(Returns)
         #     s.return_value(symtab)
-        #     # if we reach here, the return value is known, so we don't have to go futher
+        #     # if we reach here, the return value is known, so we don't have to go further
         #     break
         #   else
         #     s.execute(symtab)
@@ -4819,7 +4819,7 @@ module Idl
 
       values = []
       value_result = value_try do
-        # if there is a definate return value, then just return that
+        # if there is a definite return value, then just return that
         return [return_value(symtab)]
       end
       value_else(value_result) do
@@ -5054,7 +5054,7 @@ module Idl
 
     # we do lazy type checking of the function body so that we never check
     # uncalled functions, which avoids dealing with mentions of CSRs that
-    # may not exist in a given implmentation
+    # may not exist in a given implementation
     def type_check_from_call(symtab)
       internal_error "Function definitions should be at global + 1 scope" unless symtab.levels == 2
 
@@ -5112,7 +5112,7 @@ module Idl
       symtab.add!(name, def_type)
     end
 
-    # @return [Array<String>] Template arugment names, in order
+    # @return [Array<String>] Template argument names, in order
     def template_names
       @targs.map(&:name)
     end

--- a/lib/idl/passes/prune.rb
+++ b/lib/idl/passes/prune.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # This file contains AST functions that prune out unreachable paths given
-# some known values in a symbol talbe
+# some known values in a symbol table
 # It adds a `prune` function to every AstNode that returns a new,
 # pruned subtree.
 
@@ -118,7 +118,7 @@ module Idl
         pruned_body = nil
 
         value_result = value_try do
-          # go through the statements, and stop if we find one that retuns or raises an exception
+          # go through the statements, and stop if we find one that returns or raises an exception
           statements.each_with_index do |s, idx|
             if s.is_a?(ReturnStatementAst)
               pruned_body = FunctionBodyAst.new(input, interval, statements[0..idx].map { |s| s.prune(symtab) })

--- a/lib/idl/type.rb
+++ b/lib/idl/type.rb
@@ -12,7 +12,7 @@ module Idl
       :bitfield, # bitfield, convertable to int and/or Bits<width>
       :struct,   # structure class
       :array,    # array of other types
-      :tuple,    # tuple of other disimilar types
+      :tuple,    # tuple of other dissimilar types
       :function, # function
       :template_function, # template function, where the template arguments are known but template values need to be applied to become a full function
       :csr,      # a CSR register type
@@ -391,7 +391,7 @@ module Idl
     end
 
     # @return [Idl::Type] Type of a scalar
-    # @param schema [Hash] JSON Schema desciption of a scalar
+    # @param schema [Hash] JSON Schema description of a scalar
     def self.from_json_schema_scalar_type(schema)
       if schema.key?("type")
         case schema["type"]
@@ -432,7 +432,7 @@ module Idl
     private_class_method :from_json_schema_scalar_type
 
     # @return [Idl::Type] Type of array
-    # @param schema [Hash] JSON Schema desciption of an array
+    # @param schema [Hash] JSON Schema description of an array
     def self.from_json_schema_array_type(schema)
       width = schema["minItems"]
       if !schema.key?("minItems") || !schema.key?("maxItems") || (schema["minItems"] != schema["maxItems"])
@@ -789,7 +789,7 @@ module Idl
         arguments = @func_def_ast.arguments(symtab)
       ensure
         symtab.pop
-        symtab.relase
+        symtab.release
       end
       arguments[index][1]
     end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -15,7 +15,7 @@
 #        - 2.0 is compatible with 1.0
 #        - 1.1 is compatible with 1.0
 #        - 0.9 is *not* compatible with 1.0
-#  * A version can be explictly marked as "breaking" in the architecture defintion
+#  * A version can be explicitly marked as "breaking" in the architecture definition
 #      Breaking versions are not backward compatible with any smaller versions
 #      For example, if version 2.2 is Breaking,
 #        - 3.0 is compatible with 2.2

--- a/lib/yaml_resolver.py
+++ b/lib/yaml_resolver.py
@@ -17,7 +17,7 @@ from jsonschema.exceptions import ValidationError
 from referencing import Registry, Resource
 from referencing.exceptions import NoSuchResource
 
-# cahce of Schema valiators
+# cache of Schema validators
 schemas = {}
 
 SCHEMAS_PATH = Path(os.path.join(os.path.dirname(os.path.dirname(__file__)), "schemas"))

--- a/schemas/config_schema.json
+++ b/schemas/config_schema.json
@@ -23,7 +23,7 @@
           "non_mandatory_extensions": {
             "type": "null"
           },
-          "prohbited_extensions": {
+          "prohibited_extensions": {
             "type": "null"
           },
           "implemented_extensions": {
@@ -124,7 +124,7 @@
         "non_mandatory_extensions": {
           "type": "null"
         },
-        "prohbited_extensions": {
+        "prohibited_extensions": {
           "type": "null"
         },
         "params": {

--- a/schemas/profile_class_schema.json
+++ b/schemas/profile_class_schema.json
@@ -40,8 +40,8 @@
     },
     "$source": {
       "type": "string",
-      "format": "uri-refencence",
-      "description": "Realtive (from arch/) path to the original YAML file"
+      "format": "uri-reference",
+      "description": "Relative (from arch/) path to the original YAML file"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
This started as simple PR to fix a typo I saw in schema file and then I decide to run `codespell` on the rest.