### PR TITLE
updating actions to latest versions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: print latest_commit
         run: echo ${{ github.sha }}
 
@@ -35,13 +35,13 @@ jobs:
         uses: eWaterCycle/setup-apptainer@v2.0.0
       - name: Get container from cache
         id: cache-sif
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .singularity/image.sif
           key: ${{ hashFiles('container.def', 'bin/.container-tag') }}
       - name: Get gems and node files from cache
         id: cache-bundle-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .home/.gems

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
         continue-on-error: true
         name: check latest commit is less than a day
         if: ${{ github.event_name == 'schedule' }}
-        run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "::set-output name=should_run::false"
+        run: test -z "$(git rev-list  --after='24 hours'  ${{ github.sha }})" && echo "name=should_run::false" >> "$GITHUB_OUTPUT"
   nightly:
     needs: check_date
     if: ${{ needs.check_date.outputs.should_run != 'false' }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,13 +26,13 @@ jobs:
         uses: eWaterCycle/setup-apptainer@v2.0.0
       - name: Get container from cache
         id: cache-sif
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .singularity/image.sif
           key: ${{ hashFiles('container.def', 'bin/.container-tag') }}
       - name: Get gems and node files from cache
         id: cache-bundle-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .home/.gems

--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -8,8 +8,8 @@ jobs:
   regress-pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - uses: pre-commit/action@v3.0.1
   regress-smoke:
     runs-on: ubuntu-latest
@@ -22,13 +22,13 @@ jobs:
         uses: eWaterCycle/setup-apptainer@v2.0.0
       - name: Get container from cache
         id: cache-sif
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .singularity/image.sif
           key: ${{ hashFiles('container.def', 'bin/.container-tag') }}
       - name: Get gems and node files from cache
         id: cache-bundle-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .home/.gems
@@ -55,13 +55,13 @@ jobs:
         uses: eWaterCycle/setup-apptainer@v2.0.0
       - name: Get container from cache
         id: cache-sif
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .singularity/image.sif
           key: ${{ hashFiles('container.def', 'bin/.container-tag') }}
       - name: Get gems and node files from cache
         id: cache-bundle-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .home/.gems
@@ -86,13 +86,13 @@ jobs:
         uses: eWaterCycle/setup-apptainer@v2.0.0
       - name: Get container from cache
         id: cache-sif
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .singularity/image.sif
           key: ${{ hashFiles('container.def', 'bin/.container-tag') }}
       - name: Get gems and node files from cache
         id: cache-bundle-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .home/.gems
@@ -115,13 +115,13 @@ jobs:
         uses: eWaterCycle/setup-apptainer@v2.0.0
       - name: Get container from cache
         id: cache-sif
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .singularity/image.sif
           key: ${{ hashFiles('container.def', 'bin/.container-tag') }}
       - name: Get gems and node files from cache
         id: cache-bundle-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .home/.gems
@@ -144,13 +144,13 @@ jobs:
         uses: eWaterCycle/setup-apptainer@v2.0.0
       - name: Get container from cache
         id: cache-sif
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .singularity/image.sif
           key: ${{ hashFiles('container.def', 'bin/.container-tag') }}
       - name: Get gems and node files from cache
         id: cache-bundle-npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             .home/.gems


### PR DESCRIPTION
fixed for these issues flagged by actionlint: 

```
❯ actionlint -ignore  "SC2102"
.github/workflows/nightly.yml:16:15: the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
16 |       - uses: actions/checkout@v2
   |               ^~~~~~~~~~~~~~~~~~~
.github/workflows/nightly.yml:24:9: shellcheck reported issue in this script: SC2046:warning:1:9: Quote this to prevent word splitting [shellcheck]
   |
24 |         run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "::set-output name=should_run::false"
   |         ^~~~
.github/workflows/nightly.yml:24:14: workflow command "set-output" was deprecated. use `echo "{name}={value}" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions [deprecated-commands]
   |
24 |         run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "::set-output name=should_run::false"
   |              ^~~~
.github/workflows/nightly.yml:38:15: the runner of "actions/cache@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
38 |         uses: actions/cache@v3
   |               ^~~~~~~~~~~~~~~~
.github/workflows/nightly.yml:44:15: the runner of "actions/cache@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
44 |         uses: actions/cache@v3
   |               ^~~~~~~~~~~~~~~~
.github/workflows/pages.yml:29:15: the runner of "actions/cache@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
29 |         uses: actions/cache@v3
   |               ^~~~~~~~~~~~~~~~
.github/workflows/pages.yml:35:15: the runner of "actions/cache@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
35 |         uses: actions/cache@v3
   |               ^~~~~~~~~~~~~~~~
.github/workflows/regress.yml:11:15: the runner of "actions/checkout@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
11 |       - uses: actions/checkout@v3
   |               ^~~~~~~~~~~~~~~~~~~
.github/workflows/regress.yml:12:15: the runner of "actions/setup-python@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
12 |       - uses: actions/setup-python@v3
   |               ^~~~~~~~~~~~~~~~~~~~~~~
.github/workflows/regress.yml:25:15: the runner of "actions/cache@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
25 |         uses: actions/cache@v3
   |               ^~~~~~~~~~~~~~~~
.github/workflows/regress.yml:31:15: the runner of "actions/cache@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
31 |         uses: actions/cache@v3
   |               ^~~~~~~~~~~~~~~~
.github/workflows/regress.yml:58:15: the runner of "actions/cache@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
58 |         uses: actions/cache@v3
   |               ^~~~~~~~~~~~~~~~
.github/workflows/regress.yml:64:15: the runner of "actions/cache@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
64 |         uses: actions/cache@v3
   |               ^~~~~~~~~~~~~~~~
.github/workflows/regress.yml:89:15: the runner of "actions/cache@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
89 |         uses: actions/cache@v3
   |               ^~~~~~~~~~~~~~~~
.github/workflows/regress.yml:95:15: the runner of "actions/cache@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
   |
95 |         uses: actions/cache@v3
   |               ^~~~~~~~~~~~~~~~
.github/workflows/regress.yml:118:15: the runner of "actions/cache@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
    |
118 |         uses: actions/cache@v3
    |               ^~~~~~~~~~~~~~~~
.github/workflows/regress.yml:124:15: the runner of "actions/cache@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
    |
124 |         uses: actions/cache@v3
    |               ^~~~~~~~~~~~~~~~
.github/workflows/regress.yml:147:15: the runner of "actions/cache@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
    |
147 |         uses: actions/cache@v3
    |               ^~~~~~~~~~~~~~~~
.github/workflows/regress.yml:153:15: the runner of "actions/cache@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
    |
153 |         uses: actions/cache@v3
    |               ^~~~~~~~~~~~~~~~
```