### PR TITLE
change to correct range specifiers for an integer type

### DIFF
--- a/schemas/csr_schema.json
+++ b/schemas/csr_schema.json
@@ -226,8 +226,8 @@
         },
         "address": {
           "type": "integer",
-          "minValue": 0,
-          "maxValue": 4095,
+          "minimum": 0,
+          "maximum": 4095,
           "description": "Address of the CSR, as given to the CSR access instructions of the `Zicsr` extension"
         },
         "indirect_address": {


### PR DESCRIPTION
Based on this: https://json-schema.org/understanding-json-schema/reference/numeric#range
I believe these keywords should change.