### PR TITLE
Zcmp excludeby fix

### DIFF
--- a/arch/inst/Zcmp/cm.mva01s.yaml
+++ b/arch/inst/Zcmp/cm.mva01s.yaml
@@ -10,6 +10,10 @@ description: |
 definedBy:
   anyOf:
     - Zcmp
+excludedBy:
+  anyOf:
+    - allOf: [C, D]
+    - Zcd
 assembly: r1s, r2s
 encoding:
   match: 101011---11---10

--- a/arch/inst/Zcmp/cm.mvsa01.yaml
+++ b/arch/inst/Zcmp/cm.mvsa01.yaml
@@ -12,6 +12,10 @@ description: |
 definedBy:
   anyOf:
     - Zcmp
+excludedBy:
+  anyOf:
+    - allOf: [C, D]
+    - Zcd
 assembly: r1s, r2s
 encoding:
   match: 101011---01---10

--- a/arch/inst/Zcmp/cm.pop.yaml
+++ b/arch/inst/Zcmp/cm.pop.yaml
@@ -17,6 +17,10 @@ description: |
 definedBy:
   anyOf:
     - Zcmp
+excludedBy:
+  anyOf:
+    - allOf: [C, D]
+    - Zcd
 assembly: reg_list, stack_adj
 encoding:
   match: 10111010------10

--- a/arch/inst/Zcmp/cm.popret.yaml
+++ b/arch/inst/Zcmp/cm.popret.yaml
@@ -17,6 +17,10 @@ description: |
 definedBy:
   anyOf:
     - Zcmp
+excludedBy:
+  anyOf:
+    - allOf: [C, D]
+    - Zcd
 assembly: reg_list, stack_adj
 encoding:
   match: 10111110------10

--- a/arch/inst/Zcmp/cm.popretz.yaml
+++ b/arch/inst/Zcmp/cm.popretz.yaml
@@ -17,6 +17,10 @@ description: |
 definedBy:
   anyOf:
     - Zcmp
+excludedBy:
+  anyOf:
+    - allOf: [C, D]
+    - Zcd
 assembly: reg_list, stack_adj
 encoding:
   match: 10111100------10

--- a/arch/inst/Zcmp/cm.push.yaml
+++ b/arch/inst/Zcmp/cm.push.yaml
@@ -18,6 +18,10 @@ description: |
 definedBy:
   anyOf:
     - Zcmp
+excludedBy:
+  anyOf:
+    - allOf: [C, D]
+    - Zcd
 assembly: reg_list, -stack_adj
 encoding:
   match: 10111000------10

--- a/cfgs/qc_iu/arch_overlay/inst/Xqci/qc.c.muliadd.yaml
+++ b/cfgs/qc_iu/arch_overlay/inst/Xqci/qc.c.muliadd.yaml
@@ -8,14 +8,13 @@ description: |
   Increments `rd` by the multiplication of `rs1` and an unsigned immediate
   Instruction encoded in CL instruction format.
 definedBy:
-  allOf:
-    - not:
-        anyOf:
-          - allOf: [C, D]
-          - Zcd
-    - anyOf:
-        - Xqci
-        - Xqciac
+  anyOf:
+    - Xqci
+    - Xqciac
+excludedBy:
+  anyOf:
+    - allOf: [C, D]
+    - Zcd
 base: 32
 encoding:
   match: 001-----------10

--- a/cfgs/qc_iu/arch_overlay/inst/Xqci/qc.c.mveqz.yaml
+++ b/cfgs/qc_iu/arch_overlay/inst/Xqci/qc.c.mveqz.yaml
@@ -8,14 +8,13 @@ description: |
   Move `rs1` to `rd` if `rd` == 0, keep `rd` value otherwise
   Instruction encoded in CL instruction format.
 definedBy:
-  allOf:
-    - anyOf:
-        - Xqci
-        - Xqcicm
-    - not:
-        anyOf:
-          - allOf: [C, D]
-          - Zcd
+  anyOf:
+    - Xqci
+    - Xqciac
+excludedBy:
+  anyOf:
+    - allOf: [C, D]
+    - Zcd
 base: 32
 encoding:
   match: 101011---00---10


### PR DESCRIPTION
Add excludedBy statement to all Zcmp instructions to make sure it will not be used when Zcd or C + D extensions are included in configuration