### PR TITLE
Xqccmp extension: version 0.3 

### DIFF
--- a/arch_overlay/qc_iu/ext/Xqccmp.yaml
+++ b/arch_overlay/qc_iu/ext/Xqccmp.yaml
@@ -50,6 +50,28 @@ versions:
   requires:
     name: Zca
     version: ">= 1.0.0"
+- version: "0.3.0"
+  state: frozen
+  ratification_date: null
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  - name: Ana Pazos
+    company: Qualcomm Technologies, Inc.
+    email: apazos@qti.qualcomm.com
+  - name: James Ball
+    company: Qualcomm Technologies, Inc.
+    email: jameball@qti.qualcomm.com
+  changes:
+    - Fix all push and pop instructions IDL code to take in consideration that xlen() returns bits and not bytes
+    - Declare state of extension as "frozen"
+  requires:
+    name: Zca
+    version: ">= 1.0.0"
 description: |
   The Xqccmp extension is a set of instructions which may be executed as a series of existing 32-bit RISC-V instructions.
 

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.pop.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.pop.yaml
@@ -41,8 +41,8 @@ operation(): |
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg virtual_address_sp = get_and_validate_stack_pointer($encoding);
-  XReg size = xlen();
+  XReg virtual_address_sp = get_and_validate_stack_pointer(X[2], $encoding);
+  XReg size = xlen() / 8;
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
   XReg stack_aligned_adj = (nreg * size + 15) & ~0xF;
   XReg virtual_address_new_sp = virtual_address_sp + stack_aligned_adj + spimm;

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popret.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popret.yaml
@@ -41,8 +41,8 @@ operation(): |
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg virtual_address_sp = get_and_validate_stack_pointer($encoding);
-  XReg size = xlen();
+  XReg virtual_address_sp = get_and_validate_stack_pointer(X[2], $encoding);
+  XReg size = xlen() / 8;
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
   XReg stack_aligned_adj = (nreg * size + 15) & ~0xF;
   XReg virtual_address_new_sp = virtual_address_sp + stack_aligned_adj + spimm;

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popretz.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popretz.yaml
@@ -41,8 +41,8 @@ operation(): |
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg virtual_address_sp = get_and_validate_stack_pointer($encoding);
-  XReg size = xlen();
+  XReg virtual_address_sp = get_and_validate_stack_pointer(X[2], $encoding);
+  XReg size = xlen() / 8;
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
   XReg stack_aligned_adj = (nreg * size + 15) & ~0xF;
   XReg virtual_address_new_sp = virtual_address_sp + stack_aligned_adj + spimm;

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.push.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.push.yaml
@@ -43,8 +43,8 @@ operation(): |
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg virtual_address_sp = get_and_validate_stack_pointer($encoding);
-  XReg size = xlen();
+  XReg virtual_address_sp = get_and_validate_stack_pointer(X[2], $encoding);
+  XReg size = xlen() / 8;
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
   XReg stack_aligned_adj = (nreg * size + 15) & ~0xF;
   XReg virtual_address_new_sp = virtual_address_sp - stack_aligned_adj - spimm;

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.pushfp.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.pushfp.yaml
@@ -43,8 +43,8 @@ operation(): |
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg virtual_address_sp = get_and_validate_stack_pointer($encoding);
-  XReg size = xlen();
+  XReg virtual_address_sp = get_and_validate_stack_pointer(X[2], $encoding);
+  XReg size = xlen() / 8;
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
   XReg stack_aligned_adj = (nreg * size + 15) & ~0xF;
   XReg virtual_address_new_sp = virtual_address_sp - stack_aligned_adj - spimm;

--- a/arch_overlay/qc_iu/isa/globals.isa
+++ b/arch_overlay/qc_iu/isa/globals.isa
@@ -55,27 +55,14 @@ builtin function sync_write_after_read_device {
   }
 }
 
-function get_and_validate_stack_pointer {
+builtin function get_and_validate_stack_pointer {
   returns XReg
-  arguments Bits<INSTR_ENC_SIZE> encoding
+  arguments XReg sp, Bits<INSTR_ENC_SIZE> encoding
   description {
     Validate and return stack pointer.
 	Stack pointer is validated to fit in range, defined by qc.mstktopaddr and qc.mstkbottomaddr CSRs.
 	In case when stack pointer is out-of-range, raising exception SpOutOfRange.
 	Stack pointer is also validated to be 16-byte aligned.
 	In case when stack pointer is not 16-bytes aligned, raising exception IllegalStackPointer.
-  }
-  body {
-    XReg sp = X[2];
-    if (sp < CSR[qc.mstkbottomaddr]) {
-      raise(ExceptionCode::SpOutOfRange, mode(), encoding);
-    }
-    else if (sp > CSR[qc.mstktopaddr]) {
-      raise(ExceptionCode::SpOutOfRange, mode(), encoding);
-    }
-    else if (sp & 0xf != 0) {
-      raise(ExceptionCode::IllegalStackPointer, mode(), encoding);
-    }
-    return sp;
   }
 }


### PR DESCRIPTION
  changes:
    - Fix all push and pop instructions IDL code to take in consideration that xlen() returns bits and not bytes
    - Declare state of extension as "frozen"
 