### PR TITLE
Extension B: fix ctz instruction IDL code

### DIFF
--- a/arch/inst/B/ctz.yaml
+++ b/arch/inst/B/ctz.yaml
@@ -30,7 +30,7 @@ operation(): |
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  X[rd] = (xlen() - 1) - $signed(lowest_set_bit(X[rs1]));
+  X[rd] = $signed(lowest_set_bit(X[rs1]));
 
 sail(): |
   {


### PR DESCRIPTION
IDL code in ctz instruction was wrong, fixing it