### PR TITLE
arch_overlay/qc_iu: Fix bug in qc.c.muliadd/qc.c.mveqz

### DIFF
--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.muliadd.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.muliadd.yaml
@@ -29,5 +29,6 @@ access:
   vu: always
 operation(): |
   XReg reg = creg2reg(rd);
+  XReg src = creg2reg(rs1);
   XReg orig_val = X[reg];
-  X[reg] = orig_val + (X[reg] * uimm);
+  X[reg] = orig_val + (X[src] * uimm);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.mveqz.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.mveqz.yaml
@@ -27,5 +27,6 @@ access:
   vu: always
 operation(): |
   XReg reg = creg2reg(rd);
+  XReg src = creg2reg(rs1);
   XReg orig_val = X[reg];
-  X[reg] = (orig_val == 0) ? X[reg] : orig_val;
+  X[reg] = (orig_val == 0) ? X[src] : orig_val;


### PR DESCRIPTION
X[reg] with reg = creg2reg(rd) is used for accessing the source operand rs1.

I believe this is a bug.