### PR TITLE
Fix RORW operand and IDL

### DIFF
--- a/arch/inst/B/rorw.yaml
+++ b/arch/inst/B/rorw.yaml
@@ -15,7 +15,7 @@ base: 64
 encoding:
   match: 0110000----------101-----0111011
   variables:
-    - name: shamt
+    - name: rs2
       location: 24-20
     - name: rs1
       location: 19-15
@@ -33,7 +33,7 @@ operation(): |
   }
 
   XReg rs1_word = X[rs1][31:0];
-  XReg shamt = X[rs1][4:0];
+  XReg shamt = X[rs2][4:0];
 
   XReg unextended_result = (X[rs1] >> shamt) | (X[rs1] << (32 - shamt));
   X[rd] = {{32{unextended_result[31]}}, unextended_result};


### PR DESCRIPTION
The YAML for the RORW instruction has shamt as an operand. shamt is used as an immediate value, but the RORW instruction uses a register value. The RISC-V ISA specification shows the analogous RORW instruction's operand is named rs2, which is appropriate here.

Change RORW operand shamt to rs2.

Also, in the IDL for RORW, the shamt _value_ should be retrieved from rs2 (not rs1, as is done currently.

Fix the retrieval of the shamt value to come from rs2. 
closes #478 