### PR TITLE
Xqci/Xqccmp extensions: more fixes 

### DIFF
--- a/arch_overlay/qc_iu/ext/Xqccmp.yaml
+++ b/arch_overlay/qc_iu/ext/Xqccmp.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../../../../schemas/ext_schema.json
+# yaml-language-server: $schema=../../../schemas/ext_schema.json
 
 $schema: ext_schema.json#
 kind: extension
@@ -145,3 +145,8 @@ doc_license:
 company:
   name: Qualcomm Technologies, Inc.
   url: https://qualcomm.com
+conflicts:
+  anyOf:
+    - allOf: [C, D]
+    - Zcd
+    - Zcmp

--- a/arch_overlay/qc_iu/ext/Xqci.yaml
+++ b/arch_overlay/qc_iu/ext/Xqci.yaml
@@ -562,7 +562,3 @@ doc_license:
 company:
   name: Qualcomm Technologies, Inc.
   url: https://qualcomm.com
-conflicts:
-  anyOf:
-    - allOf: [C, D]
-    - Zcd

--- a/arch_overlay/qc_iu/ext/Xqcicm.yaml
+++ b/arch_overlay/qc_iu/ext/Xqcicm.yaml
@@ -32,6 +32,10 @@ versions:
 description: |
   The Xqcicm extension includes thirteen conditional move instructions.
 
+conflicts:
+  anyOf:
+    - allOf: [C, D]
+    - Zcd
 doc_license:
   name: Creative Commons Attribution 4.0 International License
   url: https://creativecommons.org/licenses/by/4.0/

--- a/arch_overlay/qc_iu/inst/C/c.slli.yaml
+++ b/arch_overlay/qc_iu/inst/C/c.slli.yaml
@@ -1,0 +1,3 @@
+hints:
+  - { $ref: inst/Xqci/qc.c.delay.yaml# }
+  - { $ref: inst/Xqci/qc.c.ptrace.yaml# }

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.mva01s.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.mva01s.yaml
@@ -7,14 +7,7 @@ long_name: Move two s0-s7 registers into a0-a1
 description: |
   This instruction moves r1s' into a0 and r2s' into a1. The execution is atomic, so it is not possible to observe state where only one of a0 or a1 have been updated.
   The encoding uses sreg number specifiers instead of xreg number specifiers to save encoding space. The mapping between them is specified in the pseudo-code below.
-definedBy:
-  allOf:
-    - not:
-        anyOf:
-          - allOf: [C, D]
-          - Zcd
-          - Zcmp
-    - Xqccmp
+definedBy: Xqccmp
 assembly: r1s, r2s
 encoding:
   match: 101011---11---10

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.mvsa01.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.mvsa01.yaml
@@ -9,14 +9,7 @@ description: |
   The execution is atomic, so it is not possible to observe state where only one of r1s' or r2s' has been updated.
   The encoding uses sreg number specifiers instead of xreg number specifiers to save encoding space.
   The mapping between them is specified in the pseudo-code below.
-definedBy:
-  allOf:
-    - not:
-        anyOf:
-          - allOf: [C, D]
-          - Zcd
-          - Zcmp
-    - Xqccmp
+definedBy: Xqccmp
 assembly: r1s, r2s
 encoding:
   match: 101011---01---10

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.pop.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.pop.yaml
@@ -14,14 +14,7 @@ description: |
   * it must be a multiple of 16 (bytes):
   ** for RV32 the allowed values are: 16, 32, 48, 64, 80, 96, 112
   ** for RV64 the allowed values are: 16, 32, 48, 64, 80, 96, 112, 128, 144, 160
-definedBy:
-  allOf:
-    - not:
-        anyOf:
-          - allOf: [C, D]
-          - Zcd
-          - Zcmp
-    - Xqccmp
+definedBy: Xqccmp
 assembly: reg_list, stack_adj
 encoding:
   match: 10111010------10

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popret.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popret.yaml
@@ -14,14 +14,7 @@ description: |
   * it must be a multiple of 16 (bytes):
   ** for RV32 the allowed values are: 16, 32, 48, 64, 80, 96, 112
   ** for RV64 the allowed values are: 16, 32, 48, 64, 80, 96, 112, 128, 144, 160
-definedBy:
-  allOf:
-    - not:
-        anyOf:
-          - allOf: [C, D]
-          - Zcd
-          - Zcmp
-    - Xqccmp
+definedBy: Xqccmp
 assembly: reg_list, stack_adj
 encoding:
   match: 10111110------10

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popretz.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popretz.yaml
@@ -14,14 +14,7 @@ description: |
   * it must be a multiple of 16 (bytes):
   ** for RV32 the allowed values are: 16, 32, 48, 64, 80, 96, 112
   ** for RV64 the allowed values are: 16, 32, 48, 64, 80, 96, 112, 128, 144, 160
-definedBy:
-  allOf:
-    - not:
-        anyOf:
-          - allOf: [C, D]
-          - Zcd
-          - Zcmp
-    - Xqccmp
+definedBy: Xqccmp
 assembly: reg_list, stack_adj
 encoding:
   match: 10111100------10

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.push.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.push.yaml
@@ -15,14 +15,7 @@ description: |
   * it must be a multiple of 16 (bytes):
   ** for RV32 the allowed values are: 16, 32, 48, 64, 80, 96, 112
   ** for RV64 the allowed values are: 16, 32, 48, 64, 80, 96, 112, 128, 144, 160
-definedBy:
-  allOf:
-    - not:
-        anyOf:
-          - allOf: [C, D]
-          - Zcd
-          - Zcmp
-    - Xqccmp
+definedBy: Xqccmp
 assembly: reg_list, -stack_adj
 encoding:
   match: 10111000------10

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.pushfp.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.pushfp.yaml
@@ -16,14 +16,7 @@ description: |
   * it must be a multiple of 16 (bytes):
   ** for RV32 the allowed values are: 16, 32, 48, 64, 80, 96, 112
   ** for RV64 the allowed values are: 16, 32, 48, 64, 80, 96, 112, 128, 144, 160
-definedBy:
-  allOf:
-    - not:
-        anyOf:
-          - allOf: [C, D]
-          - Zcd
-          - Zcmp
-    - Xqccmp
+definedBy: Xqccmp
 assembly: reg_list, -stack_adj
 encoding:
   match: 10111001------10

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.muliadd.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.muliadd.yaml
@@ -8,12 +8,9 @@ description: |
   Increments `rd` by the multiplication of `rs1` and an unsigned immediate
   Instruction encoded in CL instruction format.
 definedBy:
-  allOf:
-    - not:
-        anyOf:
-          - allOf: [C, D]
-          - Zcd
-    - anyOf: [Xqci, Xqciac]
+  anyOf:
+    - Xqci
+    - Xqciac
 base: 32
 encoding:
   match: 001-----------10
@@ -31,5 +28,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg orig_val = X[rd+8];
-  X[rd+8] = orig_val + (X[rs1+8] * uimm);
+  XReg reg = creg2reg(rd);
+  XReg orig_val = X[reg];
+  X[reg] = orig_val + (X[reg] * uimm);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.mveqz.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.mveqz.yaml
@@ -8,12 +8,9 @@ description: |
   Move `rs1` to `rd` if `rd` == 0, keep `rd` value otherwise
   Instruction encoded in CL instruction format.
 definedBy:
-  allOf:
-    - not:
-        anyOf:
-          - allOf: [C, D]
-          - Zcd
-    - anyOf: [Xqci, Xqcicm]
+  anyOf:
+    - Xqci
+    - Xqcicm
 base: 32
 encoding:
   match: 101011---00---10
@@ -29,5 +26,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg orig_val = X[rd+8];
-  X[rd+8] = (orig_val == 0) ? X[rs1+8] : orig_val;
+  XReg reg = creg2reg(rd);
+  XReg orig_val = X[reg];
+  X[reg] = (orig_val == 0) ? X[reg] : orig_val;


### PR DESCRIPTION
around extensions conflicts management, as well correct hint support for additional 16-bit instructions