### PR TITLE
Resolve setup file error

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -83,9 +83,9 @@ elif [ "${CONTAINER_TYPE}" == "docker" ]; then
         docker build -t riscvintl/udb:${CONTAINER_TAG} -f .devcontainer/Dockerfile .
     fi
     if [ -t 1 -a -t 0 ]; then
-      DOCKER_BASE="docker run -it -v $(ROOT):$(ROOT) -w $(ROOT) riscvintl/udb:${CONTAINER_TAG}"
+      DOCKER_BASE="docker run -it -v ${ROOT}:${ROOT} -w ${ROOT} riscvintl/udb:${CONTAINER_TAG}"
     else
-      DOCKER_BASE="docker run -v $(ROOT):$(ROOT) -w $(ROOT) riscvintl/udb:${CONTAINER_TAG}"
+      DOCKER_BASE="docker run -v ${ROOT}:${ROOT} -w ${ROOT} riscvintl/udb:${CONTAINER_TAG}"
     fi
     RUN="${DOCKER_BASE}"
 elif [ "${CONTAINER_TYPE}" == "singularity" ]; then


### PR DESCRIPTION
Fixed an error in the setup script where the ROOT command was not found. The syntax for DOCKER_BASE was updated from 
```
$(ROOT) to ${ROOT}
```
 to correctly reference the environment variable in the Bash file, ensuring proper mounting of directories within the Docker container.