### PR TITLE
Xqccmp Extension version 0.2

### DIFF
--- a/.github/workflows/regress.yaml
+++ b/.github/workflows/regress.yaml
@@ -1,6 +1,0 @@
-on:
-  push:
-    branches:
-      - main
-  merge_group:                # this is a new line
-    types: [checks_requested] # this is a new line

--- a/.github/workflows/regress.yaml
+++ b/.github/workflows/regress.yaml
@@ -1,0 +1,6 @@
+on:
+  push:
+    branches:
+      - main
+  merge_group:                # this is a new line
+    types: [checks_requested] # this is a new line

--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -1,5 +1,10 @@
 name: Regression test
 on:
+  push:
+    branches:
+      - main
+  merge_group:                # this is a new line
+    types: [checks_requested] # this is a new line
   pull_request:
     branches:
       - main

--- a/cfgs/qc_iu/arch_overlay/csr/Xqccmp/qc.mstkbottomaddr.yaml
+++ b/cfgs/qc_iu/arch_overlay/csr/Xqccmp/qc.mstkbottomaddr.yaml
@@ -1,0 +1,27 @@
+$schema: csr_schema.json#
+kind: csr
+name: qc.mstkbottomaddr
+long_name: Machine Stack Bottom Limit
+address: 0x7c5
+base: 32
+priv_mode: M
+length: MXLEN
+description: |
+  Stack bottom limit register. If the stack pointer (sp == x2) lesser then its value - SpOutOfRange exception occurs
+definedBy:
+  anyOf:
+    - Xqccmp
+    - Xqci
+    - Xqciint
+fields:
+  STKADDR:
+    location: 31-4
+    description: |
+      If the stack pointer (sp == x2) lesser then STKADDR*16 - SpOutOfRange exception occurs
+    type: RW
+    reset_value: 0
+  RESERVED:
+    location: 3-0
+    description: Reserved and must be zero
+    type: RO
+    reset_value: 0

--- a/cfgs/qc_iu/arch_overlay/csr/Xqccmp/qc.mstktopaddr.yaml
+++ b/cfgs/qc_iu/arch_overlay/csr/Xqccmp/qc.mstktopaddr.yaml
@@ -1,0 +1,27 @@
+$schema: csr_schema.json#
+kind: csr
+name: qc.mstktopaddr
+long_name: Machine Stack Top Limit
+address: 0x7c4
+base: 32
+priv_mode: M
+length: MXLEN
+description: |
+  Stack top limit register. If the stack pointer (sp == x2) greater then its value - SpOutOfRange exception occurs
+definedBy:
+  anyOf:
+    - Xqccmp
+    - Xqci
+    - Xqciint
+fields:
+  STKADDR:
+    location: 31-4
+    description: |
+      If the stack pointer (sp == x2) greater then STKADDR*16 - SpOutOfRange exception occurs
+    type: RW
+    reset_value: 0
+  RESERVED:
+    location: 3-0
+    description: Reserved and must be zero
+    type: RO
+    reset_value: 0

--- a/cfgs/qc_iu/arch_overlay/ext/Xqccmp.yaml
+++ b/cfgs/qc_iu/arch_overlay/ext/Xqccmp.yaml
@@ -25,6 +25,27 @@ versions:
   requires:
     name: Zca
     version: ">= 1.0.0"
+- version: "0.2.0"
+  state: development
+  ratification_date: null
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  - name: Ana Pazos
+    company: Qualcomm Technologies, Inc.
+    email: apazos@qti.qualcomm.com
+  - name: James Ball
+    company: Qualcomm Technologies, Inc.
+    email: jameball@qti.qualcomm.com
+  changes:
+    - Fix qc.cm.pushfp instruction to avoid rlist == 4, since not saving s0 == fp but updating it, should not occur
+  requires:
+    name: Zca
+    version: ">= 1.0.0"
 description: |
   The Xqccmp extension is a set of instructions which may be executed as a series of existing 32-bit RISC-V instructions.
 

--- a/cfgs/qc_iu/arch_overlay/ext/Xqccmp.yaml
+++ b/cfgs/qc_iu/arch_overlay/ext/Xqccmp.yaml
@@ -42,7 +42,9 @@ versions:
     company: Qualcomm Technologies, Inc.
     email: jameball@qti.qualcomm.com
   changes:
+    - Fix all push and pop instructions description for RV64 (IDL code fix)
     - Fix qc.cm.pushfp instruction to avoid rlist == 4, since not saving s0 == fp but updating it, should not occur
+    - Add CSRs qc.mstkbottomaddr and qc.mstktopaddr to support cache range checking
     - Add list of supported custom exceptions - stack alignment check and stack range check
     - Add stack exception checks in all push/pop instructions
   requires:

--- a/cfgs/qc_iu/arch_overlay/ext/Xqccmp.yaml
+++ b/cfgs/qc_iu/arch_overlay/ext/Xqccmp.yaml
@@ -43,9 +43,18 @@ versions:
     email: jameball@qti.qualcomm.com
   changes:
     - Fix qc.cm.pushfp instruction to avoid rlist == 4, since not saving s0 == fp but updating it, should not occur
+    - Add list of supported custom exceptions - stack alignment check and stack range check
+    - Add stack exception checks in all push/pop instructions
   requires:
     name: Zca
     version: ">= 1.0.0"
+exception_codes:
+  - num: 27
+    name: Illegal Stack Pointer
+    var: IllegalStackPointer
+  - num: 28
+    name: Stack Pointer Out-Of-Range
+    var: SpOutOfRange
 description: |
   The Xqccmp extension is a set of instructions which may be executed as a series of existing 32-bit RISC-V instructions.
 

--- a/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.pop.yaml
+++ b/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.pop.yaml
@@ -40,6 +40,15 @@ operation(): |
   if (implemented?(ExtensionName::Xqccmp) && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
+  if (X[2] < CSR[qc.mstkbottomaddr]) {
+    raise(ExceptionCode::SpOutOfRange, mode(), $encoding);
+  }
+  if (X[2] > CSR[qc.mstktopaddr]) {
+    raise(ExceptionCode::SpOutOfRange, mode(), $encoding);
+  }
+  if (X[2] & 0xf != 0) {
+    raise(ExceptionCode::IllegalStackPointer, mode(), $encoding);
+  }
 
   XReg size = xlen();
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);

--- a/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.pop.yaml
+++ b/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.pop.yaml
@@ -52,7 +52,7 @@ operation(): |
 
   XReg size = xlen();
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
-  XReg stack_aligned_adj = (nreg * 4 + 15) & ~0xF;
+  XReg stack_aligned_adj = (nreg * size + 15) & ~0xF;
   XReg virtual_address_sp = X[2];
   XReg virtual_address_new_sp = virtual_address_sp + stack_aligned_adj + spimm;
   XReg virtual_address_base = virtual_address_new_sp - size;

--- a/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.popret.yaml
+++ b/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.popret.yaml
@@ -40,6 +40,15 @@ operation(): |
   if (implemented?(ExtensionName::Xqccmp) && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
+  if (X[2] < CSR[qc.mstkbottomaddr]) {
+    raise(ExceptionCode::SpOutOfRange, mode(), $encoding);
+  }
+  if (X[2] > CSR[qc.mstktopaddr]) {
+    raise(ExceptionCode::SpOutOfRange, mode(), $encoding);
+  }
+  if (X[2] & 0xf != 0) {
+    raise(ExceptionCode::IllegalStackPointer, mode(), $encoding);
+  }
 
   XReg size = xlen();
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);

--- a/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.popret.yaml
+++ b/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.popret.yaml
@@ -52,7 +52,7 @@ operation(): |
 
   XReg size = xlen();
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
-  XReg stack_aligned_adj = (nreg * 4 + 15) & ~0xF;
+  XReg stack_aligned_adj = (nreg * size + 15) & ~0xF;
   XReg virtual_address_sp = X[2];
   XReg virtual_address_new_sp = virtual_address_sp + stack_aligned_adj + spimm;
   XReg virtual_address_base = virtual_address_new_sp - size;

--- a/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.popretz.yaml
+++ b/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.popretz.yaml
@@ -52,7 +52,7 @@ operation(): |
 
   XReg size = xlen();
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
-  XReg stack_aligned_adj = (nreg * 4 + 15) & ~0xF;
+  XReg stack_aligned_adj = (nreg * size + 15) & ~0xF;
   XReg virtual_address_sp = X[2];
   XReg virtual_address_new_sp = virtual_address_sp + stack_aligned_adj + spimm;
   XReg virtual_address_base = virtual_address_new_sp - size;

--- a/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.popretz.yaml
+++ b/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.popretz.yaml
@@ -40,6 +40,15 @@ operation(): |
   if (implemented?(ExtensionName::Xqccmp) && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
+  if (X[2] < CSR[qc.mstkbottomaddr]) {
+    raise(ExceptionCode::SpOutOfRange, mode(), $encoding);
+  }
+  if (X[2] > CSR[qc.mstktopaddr]) {
+    raise(ExceptionCode::SpOutOfRange, mode(), $encoding);
+  }
+  if (X[2] & 0xf != 0) {
+    raise(ExceptionCode::IllegalStackPointer, mode(), $encoding);
+  }
 
   XReg size = xlen();
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
@@ -47,7 +56,6 @@ operation(): |
   XReg virtual_address_sp = X[2];
   XReg virtual_address_new_sp = virtual_address_sp + stack_aligned_adj + spimm;
   XReg virtual_address_base = virtual_address_new_sp - size;
-
 
   X[ 1] = read_memory_xlen(virtual_address_base -  0*size, $encoding);
   if (nreg > 1) {

--- a/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.push.yaml
+++ b/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.push.yaml
@@ -42,6 +42,15 @@ operation(): |
   if (implemented?(ExtensionName::Xqccmp) && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
+  if (X[2] < CSR[qc.mstkbottomaddr]) {
+    raise(ExceptionCode::SpOutOfRange, mode(), $encoding);
+  }
+  if (X[2] > CSR[qc.mstktopaddr]) {
+    raise(ExceptionCode::SpOutOfRange, mode(), $encoding);
+  }
+  if (X[2] & 0xf != 0) {
+    raise(ExceptionCode::IllegalStackPointer, mode(), $encoding);
+  }
 
   XReg size = xlen();
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);

--- a/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.push.yaml
+++ b/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.push.yaml
@@ -54,7 +54,7 @@ operation(): |
 
   XReg size = xlen();
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
-  XReg stack_aligned_adj = (nreg * 4 + 15) & ~0xF;
+  XReg stack_aligned_adj = (nreg * size + 15) & ~0xF;
   XReg virtual_address_sp = X[2];
   XReg virtual_address_new_sp = virtual_address_sp - stack_aligned_adj - spimm;
   XReg virtual_address_base = virtual_address_sp - size;

--- a/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.pushfp.yaml
+++ b/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.pushfp.yaml
@@ -30,7 +30,7 @@ encoding:
   variables:
     - name: rlist
       location: 7-4
-      not: [0, 1, 2, 3]
+      not: [0, 1, 2, 3, 4]
     - name: spimm
       location: 3-2
 access:

--- a/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.pushfp.yaml
+++ b/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.pushfp.yaml
@@ -42,6 +42,15 @@ operation(): |
   if (implemented?(ExtensionName::Xqccmp) && (CSR[misa].C == 1'b0)) {
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
+  if (X[2] < CSR[qc.mstkbottomaddr]) {
+    raise(ExceptionCode::SpOutOfRange, mode(), $encoding);
+  }
+  if (X[2] > CSR[qc.mstktopaddr]) {
+    raise(ExceptionCode::SpOutOfRange, mode(), $encoding);
+  }
+  if (X[2] & 0xf != 0) {
+    raise(ExceptionCode::IllegalStackPointer, mode(), $encoding);
+  }
 
   XReg size = xlen();
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);

--- a/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.pushfp.yaml
+++ b/cfgs/qc_iu/arch_overlay/inst/Xqccmp/qc.cm.pushfp.yaml
@@ -54,7 +54,7 @@ operation(): |
 
   XReg size = xlen();
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
-  XReg stack_aligned_adj = (nreg * 4 + 15) & ~0xF;
+  XReg stack_aligned_adj = (nreg * size + 15) & ~0xF;
   XReg virtual_address_sp = X[2];
   XReg virtual_address_new_sp = virtual_address_sp - stack_aligned_adj - spimm;
   XReg virtual_address_base = virtual_address_sp - size;


### PR DESCRIPTION
    - Fix all push and pop instructions description for RV64 (IDL code fix)
    - Fix qc.cm.pushfp instruction to avoid rlist == 4, since not saving s0 == fp but updating it, should not occur
    - Add CSRs qc.mstkbottomaddr and qc.mstktopaddr to support cache range checking
    - Add list of supported custom exceptions - stack alignment check and stack range check
    - Add stack exception checks in all push/pop instructions
