### PR TITLE
Zcmp extension: fix IDL code

### DIFF
--- a/arch/inst/Zcmp/cm.pop.yaml
+++ b/arch/inst/Zcmp/cm.pop.yaml
@@ -41,7 +41,7 @@ operation(): |
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg size = xlen();
+  XReg size = xlen() / 8;
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
   XReg stack_aligned_adj = (nreg * 4 + 15) & ~0xF;
   XReg virtual_address_sp = X[2];

--- a/arch/inst/Zcmp/cm.popret.yaml
+++ b/arch/inst/Zcmp/cm.popret.yaml
@@ -41,7 +41,7 @@ operation(): |
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg size = xlen();
+  XReg size = xlen() / 8;
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
   XReg stack_aligned_adj = (nreg * 4 + 15) & ~0xF;
   XReg virtual_address_sp = X[2];

--- a/arch/inst/Zcmp/cm.popretz.yaml
+++ b/arch/inst/Zcmp/cm.popretz.yaml
@@ -41,7 +41,7 @@ operation(): |
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg size = xlen();
+  XReg size = xlen() / 8;
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
   XReg stack_aligned_adj = (nreg * 4 + 15) & ~0xF;
   XReg virtual_address_sp = X[2];

--- a/arch/inst/Zcmp/cm.push.yaml
+++ b/arch/inst/Zcmp/cm.push.yaml
@@ -42,7 +42,7 @@ operation(): |
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg size = xlen();
+  XReg size = xlen() / 8;
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
   XReg stack_aligned_adj = (nreg * 4 + 15) & ~0xF;
   XReg virtual_address_sp = X[2];


### PR DESCRIPTION
Need to take in account that xlen() returns bits and not bytes