### PR TITLE
Add CSR Definitions for Trigger Module Registers

### DIFF
--- a/arch/csr/hcontext.yaml
+++ b/arch/csr/hcontext.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: hcontext
+long_name: Hypervisor-mode context register
+address: 0x6A8
+priv_mode: S
+length: XLEN
+description: |
+  This optional register may be implemented only if the H extension is implemented. 
+  If it is implemented, mcontext must also be implemented. 
+  
+  This register is only accessible in HS-Mode, M-mode and Debug Mode. If Smstateen is implemented, 
+  then accessibility of in HS-Mode is controlled by mstateenzero[57].
+
+  This register is an alias of the mcontext register, providing access to the hcontext field from HS-Mode.
+
+definedBy: Sdtrig

--- a/arch/csr/mcontext.yaml
+++ b/arch/csr/mcontext.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: mcontext
+long_name: Machine-mode context register
+address: 0x7A8
+priv_mode: M
+length: XLEN
+description: |
+  This register must be implemented if hcontext is implemented, and is optional otherwise. 
+  It is only accessible in M-mode and Debug mode.
+
+  hcontext is primarily useful to set triggers on hypervisor systems that only fire when a 
+  given VM is executing. It is also useful in systems where M-Mode implements something like 
+  a hypervisor directly.
+
+  This CSR is read/write.
+
+definedBy: Sdtrig
+fields:
+  HCONTEXT:
+    location: 13-0
+    type: RW
+    description: |
+      M-Mode or HS-Mode (using hcontext) software can write a
+      context number to this register, which can be used to set
+      triggers that only fire in that specific context.
+      An implementation may tie any number of upper bits in
+      this field to 0. If the H extension is not implemented, it’s
+      recommended to implement 6 bits on RV32 and 13 bits on
+      RV64 (as visible through the mcontext register). If the H
+      extension is implemented, it’s recommended to
+      implement 7 bits on RV32 and 14 bits on RV64.
+      
+    reset_value: 0

--- a/arch/csr/scontext.yaml
+++ b/arch/csr/scontext.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: scontext
+long_name: Supervisor-mode context register
+address: 0x5A8
+priv_mode: S
+length: XLEN
+description: |
+  This optional register is only accessible in S/HS-mode, VS-mode, M-mode and Debug Mode.
+  Accessibility of this CSR is controlled by mstateenzero[57] and hstateenzero[57] in the 
+  Smstateen extension. Enabling scontext can be a security risk in a virtualized system 
+  with a hypervisor that does not swap scontext. 
+  
+  This CSR is read/write.
+
+definedBy: Sdtrig

--- a/arch/csr/tdata1.yaml
+++ b/arch/csr/tdata1.yaml
@@ -1,0 +1,79 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: tdata1
+long_name: First Debug/Trace trigger data register
+address: 0x7A1
+priv_mode: M
+length: XLEN
+description: |
+  This register provides access to the trigger selected by tselect. 
+  The reset values listed here apply to every underlying trigger.
+  
+  This register is optional if no triggers are implemented.
+  Writing 0 to this register must result in a trigger that is disabled. 
+  If this trigger supports multiple types, then the hardware should disable it 
+  by changing type to 15. 
+  
+  This CSR is read/write.
+
+definedBy: Sdtrig
+fields:
+  TYPE:
+    location_rv32: 21-18
+    location_rv64: 63-60
+    description: |
+      0 (none): There is no trigger at this tselect.
+      1 (legacy): The trigger is a legacy SiFive address match
+      trigger. These should not be implemented and aren’t
+      further documented here.
+      2 (mcontrol): The trigger is an address/data match trigger.
+      The remaining bits in this register act as described in
+      mcontrol.
+      3 (icount): The trigger is an instruction count trigger. The
+      remaining bits in this register act as described in icount.
+      4 (itrigger): The trigger is an interrupt trigger. The
+      remaining bits in this register act as described in itrigger.
+      5 (etrigger): The trigger is an exception trigger. The
+      remaining bits in this register act as described in etrigger.
+      6 (mcontrol6): The trigger is an address/data match
+      trigger. The remaining bits in this register act as described
+      in mcontrol6. This is similar to a type 2 trigger, but
+      provides additional functionality and should be used
+      instead of type 2 in newer implementations.
+      7 (tmexttrigger): The trigger is a trigger source external to
+      the TM. The remaining bits in this register act as described
+      in tmexttrigger.
+      12—14 (custom): These trigger types are available for non-
+      standard use.
+      15 (disabled): This trigger is disabled. In this state, tdata2
+      and tdata3 can be written with any value that is supported
+      for any of the types this trigger implements. The
+      remaining bits in this register, except for dmode, are
+      ignored.
+      Other values are reserved for future use.
+    reset_value: UNDEFINED_LEGAL
+  DMODE:
+    location_rv32: 17
+    location_rv64: 59
+    description: |
+      If type is 0, then this bit is hard-wired to 0.
+      0 (both): Both Debug and M-mode can write the tdata
+      registers at the selected tselect.
+      1 (dmode): Only Debug Mode can write the tdata registers
+      at the selected tselect. Writes from other modes are
+      ignored.
+      This bit is only writable from Debug Mode. In ordinary
+      use, external debuggers will always set this bit when
+      configuring a trigger. When clearing this bit, debuggers
+      should also set the action field (whose location depends on
+      type) to something other than 1.
+    reset_value: 0
+  DATA:
+    location_rv32: 16-0
+    location_rv64: 58-0
+    description: |
+      If type is 0, then this field is hard-wired to 0.
+      Trigger-specific data.
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/tdata2.yaml
+++ b/arch/csr/tdata2.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: tdata2
+long_name: Second Debug/Trace trigger data register
+address: 0x7A2
+priv_mode: M
+length: XLEN
+description: |
+  This register provides access to the trigger selected by tselect. 
+  The reset values listed here apply to every underlying trigger.
+  
+  Trigger-specific data. It is optional if no implemented triggers use it.
+  If the trigger is disabled, then this register can be written with any value 
+  supported by any of the trigger types supported by this trigger.
+  If XLEN is less than DXLEN, writes to this register are sign-extended. 
+  
+  This CSR is read/write.
+
+definedBy: Sdtrig

--- a/arch/csr/tdata3.yaml
+++ b/arch/csr/tdata3.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: tdata3
+long_name: Third Debug/Trace trigger data register
+address: 0x7A3
+priv_mode: M
+length: XLEN
+description: |
+  This register provides access to the trigger selected by tselect. 
+  The reset values listed here apply to every underlying trigger.
+  
+  Trigger-specific data. It is optional if no implemented triggers use it.
+  If the trigger is disabled, then this register can be written with any value 
+  supported by any of the trigger types supported by this trigger.
+  If XLEN is less than DXLEN, writes to this register are sign-extended. 
+  
+  This CSR is read/write.
+
+definedBy: Sdtrig

--- a/arch/csr/tselect.yaml
+++ b/arch/csr/tselect.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: tselect
+long_name: Debug/Trace trigger register select
+address: 0x7A0
+priv_mode: M
+length: XLEN
+description: |
+  This register determines which trigger is accessible through the other Trigger Module registers. 
+  
+  It is optional if no triggers are implemented. The set of accessible triggers must start at 0, 
+  and be contiguous. This register is WARL. Writes of values greater than or equal to the number of 
+  supported triggers may result in a different value in this register than what was written or may 
+  point to a trigger where type=0. 
+  
+  To verify that what they wrote is a valid index, debuggers can 
+  read back the value and check that tselect holds what they wrote and read tdata1 to see that type 
+  is non-zero. Since triggers can be used both by Debug Mode and M-mode, the external debugger must 
+  restore this register if it modifies it. 
+  
+  This CSR is read/write.
+
+definedBy: Sdtrig
+


### PR DESCRIPTION
This PR addresses Issue #81 by adding the missing CSR definitions for the following trigger module registers:
- tselect.yaml
- tdata1.yaml
- tdata2.yaml
- tdata3.yaml
- scontext.yaml
- mcontext.yaml
- hcontext.yaml