### PR TITLE
Xqci/Xqciint extension: move extension codes 

### DIFF
--- a/arch_overlay/qc_iu/ext/Xqciint.yaml
+++ b/arch_overlay/qc_iu/ext/Xqciint.yaml
@@ -90,3 +90,20 @@ doc_license:
 company:
   name: Qualcomm Technologies, Inc.
   url: https://qualcomm.com
+
+exception_codes:
+  - num: 27
+    name: Illegal Stack Pointer
+    var: IllegalStackPointer
+  - num: 28
+    name: Stack Pointer Out-Of-Range
+    var: SpOutOfRange
+  - num: 29
+    name: Execution Watchpoint
+    var: ExecWatchpoint
+  - num: 30
+    name: Read Watchpoint
+    var: ReadWatchpoint
+  - num: 31
+    name: Write Watchpoint
+    var: WriteWatchpoint

--- a/cfgs/qc_iu.yaml
+++ b/cfgs/qc_iu.yaml
@@ -21,22 +21,6 @@ implemented_extensions:
   - { name: Zihpm, version: "2.0" }
   - { name: Xqccmp, version: "0.3" }
   - { name: Xqci, version: "0.8" }
-exception_codes:
-  - num: 27
-    name: Illegal Stack Pointer
-    var: IllegalStackPointer
-  - num: 28
-    name: Stack Pointer Out-Of-Range
-    var: SpOutOfRange
-  - num: 29
-    name: Execution Watchpoint
-    var: ExecWatchpoint
-  - num: 30
-    name: Read Watchpoint
-    var: ReadWatchpoint
-  - num: 31
-    name: Write Watchpoint
-    var: WriteWatchpoint
 params:
   XLEN: 32
   PHYS_ADDR_WIDTH: 32


### PR DESCRIPTION
from cfgs/qc_iu to Xqciint extension.
currently supported only as part of extension.