### PR TITLE
Add Smstateen/Ssstateen Extension and CSRs

### DIFF
--- a/arch/csr/hstateen0.yaml
+++ b/arch/csr/hstateen0.yaml
@@ -1,0 +1,100 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: hstateen0
+long_name: Hypervisor State Enable 0 Register
+address: 0x60C
+priv_mode: S
+length: 64
+description: |
+  For each hstateen CSR, bit 63 is defined to control access to the matching sstateen CSR.
+  Bit 63 of hstateen0 controls access to sstateen0.
+
+  With the hypervisor extension, the hstateen CSRs have identical encodings to the mstateen
+  CSRs, except controlling accesses for a virtual machine (from VS and VU modes).
+
+  For every bit in an hstateen CSR that is zero (whether read-only zero or set to zero),
+  the same bit appears as read-only zero in sstateen when accessed in VS-mode.
+
+  A bit in an hstateen CSR cannot be read-only one unless the same bit is read-only one
+  in the matching mstateen CSR.
+
+definedBy:
+  allOf:
+    - H
+    - Smstateen
+    - Ssstateen
+fields:
+  SEO:
+    location: 63
+    description: |
+      The SE0 bit in hstateen0 controls access to the sstateen0 CSR.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  ENVCFG:
+    location: 62
+    description: |
+      The ENVCFG bit in hstateen0 controls access to the senvcfg CSRs.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  CSRIND:
+    location: 60
+    description: |
+      The CSRIND bit in hstateen0 controls access to the siselect and the
+      sireg*, (really vsiselect and vsireg*) CSRs provided by the Sscsrind
+      extensions.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  AIA:
+    location: 59
+    description: |
+      The AIA bit in hstateen0 controls access to all state introduced by
+      the Ssaia extension and is not controlled by either the CSRIND or the
+      IMSIC bits of hstateen0.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  IMSIC:
+    location: 58
+    description: |
+      The IMSIC bit in hstateen0 controls access to the guest IMSIC state,
+      including CSRs stopei (really vstopei), provided by the Ssaia extension.
+
+      Setting the IMSIC bit in hstateen0 to zero prevents a virtual machine
+      from accessing the hart’s IMSIC the same as setting `hstatus.`VGEIN = 0.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  CONTEXT:
+    location: 57
+    description: |
+      The CONTEXT bit in hstateen0 controls access to the scontext CSR provided
+      by the Sdtrig extension.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  JVT:
+    location: 2
+    description: |
+      The JVT bit controls access to the jvt CSR provided by the Zcmt extension.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  FCSR:
+    location: 1
+    description: |
+      The FCSR bit controls access to fcsr for the case when floating-point instructions
+      operate on x registers instead of f registers as specified by the Zfinx and related
+      extensions (Zdinx, etc.). Whenever misa.F = 1, FCSR bit of mstateen0 is read-only
+      zero (and hence read-only zero in hstateen0 and sstateen0 too). For convenience,
+      when the stateen CSRs are implemented and misa.F = 0, then if the FCSR bit of a
+      controlling stateen0 CSR is zero, all floating-point instructions cause an illegal
+      instruction trap (or virtual instruction trap, if relevant), as though they all access
+      fcsr, regardless of whether they really do.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  C:
+    location: 0
+    description: |
+      The C bit controls access to any and all custom state. This bit is not custom state itself.
+      The C bit of these registers is not custom state itself; it is a standard field of a
+      standard CSR, either mstateen0, hstateen0, or sstateen0.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/hstateen0h.yaml
+++ b/arch/csr/hstateen0h.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: hstateen0h
+long_name: Upper 32 bits of Hypervisor State Enable 0 Register
+address: 0x61C
+priv_mode: S
+length: 32
+description: |
+  For RV64 harts, the Smstateen/Ssstateen extension adds four new 64-bit CSRs at machine level: mstateen0 (Machine State Enable 0),
+  mstateen1, mstateen2, and mstateen3. If supervisor mode is implemented, another four CSRs are defined at
+  supervisor level: sstateen0, sstateen1, sstateen2, and sstateen3. And if the hypervisor extension is implemented,
+  another set of CSRs is added: hstateen0, hstateen1, hstateen2, and hstateen3.
+
+  For RV32, the registers listed above are 32-bit, and for the machine-level and hypervisor CSRs there is a corresponding
+  set of high-half CSRs for the upper 32 bits of each register: mstateen0h, mstateen1h, mstateen2h, mstateen3h, hstateen0h,
+  hstateen1h, hstateen2h, and hstateen3h.
+
+definedBy:
+  allOf:
+    - H
+    - Smstateen
+    - Ssstateen
+fields:
+  SEO:
+    location: 31
+    description: |
+      The SE0 bit in hstateen0h controls access to the sstateen0 CSR.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  ENVCFG:
+    location: 30
+    description: |
+      The ENVCFG bit in hstateen0h controls access to the senvcfg CSRs.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  CSRIND:
+    location: 28
+    description: |
+      The CSRIND bit in hstateen0h controls access to the siselect and the
+      sireg*, (really vsiselect and vsireg*) CSRs provided by the Sscsrind
+      extensions.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  AIA:
+    location: 27
+    description: |
+      The AIA bit in hstateen0h controls access to all state introduced by
+      the Ssaia extension and is not controlled by either the CSRIND or the
+      IMSIC bits of hstateen0.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  IMSIC:
+    location: 26
+    description: |
+      The IMSIC bit in hstateen0h controls access to the guest IMSIC state,
+      including CSRs stopei (really vstopei), provided by the Ssaia extension.
+
+      Setting the IMSIC bit in hstateen0h to zero prevents a virtual machine
+      from accessing the hart’s IMSIC the same as setting `hstatus.`VGEIN = 0.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  CONTEXT:
+    location: 25
+    description: |
+      The CONTEXT bit in hstateen0h controls access to the scontext CSR provided
+      by the Sdtrig extension.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/hstateen1.yaml
+++ b/arch/csr/hstateen1.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: hstateen1
+long_name: Hypervisor State Enable 1 Register
+address: 0x60D
+priv_mode: S
+length: 64
+description: |
+  For each hstateen CSR, bit 63 is defined to control access to the matching sstateen CSR.
+  Bit 63 of hstateen1 controls access to sstateen1.
+
+  With the hypervisor extension, the hstateen CSRs have identical encodings to the mstateen
+  CSRs, except controlling accesses for a virtual machine (from VS and VU modes).
+
+  For every bit in an hstateen CSR that is zero (whether read-only zero or set to zero),
+  the same bit appears as read-only zero in sstateen when accessed in VS-mode.
+
+  A bit in an hstateen CSR cannot be read-only one unless the same bit is read-only one
+  in the matching mstateen CSR.
+
+definedBy:
+  allOf:
+    - H
+    - Smstateen
+    - Ssstateen
+fields:
+  SEO:
+    location: 63
+    description: |
+      The SE0 bit in hstateen1 controls access to the sstateen1 CSR.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/hstateen1h.yaml
+++ b/arch/csr/hstateen1h.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: hstateen1h
+long_name: Upper 32 bits of Hypervisor State Enable 1 Register
+address: 0x61D
+priv_mode: S
+length: 32
+description: |
+  For RV64 harts, the Smstateen/Ssstateen extension adds four new 64-bit CSRs at machine level: mstateen0 (Machine State Enable 0),
+  mstateen1, mstateen2, and mstateen3. If supervisor mode is implemented, another four CSRs are defined at
+  supervisor level: sstateen0, sstateen1, sstateen2, and sstateen3. And if the hypervisor extension is implemented,
+  another set of CSRs is added: hstateen0, hstateen1, hstateen2, and hstateen3.
+
+  For RV32, the registers listed above are 32-bit, and for the machine-level and hypervisor CSRs there is a corresponding
+  set of high-half CSRs for the upper 32 bits of each register: mstateen0h, mstateen1h, mstateen2h, mstateen3h, hstateen0h,
+  hstateen1h, hstateen2h, and hstateen3h.
+
+definedBy:
+  allOf:
+    - H
+    - Smstateen
+    - Ssstateen
+fields:
+  SEO:
+    location: 31
+    description: |
+      The SE0 bit in hstateen1h controls access to the sstateen1 CSR.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/hstateen2.yaml
+++ b/arch/csr/hstateen2.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: hstateen2
+long_name: Hypervisor State Enable 2 Register
+address: 0x60E
+priv_mode: S
+length: 64
+description: |
+  For each hstateen CSR, bit 63 is defined to control access to the matching sstateen CSR.
+  Bit 63 of hstateen2 controls access to sstateen2.
+
+  With the hypervisor extension, the hstateen CSRs have identical encodings to the mstateen
+  CSRs, except controlling accesses for a virtual machine (from VS and VU modes).
+
+  For every bit in an hstateen CSR that is zero (whether read-only zero or set to zero),
+  the same bit appears as read-only zero in sstateen when accessed in VS-mode.
+
+  A bit in an hstateen CSR cannot be read-only one unless the same bit is read-only one
+  in the matching mstateen CSR.
+
+definedBy:
+  allOf:
+    - H
+    - Smstateen
+    - Ssstateen
+fields:
+  SEO:
+    location: 63
+    description: |
+      The SE0 bit in hstateen2 controls access to the sstateen2 CSR.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/hstateen2h.yaml
+++ b/arch/csr/hstateen2h.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: hstateen2h
+long_name: Upper 32 bits of Hypervisor State Enable 2 Register
+address: 0x61E
+priv_mode: S
+length: 32
+description: |
+  For RV64 harts, the Smstateen/Ssstateen extension adds four new 64-bit CSRs at machine level: mstateen0 (Machine State Enable 0),
+  mstateen1, mstateen2, and mstateen3. If supervisor mode is implemented, another four CSRs are defined at
+  supervisor level: sstateen0, sstateen1, sstateen2, and sstateen3. And if the hypervisor extension is implemented,
+  another set of CSRs is added: hstateen0, hstateen1, hstateen2, and hstateen3.
+
+  For RV32, the registers listed above are 32-bit, and for the machine-level and hypervisor CSRs there is a corresponding
+  set of high-half CSRs for the upper 32 bits of each register: mstateen0h, mstateen1h, mstateen2h, mstateen3h, hstateen0h,
+  hstateen1h, hstateen2h, and hstateen3h.
+
+definedBy:
+  allOf:
+    - H
+    - Smstateen
+    - Ssstateen
+fields:
+  SEO:
+    location: 31
+    description: |
+      The SE0 bit in hstateen2h controls access to the sstateen2 CSR.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/hstateen3.yaml
+++ b/arch/csr/hstateen3.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: hstateen3
+long_name: Hypervisor State Enable 3 Register
+address: 0x60F
+priv_mode: S
+length: 64
+description: |
+  For each hstateen CSR, bit 63 is defined to control access to the matching sstateen CSR.
+  Bit 63 of hstateen3 controls access to sstateen3.
+
+  With the hypervisor extension, the hstateen CSRs have identical encodings to the mstateen
+  CSRs, except controlling accesses for a virtual machine (from VS and VU modes).
+
+  For every bit in an hstateen CSR that is zero (whether read-only zero or set to zero),
+  the same bit appears as read-only zero in sstateen when accessed in VS-mode.
+
+  A bit in an hstateen CSR cannot be read-only one unless the same bit is read-only one
+  in the matching mstateen CSR.
+
+definedBy:
+  allOf:
+    - H
+    - Smstateen
+    - Ssstateen
+fields:
+  SEO:
+    location: 63
+    description: |
+      The SE0 bit in hstateen3 controls access to the sstateen3 CSR.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/hstateen3h.yaml
+++ b/arch/csr/hstateen3h.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: hstateen3h
+long_name: Upper 32 bits of Hypervisor State Enable 3 Register
+address: 0x61F
+priv_mode: S
+length: 32
+description: |
+  For RV64 harts, the Smstateen/Ssstateen extension adds four new 64-bit CSRs at machine level: mstateen0 (Machine State Enable 0),
+  mstateen1, mstateen2, and mstateen3. If supervisor mode is implemented, another four CSRs are defined at
+  supervisor level: sstateen0, sstateen1, sstateen2, and sstateen3. And if the hypervisor extension is implemented,
+  another set of CSRs is added: hstateen0, hstateen1, hstateen2, and hstateen3.
+
+  For RV32, the registers listed above are 32-bit, and for the machine-level and hypervisor CSRs there is a corresponding
+  set of high-half CSRs for the upper 32 bits of each register: mstateen0h, mstateen1h, mstateen2h, mstateen3h, hstateen0h,
+  hstateen1h, hstateen2h, and hstateen3h.
+
+definedBy:
+  allOf:
+    - H
+    - Smstateen
+    - Ssstateen
+fields:
+  SEO:
+    location: 31
+    description: |
+      The SE0 bit in hstateen3h controls access to the sstateen3 CSR.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/mstateen0.yaml
+++ b/arch/csr/mstateen0.yaml
@@ -1,0 +1,95 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: mstateen0
+long_name: Machine State Enable 0 Register
+address: 0x30C
+priv_mode: M
+length: 64
+description: |
+  For each mstateen CSR, bit 63 is defined to control access to the matching sstateen and hstateen
+  CSRs. Bit 63 of mstateen0 controls access to sstateen0 and hstateen0.
+
+  On reset, all writable mstateen bits are initialized by the hardware to zeros. If machine-level software
+  changes these values, it is responsible for initializing the corresponding writable bits of the hstateen
+  and sstateen CSRs to zeros too. Software at each privilege level should set its respective stateen CSRs
+  to indicate the state it is prepared to allow less-privileged software to access. For OSes and hypervisors,
+  this usually means the state that the OS or hypervisor is prepared to swap on a context switch, or to
+  manage in some other way.
+definedBy: Smstateen
+fields:
+  SEO:
+    location: 63
+    description: |
+      The SE0 bit in mstateen0 controls access to the hstateen0, hstateen0h, and the sstateen0 CSRs.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  ENVCFG:
+    location: 62
+    description: |
+      The ENVCFG bit in mstateen0 controls access to the henvcfg, henvcfgh, and the senvcfg CSRs.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  CSRIND:
+    location: 60
+    description: |
+      The CSRIND bit in mstateen0 controls access to the siselect, sireg*, vsiselect, and the vsireg*
+      CSRs provided by the Sscsrind extensions.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  AIA:
+    location: 59
+    description: |
+      The AIA bit in mstateen0 controls access to all state introduced by the Ssaia extension and is not
+      controlled by either the CSRIND or the IMSIC bits.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  IMSIC:
+    location: 58
+    description: |
+      The IMSIC bit in mstateen0 controls access to the IMSIC state, including CSRs stopei and vstopei,
+      provided by the Ssaia extension.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  CONTEXT:
+    location: 57
+    description: |
+      The CONTEXT bit in mstateen0 controls access to the scontext and hcontext CSRs provided by the
+      Sdtrig extension.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  P1P13:
+    location: 56
+    description: |
+      The P1P13 bit in mstateen0 controls access to the hedelegh introduced by Privileged Specification
+      Version 1.13.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  JVT:
+    location: 2
+    description: |
+      The JVT bit controls access to the jvt CSR provided by the Zcmt extension.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  FCSR:
+    location: 1
+    description: |
+      The FCSR bit controls access to fcsr for the case when floating-point instructions
+      operate on x registers instead of f registers as specified by the Zfinx and related
+      extensions (Zdinx, etc.). Whenever misa.F = 1, FCSR bit of mstateen0 is read-only
+      zero (and hence read-only zero in hstateen0 and sstateen0 too). For convenience,
+      when the stateen CSRs are implemented and misa.F = 0, then if the FCSR bit of a
+      controlling stateen0 CSR is zero, all floating-point instructions cause an illegal
+      instruction trap (or virtual instruction trap, if relevant), as though they all access
+      fcsr, regardless of whether they really do.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  C:
+    location: 0
+    description: |
+      The C bit controls access to any and all custom state. This bit is not custom state itself. The C bit of
+      these registers is not custom state itself; it is a standard field of a standard CSR, either mstateen0,
+      hstateen0, or sstateen0.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/mstateen0h.yaml
+++ b/arch/csr/mstateen0h.yaml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: mstateen0h
+long_name: Upper 32 bits of Machine State Enable 0 Register
+address: 0x31C
+priv_mode: M
+length: 32
+description: |
+  For RV64 harts, the Smstateen extension adds four new 64-bit CSRs at machine level: mstateen0 (Machine State
+  Enable 0), mstateen1, mstateen2, and mstateen3. For RV32, the registers listed above are 32-bit, and for the
+  machine-level CSRs there is a corresponding set of high-half CSRs for the upper 32 bits of each register:
+  mstateen0h, mstateen1h, mstateen2h, mstateen3h.
+definedBy: Smstateen
+fields:
+  SEO:
+    location: 31
+    description: |
+      The SE0 bit in mstateen0h controls access to the hstateen0, hstateen0h, and the sstateen0 CSRs.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  ENVCFG:
+    location: 30
+    description: |
+      The ENVCFG bit in mstateen0h controls access to the henvcfg, henvcfgh, and the senvcfg CSRs.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  CSRIND:
+    location: 28
+    description: |
+      The CSRIND bit in mstateen0h controls access to the siselect, sireg*, vsiselect, and the vsireg*
+      CSRs provided by the Sscsrind extensions.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  AIA:
+    location: 27
+    description: |
+      The AIA bit in mstateen0h controls access to all state introduced by the Ssaia extension and is not
+      controlled by either the CSRIND or the IMSIC bits.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  IMSIC:
+    location: 26
+    description: |
+      The IMSIC bit in mstateen0h controls access to the IMSIC state, including CSRs stopei and vstopei,
+      provided by the Ssaia extension.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  CONTEXT:
+    location: 25
+    description: |
+      The CONTEXT bit in mstateen0h controls access to the scontext and hcontext CSRs provided by the
+      Sdtrig extension.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  P1P13:
+    location: 24
+    description: |
+      The P1P13 bit in mstateen0h controls access to the hedelegh introduced by Privileged Specification
+      Version 1.13.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/mstateen1.yaml
+++ b/arch/csr/mstateen1.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: mstateen1
+long_name: Machine State Enable 1 Register
+address: 0x30D
+priv_mode: M
+length: 64
+description: |
+  For each mstateen CSR, bit 63 is defined to control access to the matching sstateen and hstateen
+  CSRs. Bit 63 of mstateen1 controls access to sstateen1 and hstateen1.
+
+  On reset, all writable mstateen bits are initialized by the hardware to zeros. If machine-level software
+  changes these values, it is responsible for initializing the corresponding writable bits of the hstateen
+  and sstateen CSRs to zeros too. Software at each privilege level should set its respective stateen CSRs
+  to indicate the state it is prepared to allow less-privileged software to access. For OSes and hypervisors,
+  this usually means the state that the OS or hypervisor is prepared to swap on a context switch, or to
+  manage in some other way.
+definedBy: Smstateen
+fields:
+  SEO:
+    location: 63
+    description: |
+      The SE0 bit in mstateen1 controls access to the hstateen1, hstateen1h, and the sstateen1 CSRs.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/mstateen1h.yaml
+++ b/arch/csr/mstateen1h.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: mstateen1h
+long_name: Upper 32 bits of Machine State Enable 1 Register
+address: 0x31D
+priv_mode: M
+length: 32
+description: |
+  For RV64 harts, the Smstateen extension adds four new 64-bit CSRs at machine level: mstateen0 (Machine State
+  Enable 0), mstateen1, mstateen2, and mstateen3. For RV32, the registers listed above are 32-bit, and for the
+  machine-level CSRs there is a corresponding set of high-half CSRs for the upper 32 bits of each register:
+  mstateen0h, mstateen1h, mstateen2h, mstateen3h.
+definedBy: Smstateen
+fields:
+  SEO:
+    location: 31
+    description: |
+      The SE0 bit in mstateen1h controls access to the hstateen1, hstateen1h, and the sstateen1 CSRs.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/mstateen2.yaml
+++ b/arch/csr/mstateen2.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: mstateen2
+long_name: Machine State Enable 2 Register
+address: 0x30E
+priv_mode: M
+length: 64
+description: |
+  For each mstateen CSR, bit 63 is defined to control access to the matching sstateen and hstateen
+  CSRs. Bit 63 of mstateen2 controls access to sstateen2 and hstateen2.
+
+  On reset, all writable mstateen bits are initialized by the hardware to zeros. If machine-level software
+  changes these values, it is responsible for initializing the corresponding writable bits of the hstateen
+  and sstateen CSRs to zeros too. Software at each privilege level should set its respective stateen CSRs
+  to indicate the state it is prepared to allow less-privileged software to access. For OSes and hypervisors,
+  this usually means the state that the OS or hypervisor is prepared to swap on a context switch, or to
+  manage in some other way.
+definedBy: Smstateen
+fields:
+  SEO:
+    location: 63
+    description: |
+      The SE0 bit in mstateen2 controls access to the hstateen2, hstateen2h, and the sstateen2 CSRs.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/mstateen2h.yaml
+++ b/arch/csr/mstateen2h.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: mstateen2h
+long_name: Upper 32 bits of Machine State Enable 2 Register
+address: 0x31E
+priv_mode: M
+length: 32
+description: |
+  For RV64 harts, the Smstateen extension adds four new 64-bit CSRs at machine level: mstateen0 (Machine State
+  Enable 0), mstateen1, mstateen2, and mstateen3. For RV32, the registers listed above are 32-bit, and for the
+  machine-level CSRs there is a corresponding set of high-half CSRs for the upper 32 bits of each register:
+  mstateen0h, mstateen1h, mstateen2h, mstateen3h.
+definedBy: Smstateen
+fields:
+  SEO:
+    location: 31
+    description: |
+      The SE0 bit in mstateen2h controls access to the hstateen2, hstateen2h, and the sstateen2 CSRs.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/mstateen3.yaml
+++ b/arch/csr/mstateen3.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: mstateen3
+long_name: Machine State Enable 3 Register
+address: 0x30F
+priv_mode: M
+length: 64
+description: |
+  For each mstateen CSR, bit 63 is defined to control access to the matching sstateen and hstateen
+  CSRs. Bit 63 of mstateen3 controls access to sstateen3 and hstateen3.
+
+  On reset, all writable mstateen bits are initialized by the hardware to zeros. If machine-level software
+  changes these values, it is responsible for initializing the corresponding writable bits of the hstateen
+  and sstateen CSRs to zeros too. Software at each privilege level should set its respective stateen CSRs
+  to indicate the state it is prepared to allow less-privileged software to access. For OSes and hypervisors,
+  this usually means the state that the OS or hypervisor is prepared to swap on a context switch, or to
+  manage in some other way.
+definedBy: Smstateen
+fields:
+  SEO:
+    location: 63
+    description: |
+      The SE0 bit in mstateen3 controls access to the hstateen3, hstateen3h, and the sstateen3 CSRs.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/mstateen3h.yaml
+++ b/arch/csr/mstateen3h.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: mstateen3h
+long_name: Upper 32 bits of Machine State Enable 3 Register
+address: 0x31F
+priv_mode: M
+length: 32
+description: |
+  For RV64 harts, the Smstateen extension adds four new 64-bit CSRs at machine level: mstateen0 (Machine State
+  Enable 0), mstateen1, mstateen2, and mstateen3. For RV32, the registers listed above are 32-bit, and for the
+  machine-level CSRs there is a corresponding set of high-half CSRs for the upper 32 bits of each register:
+  mstateen0h, mstateen1h, mstateen2h, mstateen3h.
+definedBy: Smstateen
+fields:
+  SEO:
+    location: 31
+    description: |
+      The SE0 bit in mstateen3h controls access to the hstateen3, hstateen3h, and the sstateen3 CSRs.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/sstateen0.yaml
+++ b/arch/csr/sstateen0.yaml
@@ -1,0 +1,71 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: sstateen0
+long_name: Supervisor State Enable 0 Register
+address: 0x10C
+priv_mode: S
+length: 64
+description: |
+  For the supervisor-level sstateen registers, high-half CSRs are not added at this
+  time because it is expected the upper 32 bits of these registers will always be zeros.
+
+  For every bit with a defined purpose in an sstateen CSR, the same bit is defined in the
+  matching mstateen CSR to control access below machine level to the same state.
+
+  Each bit of a stateen CSR controls less-privileged access to an extension’s state,
+  for an extension that was not deemed "worthy" of a full XS field in sstatus like the
+  FS and VS fields for the F and V extensions. The number of registers provided at each
+  level is four because it is believed that 4 * 64 = 256 bits for machine and hypervisor
+  levels, and 4 * 32 = 128 bits for supervisor level, will be adequate for many years to
+  come, perhaps for as long as the RISC-V ISA is in use. The exact number four is an
+  attempted compromise between providing too few bits on the one hand and going overboard
+  with CSRs that will never be used on the other.
+
+  The stateen registers at each level control access to state at all less-privileged levels,
+  but not at its own level.
+
+  When a stateen CSR prevents access to state for a privilege mode, attempting to execute in
+  that privilege mode an instruction that implicitly updates the state without reading it may
+  or may not raise an illegal instruction or virtual instruction exception. Such cases must
+  be disambiguated by being explicitly specified one way or the other.
+  In some cases, the bits of the stateen CSRs will have a dual purpose as enables for the ISA
+  extensions that introduce the controlled state.
+  Each bit of a supervisor-level sstateen CSR controls user-level access (from U-mode or VU-mode)
+  to an extension’s state. The intention is to allocate the bits of sstateen CSRs starting at the
+  least- significant end, bit 0, through to bit 31, and then on to the next-higher-numbered
+  sstateen CSR.
+
+definedBy:
+  allOf:
+    - Smstateen
+    - Ssstateen
+fields:
+  JVT:
+    location: 2
+    description: |
+      The JVT bit controls access to the jvt CSR provided by the Zcmt extension.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  FCSR:
+    location: 1
+    description: |
+      The FCSR bit controls access to fcsr for the case when floating-point instructions
+      operate on x registers instead of f registers as specified by the Zfinx and related
+      extensions (Zdinx, etc.). Whenever misa.F = 1, FCSR bit of mstateen0 is read-only
+      zero (and hence read-only zero in hstateen0 and sstateen0 too). For convenience,
+      when the stateen CSRs are implemented and misa.F = 0, then if the FCSR bit of a
+      controlling stateen0 CSR is zero, all floating-point instructions cause an illegal
+      instruction trap (or virtual instruction trap, if relevant), as though they all access
+      fcsr, regardless of whether they really do.
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  C:
+    location: 0
+    description: |
+      The C bit controls access to any and all custom state. This bit is not custom state itself. The C bit of
+      these registers is not custom state itself; it is a standard field of a standard CSR, either mstateen0,
+      hstateen0, or sstateen0.
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/sstateen1.yaml
+++ b/arch/csr/sstateen1.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: sstateen1
+long_name: Supervisor State Enable 1 Register
+address: 0x10D
+priv_mode: S
+length: 64
+description: |
+  For the supervisor-level sstateen registers, high-half CSRs are not added at this
+  time because it is expected the upper 32 bits of these registers will always be zeros.
+
+  For every bit with a defined purpose in an sstateen CSR, the same bit is defined in the
+  matching mstateen CSR to control access below machine level to the same state.
+
+  Each bit of a stateen CSR controls less-privileged access to an extension’s state,
+  for an extension that was not deemed "worthy" of a full XS field in sstatus like the
+  FS and VS fields for the F and V extensions. The number of registers provided at each
+  level is four because it is believed that 4 * 64 = 256 bits for machine and hypervisor
+  levels, and 4 * 32 = 128 bits for supervisor level, will be adequate for many years to
+  come, perhaps for as long as the RISC-V ISA is in use. The exact number four is an
+  attempted compromise between providing too few bits on the one hand and going overboard
+  with CSRs that will never be used on the other.
+
+  The stateen registers at each level control access to state at all less-privileged levels,
+  but not at its own level.
+
+  When a stateen CSR prevents access to state for a privilege mode, attempting to execute in
+  that privilege mode an instruction that implicitly updates the state without reading it may
+  or may not raise an illegal instruction or virtual instruction exception. Such cases must
+  be disambiguated by being explicitly specified one way or the other.
+  In some cases, the bits of the stateen CSRs will have a dual purpose as enables for the ISA
+  extensions that introduce the controlled state.
+  Each bit of a supervisor-level sstateen CSR controls user-level access (from U-mode or VU-mode)
+  to an extension’s state. The intention is to allocate the bits of sstateen CSRs starting at the
+  least- significant end, bit 0, through to bit 31, and then on to the next-higher-numbered
+  sstateen CSR.
+
+definedBy:
+  allOf:
+    - Smstateen
+    - Ssstateen
+
+fields:
+  DATA:
+    location: 63-0
+    description: Data value
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/sstateen2.yaml
+++ b/arch/csr/sstateen2.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: sstateen2
+long_name: Supervisor State Enable 2 Register
+address: 0x10E
+priv_mode: S
+length: 64
+description: |
+  For the supervisor-level sstateen registers, high-half CSRs are not added at this
+  time because it is expected the upper 32 bits of these registers will always be zeros.
+
+  For every bit with a defined purpose in an sstateen CSR, the same bit is defined in the
+  matching mstateen CSR to control access below machine level to the same state.
+
+  Each bit of a stateen CSR controls less-privileged access to an extension’s state,
+  for an extension that was not deemed "worthy" of a full XS field in sstatus like the
+  FS and VS fields for the F and V extensions. The number of registers provided at each
+  level is four because it is believed that 4 * 64 = 256 bits for machine and hypervisor
+  levels, and 4 * 32 = 128 bits for supervisor level, will be adequate for many years to
+  come, perhaps for as long as the RISC-V ISA is in use. The exact number four is an
+  attempted compromise between providing too few bits on the one hand and going overboard
+  with CSRs that will never be used on the other.
+
+  The stateen registers at each level control access to state at all less-privileged levels,
+  but not at its own level.
+
+  When a stateen CSR prevents access to state for a privilege mode, attempting to execute in
+  that privilege mode an instruction that implicitly updates the state without reading it may
+  or may not raise an illegal instruction or virtual instruction exception. Such cases must
+  be disambiguated by being explicitly specified one way or the other.
+  In some cases, the bits of the stateen CSRs will have a dual purpose as enables for the ISA
+  extensions that introduce the controlled state.
+  Each bit of a supervisor-level sstateen CSR controls user-level access (from U-mode or VU-mode)
+  to an extension’s state. The intention is to allocate the bits of sstateen CSRs starting at the
+  least- significant end, bit 0, through to bit 31, and then on to the next-higher-numbered
+  sstateen CSR.
+
+definedBy:
+  allOf:
+    - Smstateen
+    - Ssstateen
+
+fields:
+  DATA:
+    location: 63-0
+    description: Data value
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/csr/sstateen3.yaml
+++ b/arch/csr/sstateen3.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: sstateen3
+long_name: Supervisor State Enable 3 Register
+address: 0x10F
+priv_mode: S
+length: 64
+description: |
+  For the supervisor-level sstateen registers, high-half CSRs are not added at this
+  time because it is expected the upper 32 bits of these registers will always be zeros.
+
+  For every bit with a defined purpose in an sstateen CSR, the same bit is defined in the
+  matching mstateen CSR to control access below machine level to the same state.
+
+  Each bit of a stateen CSR controls less-privileged access to an extension’s state,
+  for an extension that was not deemed "worthy" of a full XS field in sstatus like the
+  FS and VS fields for the F and V extensions. The number of registers provided at each
+  level is four because it is believed that 4 * 64 = 256 bits for machine and hypervisor
+  levels, and 4 * 32 = 128 bits for supervisor level, will be adequate for many years to
+  come, perhaps for as long as the RISC-V ISA is in use. The exact number four is an
+  attempted compromise between providing too few bits on the one hand and going overboard
+  with CSRs that will never be used on the other.
+
+  The stateen registers at each level control access to state at all less-privileged levels,
+  but not at its own level.
+
+  When a stateen CSR prevents access to state for a privilege mode, attempting to execute in
+  that privilege mode an instruction that implicitly updates the state without reading it may
+  or may not raise an illegal instruction or virtual instruction exception. Such cases must
+  be disambiguated by being explicitly specified one way or the other.
+  In some cases, the bits of the stateen CSRs will have a dual purpose as enables for the ISA
+  extensions that introduce the controlled state.
+  Each bit of a supervisor-level sstateen CSR controls user-level access (from U-mode or VU-mode)
+  to an extension’s state. The intention is to allocate the bits of sstateen CSRs starting at the
+  least- significant end, bit 0, through to bit 31, and then on to the next-higher-numbered
+  sstateen CSR.
+
+definedBy:
+  allOf:
+    - Smstateen
+    - Ssstateen
+
+fields:
+  DATA:
+    location: 63-0
+    description: Data value
+    type: RW
+    reset_value: UNDEFINED_LEGAL

--- a/arch/ext/Smstateen.yaml
+++ b/arch/ext/Smstateen.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=../../schemas/ext_schema.json
+
+$schema: "ext_schema.json#"
+kind: extension
+name: Smstateen
+long_name: Machine-mode view of the state-enable extension
+description: |
+  Machine-mode view of the state-enable extension. The Smstateen
+  extension specification comprises the mstateen*, sstateen*,
+  and hstateen* CSRs and their functionality.
+
+  NOTE: The Smstateen extension specification is an M-mode extension as
+  it includes M-mode features, but the supervisor-mode visible
+  components of the extension are named as the Ssstateen extension.  Only
+  Ssstateen is mandated in the RVA22S64 profile when the hypervisor
+  extension is implemented.  These registers are not mandated or
+  supported options without the hypervisor extension, as there are no
+  RVA22S64 supported options with relevant state to control in the
+  absence of the hypervisor extension.
+
+type: privileged
+versions:
+  - version: "1.0.0"
+    state: ratified
+    ratification_date: null


### PR DESCRIPTION
This PR addresses Issue #547 and adds the Smstateen extension, along with the following Smstateen/Ssstateen CSRs
- mstateen0, mstateen1, mstateen2, mstateen3
- mstateen0h, mstateen1h, mstateen2h, mstateen3h
- hstateen0, hstateen1, hstateen2, hstateen3
- hstateen0h, hstateen1h, hstateen2h, hstateen3h
- sstateen0, sstateen1, sstateen2, sstateen3


