### PR TITLE
Xqci Extension v0.9

### DIFF
--- a/arch_overlay/qc_iu/ext/Xqci.yaml
+++ b/arch_overlay/qc_iu/ext/Xqci.yaml
@@ -268,6 +268,43 @@ versions:
   requires:
     name: Zca
     version: ">= 1.0.0"
+- version: "0.9.0"
+  state: frozen
+  ratification_date: null
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  changes:
+    - Fix IDL code sign extension logic for qc.e.lb and qc.e.lh instructions
+    - Fix IDL code sign extension logic for qc.ext and qc.extd instructions
+    - Fix IDL code sign extension logic for qc.extdpr, qc.extdprh and qc.extdr instructions
+    - Fix IDL code sign extension logic for qc.lieq instruction
+  implies:
+  - { name: Xqcia, version: "0.5.0" }
+  - { name: Xqciac, version: "0.3.0" }
+  - { name: Xqcibi, version: "0.2.0" }
+  - { name: Xqcibm, version: "0.7.0" }
+  - { name: Xqcicli, version: "0.3.0" }
+  - { name: Xqcicm, version: "0.2.0" }
+  - { name: Xqcics, version: "0.2.0" }
+  - { name: Xqcicsr, version: "0.3.0" }
+  - { name: Xqciint, version: "0.5.0" }
+  - { name: Xqciio, version: "0.1.0" }
+  - { name: Xqcilb, version: "0.2.0" }
+  - { name: Xqcili, version: "0.2.0" }
+  - { name: Xqcilia, version: "0.2.0" }
+  - { name: Xqcilo, version: "0.3.0" }
+  - { name: Xqcilsm, version: "0.4.0" }
+  - { name: Xqcisim, version: "0.2.0" }
+  - { name: Xqcisls, version: "0.2.0" }
+  - { name: Xqcisync, version: "0.2.0" }
+  requires:
+    name: Zca
+    version: ">= 1.0.0"
 description: |
   The Xqci extension includes a set of instructions that improve RISC-V code density and
   performance in microontrollers. It fills several gaps:

--- a/arch_overlay/qc_iu/ext/Xqci.yaml
+++ b/arch_overlay/qc_iu/ext/Xqci.yaml
@@ -288,6 +288,7 @@ versions:
     - Fix IDL code sign extension logic for qc.lieq instruction
     - Fix wrong mantissa bit selection in qc.norm, qc.normu and qc.normeu instructions
     - Fix wrong exponent calculation in qc.normeu instruction
+    - Fix IDL code and description of qc.setwm instruction to state that number of words written 0..31.
   implies:
   - { name: Xqcia, version: "0.6.0" }
   - { name: Xqciac, version: "0.3.0" }
@@ -303,7 +304,7 @@ versions:
   - { name: Xqcili, version: "0.2.0" }
   - { name: Xqcilia, version: "0.2.0" }
   - { name: Xqcilo, version: "0.3.0" }
-  - { name: Xqcilsm, version: "0.4.0" }
+  - { name: Xqcilsm, version: "0.5.0" }
   - { name: Xqcisim, version: "0.2.0" }
   - { name: Xqcisls, version: "0.2.0" }
   - { name: Xqcisync, version: "0.2.0" }

--- a/arch_overlay/qc_iu/ext/Xqci.yaml
+++ b/arch_overlay/qc_iu/ext/Xqci.yaml
@@ -287,6 +287,7 @@ versions:
     - Fix IDL code and description increasing shift to 6 bit for qc.extdupr and qc.extduprh instructions
     - Fix IDL code sign extension logic for qc.lieq instruction
     - Fix wrong mantissa bit selection in qc.norm, qc.normu and qc.normeu instructions
+    - Fix wrong exponent calculation in qc.normeu instruction
   implies:
   - { name: Xqcia, version: "0.6.0" }
   - { name: Xqciac, version: "0.3.0" }

--- a/arch_overlay/qc_iu/ext/Xqci.yaml
+++ b/arch_overlay/qc_iu/ext/Xqci.yaml
@@ -289,6 +289,7 @@ versions:
     - Fix wrong mantissa bit selection in qc.norm, qc.normu and qc.normeu instructions
     - Fix wrong exponent calculation in qc.normeu instruction
     - Fix IDL code and description of qc.setwm instruction to state that number of words written 0..31.
+    - Fix IDL code for Smdbltrp and Smrnmi spec compatibility for qc.c.mret and qc.c.mnret instructions
   implies:
   - { name: Xqcia, version: "0.6.0" }
   - { name: Xqciac, version: "0.3.0" }
@@ -298,7 +299,7 @@ versions:
   - { name: Xqcicm, version: "0.2.0" }
   - { name: Xqcics, version: "0.2.0" }
   - { name: Xqcicsr, version: "0.3.0" }
-  - { name: Xqciint, version: "0.5.0" }
+  - { name: Xqciint, version: "0.6.0" }
   - { name: Xqciio, version: "0.1.0" }
   - { name: Xqcilb, version: "0.2.0" }
   - { name: Xqcili, version: "0.2.0" }

--- a/arch_overlay/qc_iu/ext/Xqci.yaml
+++ b/arch_overlay/qc_iu/ext/Xqci.yaml
@@ -286,8 +286,9 @@ versions:
     - Fix IDL code and description increasing shift to 6 bit for qc.extdpr and qc.extdprh instructions
     - Fix IDL code and description increasing shift to 6 bit for qc.extdupr and qc.extduprh instructions
     - Fix IDL code sign extension logic for qc.lieq instruction
+    - Fix wrong mantissa bit selection in qc.norm, qc.normu and qc.normeu instructions
   implies:
-  - { name: Xqcia, version: "0.5.0" }
+  - { name: Xqcia, version: "0.6.0" }
   - { name: Xqciac, version: "0.3.0" }
   - { name: Xqcibi, version: "0.2.0" }
   - { name: Xqcibm, version: "0.7.0" }

--- a/arch_overlay/qc_iu/ext/Xqci.yaml
+++ b/arch_overlay/qc_iu/ext/Xqci.yaml
@@ -282,6 +282,9 @@ versions:
     - Fix IDL code sign extension logic for qc.e.lb and qc.e.lh instructions
     - Fix IDL code sign extension logic for qc.ext and qc.extd instructions
     - Fix IDL code sign extension logic for qc.extdpr, qc.extdprh and qc.extdr instructions
+    - Fix IDL code and description increasing shift to 6 bit for qc.extdr and qc.extdur instructions
+    - Fix IDL code and description increasing shift to 6 bit for qc.extdpr and qc.extdprh instructions
+    - Fix IDL code and description increasing shift to 6 bit for qc.extdupr and qc.extduprh instructions
     - Fix IDL code sign extension logic for qc.lieq instruction
   implies:
   - { name: Xqcia, version: "0.5.0" }

--- a/arch_overlay/qc_iu/ext/Xqcia.yaml
+++ b/arch_overlay/qc_iu/ext/Xqcia.yaml
@@ -79,6 +79,7 @@ versions:
     email: dhower@qti.qualcomm.com
   changes:
     - Fix wrong mantissa bit selection in qc.norm, qc.normu and qc.normeu instructions
+    - Fix wrong exponent calculation in qc.normeu instruction
 description: |
   The Xqcia extension includes eleven instructions to perform integer arithmetic.
 

--- a/arch_overlay/qc_iu/ext/Xqcia.yaml
+++ b/arch_overlay/qc_iu/ext/Xqcia.yaml
@@ -67,6 +67,18 @@ versions:
     - Fix typos in description of qc.shlsat and qc.shlusat instructions
     - Fix bug in qc.shlsat that caused wrong IDL code result
     - Fix clobbering of saturation results in [add|addu|sub]sat instructions
+- version: "0.6.0"
+  state: frozen
+  ratification_date: null
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  changes:
+    - Fix wrong mantissa bit selection in qc.norm, qc.normu and qc.normeu instructions
 description: |
   The Xqcia extension includes eleven instructions to perform integer arithmetic.
 

--- a/arch_overlay/qc_iu/ext/Xqcibm.yaml
+++ b/arch_overlay/qc_iu/ext/Xqcibm.yaml
@@ -88,6 +88,20 @@ versions:
     - Fix IDL code and description to look correct in PDF for qc.insbhr and qc.insbh instructions
     - Fix IDL code to to match description for qc.insbr instruction
   requires: { name: Zca, version: ">= 1.0.0" }
+- version: "0.7.0"
+  state: frozen
+  ratification_date: null
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  changes:
+    - Fix IDL code sign extension logic for qc.ext and qc.extd instructions
+    - Fix IDL code sign extension logic for qc.extdpr, qc.extdprh and qc.extdr instructions
+  requires: { name: Zca, version: ">= 1.0.0" }
 description: |
   The Xqcibm extension includes thirty eight instructions that perform bit manipulation,
   include insertion and extraction.

--- a/arch_overlay/qc_iu/ext/Xqcibm.yaml
+++ b/arch_overlay/qc_iu/ext/Xqcibm.yaml
@@ -101,6 +101,9 @@ versions:
   changes:
     - Fix IDL code sign extension logic for qc.ext and qc.extd instructions
     - Fix IDL code sign extension logic for qc.extdpr, qc.extdprh and qc.extdr instructions
+    - Fix IDL code and description increasing shift to 6 bit for qc.extdr and qc.extdur instructions
+    - Fix IDL code and description increasing shift to 6 bit for qc.extdpr and qc.extdprh instructions
+    - Fix IDL code and description increasing shift to 6 bit for qc.extdupr and qc.extduprh instructions
   requires: { name: Zca, version: ">= 1.0.0" }
 description: |
   The Xqcibm extension includes thirty eight instructions that perform bit manipulation,

--- a/arch_overlay/qc_iu/ext/Xqcicli.yaml
+++ b/arch_overlay/qc_iu/ext/Xqcicli.yaml
@@ -28,6 +28,18 @@ versions:
     email: dhower@qti.qualcomm.com
   changes:
     - Add information about instruction formats of each instruction
+- version: "0.3.0"
+  state: frozen
+  ratification_date: null
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  changes:
+    - Fix IDL code sign extension logic for qc.lieq instruction
 description: |
   The Xqcicli extension includes twelve instructions that conditionally
   load an immediate value.

--- a/arch_overlay/qc_iu/ext/Xqciint.yaml
+++ b/arch_overlay/qc_iu/ext/Xqciint.yaml
@@ -80,6 +80,19 @@ versions:
   changes:
     - Add stack checks to qc.c.mienter, qc.c.mienter.nest, qc.c.mileaveret
   requires: { name: Zca, version: ">= 1.0.0" }
+- version: "0.6.0"
+  state: frozen
+  ratification_date: null
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  changes:
+    - Fix IDL code for Smdbltrp and Smrnmi spec compatibility for qc.c.mret and qc.c.mnret instructions
+  requires: { name: Zca, version: ">= 1.0.0" }
 description: |
   The Xqciint extension includes eleven instructions to accelerate interrupt
   servicing by performing common actions during ISR prologue/epilogue.

--- a/arch_overlay/qc_iu/ext/Xqcilo.yaml
+++ b/arch_overlay/qc_iu/ext/Xqcilo.yaml
@@ -29,6 +29,18 @@ versions:
   changes:
     - Add information about instruction formats of each instruction
   requires: { name: Zca, version: ">= 1.0.0" }
+- version: "0.3.0"
+  state: frozen
+  ratification_date: null
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  changes:
+    - Fix IDL code sign extension logic for qc.e.lb and qc.e.lh instructions
 description: |
   The Xqcilo extension includes eight 48-bit load/stores instructions that use an offset
   larger than can be found in the base RISC-V ISA.

--- a/arch_overlay/qc_iu/ext/Xqcilsm.yaml
+++ b/arch_overlay/qc_iu/ext/Xqcilsm.yaml
@@ -52,6 +52,18 @@ versions:
     email: dhower@qti.qualcomm.com
   changes:
     - Fix encoding of qc.swmi
+- version: "0.5.0"
+  state: frozen
+  ratification_date: null
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  changes:
+    - Fix IDL code and description of qc.setwm instruction to state that number of words written 0..31.
 description: |
   The Xqcilsm extension includes six instructions that transfer multiple values
   between registers and memory.

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.mnret.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.mnret.yaml
@@ -30,6 +30,12 @@ operation(): |
   CSR[qc.mcause].sw_write(qc_mcause_val_masked |
                           (1<<28) | (mnpie_val<<26) | (1<<30) |
                           (mnpil_val << 12) | (0xF << 20));
+  if (CSR[mnstatus].MNPP != 2'b11) {
+    CSR[mstatus].MPRV = 0;
+    if (implemented?(ExtensionName::Smdbltrp)) {
+      CSR[mstatush].MDT = 1'b0;
+    }
+  }
   if (CSR[mnstatus].MNPP == 2'b00) {
     set_mode(PrivilegeMode::U);
   } else if (CSR[mnstatus].MNPP == 2'b01) {

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.mret.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.mret.yaml
@@ -28,11 +28,16 @@ operation(): |
   Bits<4> mpil_val = (qc_mcause_val >> 16) & 0xF;
   CSR[mstatus].MIE = mpie_val;
   CSR[mstatus].MPIE = 1'b1;
-  CSR[mstatush].MDT = mpdt_val;
+  if (implemented?(ExtensionName::Smdbltrp)) {
+    CSR[mstatush].MDT = mpdt_val;
+  }
   CSR[qc.mcause].sw_write(qc_mcause_val_masked |
                           (1<<27) | (mpie_val<<26) | (0<<29) |
                           (mpil_val << 12) | (0xF << 16));
   if (mpdt_val == 1'b0) {
+    if (CSR[mstatus].MPP != 2'b11) {
+      CSR[mstatus].MPRV = 0;
+    }
     if (CSR[mstatus].MPP == 2'b00) {
       set_mode(PrivilegeMode::U);
     } else if (CSR[mstatus].MPP == 2'b01) {

--- a/arch_overlay/qc_iu/inst/Xqci/qc.e.lb.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.e.lb.yaml
@@ -31,4 +31,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[rs1] + imm;
-  X[rd] = sext(read_memory<8>(virtual_address, $encoding), 7);
+  X[rd] = sext(read_memory<8>(virtual_address, $encoding), 8);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.e.lh.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.e.lh.yaml
@@ -31,4 +31,4 @@ access:
   vu: always
 operation(): |
   XReg virtual_address = X[rs1] + imm;
-  X[rd] = sext(read_memory<16>(virtual_address, $encoding), 15);
+  X[rd] = sext(read_memory<16>(virtual_address, $encoding), 16);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.ext.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.ext.yaml
@@ -36,4 +36,4 @@ access:
 operation(): |
   XReg width = width_minus1 + 1;
   XReg unsigned_extraction = (X[rs1] >> shamt) & ((1 << width) - 1);
-  X[rd] = sext(unsigned_extraction, width_minus1);
+  X[rd] = sext(unsigned_extraction, width);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extd.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extd.yaml
@@ -36,4 +36,4 @@ access:
 operation(): |
   Bits<{1'b0, XLEN}*2> pair = {X[rs1 + 1], X[rs1]};
   XReg width = width_minus1 + 1;
-  X[rd] = sext((pair >> shamt) & ((1 << width) - 1), width_minus1);
+  X[rd] = sext((pair >> shamt) & ((1 << width) - 1), width);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extdpr.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extdpr.yaml
@@ -7,7 +7,7 @@ long_name: Extract bits from pair signed, packed descriptor (Register)
 description: |
   Extract a subset of bits from the register pair [`rs1`, `rs1`+1] into `rd`, and sign extend the result.
   The width of the subset is determined by `rs2` bits [13:8] (0..32),
-  and the offset of the subset is determined by `rs2` bits [4:0].
+  and the offset of the subset is determined by `rs2` bits [5:0] (0..63).
   In case when `rs2` bit [13] == 1 width is enforced to 32.
   In case when width == 0, to the destination register written 0.
   Instruction encoded in R instruction format.
@@ -38,7 +38,7 @@ operation(): |
   Bits<{1'b0, XLEN}*2> pair = {X[rs1 + 1], X[rs1]};
   XReg width_bits = X[rs2][13:8];
   XReg width = (width_bits > 32) ? 32 : width_bits;
-  XReg shamt = X[rs2][4:0];
+  XReg shamt = X[rs2][5:0];
   if (width > 0) {
     X[rd] = sext((pair >> shamt) & ((1 << width) - 1), width);
   } else {

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extdpr.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extdpr.yaml
@@ -40,7 +40,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][4:0];
   if (width > 0) {
-    X[rd] = sext((pair >> shamt) & ((1 << width) - 1), width - 1);
+    X[rd] = sext((pair >> shamt) & ((1 << width) - 1), width);
   } else {
     X[rd] = 0;
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extdprh.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extdprh.yaml
@@ -7,7 +7,7 @@ long_name: Extract bits from pair signed, packed descriptor high part (Register)
 description: |
   Extract a subset of bits from the register pair [`rs1`, `rs1`+1] into `rd`, and sign extend the result.
   The width of the subset is determined by `rs2` bits [29:24] (0..32),
-  and the offset of the subset is determined by `rs2` bits [20:16].
+  and the offset of the subset is determined by `rs2` bits [21:16] (0..63).
   In case when `rs2` bit [29] == 1 width is enforced to 32.
   In case when width == 0, to the destination register written 0.
   Instruction encoded in R instruction format.
@@ -38,7 +38,7 @@ operation(): |
   Bits<{1'b0, XLEN}*2> pair = {X[rs1 + 1], X[rs1]};
   XReg width_bits = X[rs2][29:24];
   XReg width = (width_bits > 32) ? 32 : width_bits;
-  XReg shamt = X[rs2][20:16];
+  XReg shamt = X[rs2][21:16];
   if (width > 0) {
     X[rd] = sext((pair >> shamt) & ((1 << width) - 1), width);
   } else {

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extdprh.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extdprh.yaml
@@ -40,7 +40,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][20:16];
   if (width > 0) {
-    X[rd] = sext((pair >> shamt) & ((1 << width) - 1), width - 1);
+    X[rd] = sext((pair >> shamt) & ((1 << width) - 1), width);
   } else {
     X[rd] = 0;
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extdr.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extdr.yaml
@@ -7,7 +7,7 @@ long_name: Extract bits from pair signed (Register)
 description: |
   Extract a subset of bits from the register pair [`rs1`, `rs1`+1] into `rd`, and sign extend the result.
   The width of the subset is determined by `rs2` bits [21:16] (0..32),
-  and the offset of the subset is determined by `rs2` bits [4:0].
+  and the offset of the subset is determined by `rs2` bits [5:0] (0..63).
   In case when `rs2` bit [21] == 1 width is enforced to 32.
   In case when width == 0, to the destination register written 0.
   Instruction encoded in R instruction format.
@@ -38,7 +38,7 @@ operation(): |
   Bits<{1'b0, XLEN}*2> pair = {X[rs1 + 1], X[rs1]};
   XReg width_bits = X[rs2][21:16];
   XReg width = (width_bits > 32) ? 32 : width_bits;
-  XReg shamt = X[rs2][4:0];
+  XReg shamt = X[rs2][5:0];
   if (width > 0) {
     X[rd] = sext((pair >> shamt) & ((1 << width) - 1), width);
   } else {

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extdr.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extdr.yaml
@@ -40,7 +40,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][4:0];
   if (width > 0) {
-    X[rd] = sext((pair >> shamt) & ((1 << width) - 1), width - 1);
+    X[rd] = sext((pair >> shamt) & ((1 << width) - 1), width);
   } else {
     X[rd] = 0;
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extdupr.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extdupr.yaml
@@ -7,7 +7,7 @@ long_name: Extract bits from pair unsigned, packed descriptor (Register)
 description: |
   Extract a subset of bits from the register pair [`rs1`, `rs1`+1] into `rd`.
   The width of the subset is determined by `rs2` bits [13:8] (0..32),
-  and the offset of the subset is determined by `rs2` bits [4:0].
+  and the offset of the subset is determined by `rs2` bits [5:0] (0..63).
   In case when `rs2` bit [13] == 1 width is enforced to 32.
   In case when width == 0, to the destination register written 0.
   Instruction encoded in R instruction format.
@@ -38,7 +38,7 @@ operation(): |
   Bits<{1'b0, XLEN}*2> pair = {X[rs1 + 1], X[rs1]};
   XReg width_bits = X[rs2][13:8];
   XReg width = (width_bits > 32) ? 32 : width_bits;
-  XReg shamt = X[rs2][4:0];
+  XReg shamt = X[rs2][5:0];
   if (width > 0) {
     X[rd] = (pair >> shamt) & ((1 << width) - 1);
   } else {

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extduprh.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extduprh.yaml
@@ -7,7 +7,7 @@ long_name: Extract bits from pair unsigned, packed descriptor high part (Registe
 description: |
   Extract a subset of bits from the register pair [`rs1`, `rs1`+1] into `rd`.
   The width of the subset is determined by `rs2` bits [29:24] (0..32),
-  and the offset of the subset is determined by `rs2` bits [20:16].
+  and the offset of the subset is determined by `rs2` bits [21:16] (0..63).
   In case when `rs2` bit [29] == 1 width is enforced to 32.
   In case when width == 0, to the destination register written 0.
   Instruction encoded in R instruction format.
@@ -38,7 +38,7 @@ operation(): |
   Bits<{1'b0, XLEN}*2> pair = {X[rs1 + 1], X[rs1]};
   XReg width_bits = X[rs2][29:24];
   XReg width = (width_bits > 32) ? 32 : width_bits;
-  XReg shamt = X[rs2][20:16];
+  XReg shamt = X[rs2][21:16];
   if (width > 0) {
     X[rd] = (pair >> shamt) & ((1 << width) - 1);
   } else {

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extdur.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extdur.yaml
@@ -7,7 +7,7 @@ long_name: Extract bits from pair unsigned (Register)
 description: |
   Extract a subset of bits from the register pair [`rs1`, `rs1`+1] into `rd`.
   The width of the subset is determined by `rs2` bits [21:16] (0..32),
-  and the offset of the subset is determined by `rs2` bits [4:0].
+  and the offset of the subset is determined by `rs2` bits [5:0] (0..63).
   In case when `rs2` bit [21] == 1 width is enforced to 32.
   In case when width == 0, to the destination register written 0.
   Instruction encoded in R instruction format.
@@ -38,7 +38,7 @@ operation(): |
   Bits<{1'b0, XLEN}*2> pair = {X[rs1 + 1], X[rs1]};
   XReg width_bits = X[rs2][21:16];
   XReg width = (width_bits > 32) ? 32 : width_bits;
-  XReg shamt = X[rs2][4:0];
+  XReg shamt = X[rs2][5:0];
   if (width > 0) {
     X[rd] = (pair >> shamt) & ((1 << width) - 1);
   } else {

--- a/arch_overlay/qc_iu/inst/Xqci/qc.lieq.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.lieq.yaml
@@ -34,5 +34,5 @@ access:
   vu: always
 operation(): |
   if (X[rs1] == X[rs2]) {
-    X[rd] = sext(simm, 20);
+    X[rd] = sext(simm, 5);
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.norm.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.norm.yaml
@@ -35,4 +35,4 @@ operation(): |
   XReg clo = (xlen() - 1) - $signed(highest_set_bit(~X[rs1]));
   XReg mnt = (X[rs1][31] == 1) ? (X[rs1] << (clo - 1)) : (X[rs1] << (clz - 1));
   XReg exp = (X[rs1][31] == 1) ? (-(clo - 1)) : (-(clz - 1));
-  X[rd] = {mnt[23:0],exp[7:0]};
+  X[rd] = {mnt[31:8],exp[7:0]};

--- a/arch_overlay/qc_iu/inst/Xqci/qc.normeu.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.normeu.yaml
@@ -33,5 +33,5 @@ access:
 operation(): |
   XReg clz = ((xlen() - 1) - $signed(highest_set_bit(X[rs1]))) & ~1;
   XReg mnt = (X[rs1] << (clz & ~1));
-  XReg exp = ((-clz) & ~1);
+  XReg exp =  (-(clz & ~1));
   X[rd] = {mnt[31:8],exp[7:0]};

--- a/arch_overlay/qc_iu/inst/Xqci/qc.normeu.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.normeu.yaml
@@ -34,4 +34,4 @@ operation(): |
   XReg clz = ((xlen() - 1) - $signed(highest_set_bit(X[rs1]))) & ~1;
   XReg mnt = (X[rs1] << (clz & ~1));
   XReg exp = ((-clz) & ~1);
-  X[rd] = {mnt[23:0],exp[7:0]};
+  X[rd] = {mnt[31:8],exp[7:0]};

--- a/arch_overlay/qc_iu/inst/Xqci/qc.normu.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.normu.yaml
@@ -34,4 +34,4 @@ operation(): |
   XReg clz = (xlen() - 1) - $signed(highest_set_bit(X[rs1]));
   XReg mnt = (X[rs1] << clz);
   XReg exp = (-clz);
-  X[rd] = {mnt[23:0],exp[7:0]};
+  X[rd] = {mnt[31:8],exp[7:0]};

--- a/arch_overlay/qc_iu/inst/Xqci/qc.setwm.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.setwm.yaml
@@ -6,7 +6,7 @@ name: qc.setwm
 long_name: Set word multiple (Register)
 description: |
   Stores the value of `rs3` multiple times into the address starting at (`rs1` + `imm`).
-  The number of writes is in `rs2`.
+  The number of writes is in `rs2` bits [4:0] (0..31).
   Instruction encoded in R instruction format.
 definedBy:
   anyOf:
@@ -35,7 +35,7 @@ access:
 operation(): |
   XReg vaddr = X[rs1] + imm;
   Bits<32> write_value = X[rs3][31:0];
-  XReg num_words = X[rs2];
+  XReg num_words = X[rs2][4:0];
   for (U32 i = 0; i < num_words; i++) {
     write_memory<32>(vaddr, write_value, $encoding);
     vaddr = vaddr + 4;


### PR DESCRIPTION
  changes:
    - Fix IDL code sign extension logic for qc.e.lb and qc.e.lh instructions
    - Fix IDL code sign extension logic for qc.ext and qc.extd instructions
    - Fix IDL code sign extension logic for qc.extdpr, qc.extdprh and qc.extdr instructions
    - Fix IDL code and description increasing shift to 6 bit for qc.extdr and qc.extdur instructions
    - Fix IDL code and description increasing shift to 6 bit for qc.extdpr and qc.extdprh instructions
    - Fix IDL code and description increasing shift to 6 bit for qc.extdupr and qc.extduprh instructions
    - Fix IDL code sign extension logic for qc.lieq instruction
    - Fix wrong mantissa bit selection in qc.norm, qc.normu and qc.normeu instructions
    - Fix wrong exponent calculation in qc.normeu instruction
    - Fix IDL code and description of qc.setwm instruction to state that number of words written 0..31.
    - Fix IDL code for Smdbltrp and Smrnmi spec compatibility for qc.c.mret and qc.c.mnret instructions
 