### PR TITLE
This commit adds the Zilsd extension, which improves code size and pe…

### DIFF
--- a/arch/ext/Zilsd.yaml
+++ b/arch/ext/Zilsd.yaml
@@ -1,0 +1,13 @@
+$schema: "ext_schema.json#"
+kind: extension
+name: Zilsd
+long_name: Load/Store Pair for RV32
+description: |
+  This specification adds load and store instructions using register pairs. It does so by reusing existing instruction encodings which are RV64-only. The specification defines 32-bit encodings.
+  Load and store instructions will use the same definition of even-odd pairs as defined by the Zdinx extension.
+  The extension improves static code density, by replacing two separate load or store instructions with a single one. In addition, it can provide a performance improvement for implementations that can make use of a wider than XLEN memory interface.
+type: unprivileged
+versions:
+  - version: "1.0"
+    state: ratified
+    ratification_date: "2025-02"

--- a/arch/inst/Zilsd/ld.yaml
+++ b/arch/inst/Zilsd/ld.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=../../../schemas/inst_schema.json
+
+$schema: "inst_schema.json#"
+kind: instruction
+name: ld
+long_name: Load doubleword to even/odd register pair
+description: |
+  Loads a 64-bit value into registers rd and rd+1. The effective address is obtained by adding
+  register rs1 to the sign-extended 12-bit offset.
+definedBy: Zilsd
+assembly: rd, offset(rs1)
+encoding:
+  match: -----------------011-----0000011
+  variables:
+    - name: rd
+      location: 11-7
+      not: [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31]
+    - name: rs1
+      location: 19-15
+    - name: imm
+      location: 31-20
+access:
+  s: always
+  u: always
+  vs: always
+  vu: always
+operation(): |
+  Bits<XLEN> base = X[rs1];
+  Bits<XLEN> offset = $signed(imm);
+  Bits<XLEN> eff_addr = base + offset;
+
+  Bits<64> data = read_memory<64>(eff_addr, $encoding);
+
+  X[rd] = data[31:0];
+  X[rd+1] = data[63:32];
+sail(): "" #not implemented in the sail model yet

--- a/arch/inst/Zilsd/sd.yaml
+++ b/arch/inst/Zilsd/sd.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=../../../schemas/inst_schema.json
+
+$schema: "inst_schema.json#"
+kind: instruction
+name: sd
+long_name: Store doubleword from even/odd register pair
+description: |
+  Stores a 64-bit value from registers rs2 and rs2+1. The effective address is obtained by adding
+  register rs1 to the sign-extended 12-bit offset.
+definedBy: Zilsd
+assembly: rs2, offset(rs1)
+encoding:
+  match: -----------------011-----0100011
+  variables:
+    - name: rs1
+      location: 19-15
+    - name: rs2
+      not: [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31]
+      location: 24-20
+    - name: imm
+      location: 31-25|11-7
+access:
+  s: always
+  u: always
+  vs: always
+  vu: always
+operation(): |
+  Bits<XLEN> base = X[rs1];
+  Bits<XLEN> offset = $signed(imm);
+  Bits<XLEN> eff_addr = base + offset;
+
+  Bits<32> lower_word = X[rs2];
+  Bits<32> upper_word = X[rs2 + 1];
+  Bits<64> store_data = {upper_word, lower_word};
+
+  write_memory<64>(eff_addr, store_data, $encoding);
+sail(): "" #not implemented in the sail model yet


### PR DESCRIPTION
…rformance by introducing load/store pair instructions for RV32. It includes 32-bit instructions (ld and sd) for loading and storing doublewords, as well as 16-bit compressed versions (c.ldsp, c.sdsp, c.ld, and c.sd) for more efficient memory access. These instructions work with even/odd register pairs, following the Zdinx extension, and ensure proper alignment for better performance. The extension was officially approved in February 2025 and helps reduce instruction count while making memory operations faster.
Closes #510 
Closes #511 