### PR TITLE
idl: indirect csr support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -238,18 +238,15 @@ namespace :test do
     puts "All files validate against their schema"
   end
 
-  task idl: ["#{$root}/.stamps/resolve-rv32.stamp", "#{$root}/.stamps/resolve-rv64.stamp"]  do
-    print "Parsing IDL code for RV32..."
-    cfg_arch32 = cfg_arch_for("rv32")
+  task :idl do
+    cfg = ENV["CFG"]
+    raise "Missing CFG enviornment variable" if cfg.nil?
+
+    print "Parsing IDL code for #{cfg}..."
+    cfg_arch = cfg_arch_for(cfg)
     puts "done"
 
-    cfg_arch32.type_check
-
-    print "Parsing IDL code for RV64..."
-    cfg_arch64 = cfg_arch_for("rv64")
-    puts "done"
-
-    cfg_arch64.type_check
+    cfg_arch.type_check
 
     puts "All IDL passed type checking"
   end
@@ -410,6 +407,11 @@ namespace :test do
     Rake::Task["test:idl_compiler"].invoke
     Rake::Task["test:lib"].invoke
     Rake::Task["test:schema"].invoke
+    ENV["CFG"] = "rv32"
+    Rake::Task["test:idl"].invoke
+    ENV["CFG"] = "rv64"
+    Rake::Task["test:idl"].invoke
+    ENV["CFG"] = "qc_iu"
     Rake::Task["test:idl"].invoke
     Rake::Task["test:inst_encodings"].invoke
   end

--- a/arch/csr/F/fcsr.yaml
+++ b/arch/csr/F/fcsr.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: fcsr
 long_name: Floating-point control and status register (`frm` + `fflags`)
 address: 0x003
+writeable: true
 description: |
   The floating-point control and status register, `fcsr`, is a RISC-V
   control and status register (CSR). It is a 32-bit read/write register

--- a/arch/csr/H/hcounteren.yaml
+++ b/arch/csr/H/hcounteren.yaml
@@ -6,6 +6,7 @@ kind: csr
 name: hcounteren
 long_name: Hypervisor Counter Enable
 address: 0x606
+writeable: true
 priv_mode: S
 length: 32
 description: |

--- a/arch/csr/H/henvcfg.yaml
+++ b/arch/csr/H/henvcfg.yaml
@@ -4,6 +4,7 @@ $schema: "csr_schema.json#"
 kind: csr
 name: henvcfg
 address: 0x60A
+writeable: true
 long_name: Hypervisor Environment Configuration
 description: |
   The henvcfg CSR is a 64-bit read/write register that controls certain characteristics of the

--- a/arch/csr/H/henvcfgh.yaml
+++ b/arch/csr/H/henvcfgh.yaml
@@ -4,6 +4,7 @@ $schema: "csr_schema.json#"
 kind: csr
 name: henvcfgh
 address: 0x61A
+writeable: true
 base: 32
 long_name: most-significant 32 bits of Hypervisor Environment Configuration
 description: |

--- a/arch/csr/H/hgatp.yaml
+++ b/arch/csr/H/hgatp.yaml
@@ -102,6 +102,7 @@ description: |
   HFENCE.GVMA instruction (see <<hfence.vma>>) before or
   after writing `hgatp`.
 address: 0x680
+writeable: true
 priv_mode: S
 definedBy: H
 length: SXLEN

--- a/arch/csr/H/htimedelta.yaml
+++ b/arch/csr/H/htimedelta.yaml
@@ -15,6 +15,7 @@ description: |
   `htimedelta` may be used to represent negative time offsets.
 
 address: 0x605
+writeable: true
 priv_mode: S
 definedBy: H
 length: 64

--- a/arch/csr/H/htimedeltah.yaml
+++ b/arch/csr/H/htimedeltah.yaml
@@ -8,6 +8,7 @@ description: |
   Upper half of the `htimedelta` CSR.
 
 address: 0x615
+writeable: true
 priv_mode: S
 definedBy: H
 length: 32

--- a/arch/csr/H/htinst.yaml
+++ b/arch/csr/H/htinst.yaml
@@ -4,6 +4,7 @@ $schema: "csr_schema.json#"
 kind: csr
 name: htinst
 address: 0x64a
+writeable: true
 long_name: Hypervisor Trap Instruction Register
 description: |
   When a trap is taken into HS-mode, mtinst is written with a value that, if nonzero,

--- a/arch/csr/H/htval.yaml
+++ b/arch/csr/H/htval.yaml
@@ -4,6 +4,7 @@ $schema: "csr_schema.json#"
 kind: csr
 name: htval
 address: 0x643
+writeable: true
 long_name: Hypervisor Trap Value Register
 description: |
   When a trap is taken into HS-mode, htval is written with additional exception-specific information, alongside stval, to assist software in handling the trap.

--- a/arch/csr/H/mtinst.yaml
+++ b/arch/csr/H/mtinst.yaml
@@ -4,6 +4,7 @@ $schema: "csr_schema.json#"
 kind: csr
 name: mtinst
 address: 0x34a
+writeable: true
 long_name: Machine Trap Instruction Register
 description: |
   When a trap is taken into M-mode, mtinst is written with a value that, if nonzero,

--- a/arch/csr/H/mtval2.yaml
+++ b/arch/csr/H/mtval2.yaml
@@ -4,6 +4,7 @@ $schema: "csr_schema.json#"
 kind: csr
 name: mtval2
 address: 0x34b
+writeable: true
 long_name: Machine Second Trap Value Register
 description: |
   When a trap is taken into M-mode from a virtual mode, mtval2 is written with additional exception-specific information,

--- a/arch/csr/H/vsatp.yaml
+++ b/arch/csr/H/vsatp.yaml
@@ -4,6 +4,7 @@ $schema: "csr_schema.json#"
 kind: csr
 name: vsatp
 address: 0x280
+writeable: true
 virtual_address: 0x180
 long_name: Virtual Supervisor Address Translation and Protection
 description: |

--- a/arch/csr/I/mcounteren.yaml
+++ b/arch/csr/I/mcounteren.yaml
@@ -6,6 +6,7 @@ kind: csr
 name: mcounteren
 long_name: Machine Counter Enable
 address: 0x306
+writeable: true
 priv_mode: M
 length: 32
 description: |

--- a/arch/csr/I/pmpaddr0.yaml
+++ b/arch/csr/I/pmpaddr0.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr0
 long_name: PMP Address 0
 address: 0x3B0
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr1.yaml
+++ b/arch/csr/I/pmpaddr1.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr1
 long_name: PMP Address 1
 address: 0x3B1
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr10.yaml
+++ b/arch/csr/I/pmpaddr10.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr10
 long_name: PMP Address 10
 address: 0x3BA
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr11.yaml
+++ b/arch/csr/I/pmpaddr11.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr11
 long_name: PMP Address 11
 address: 0x3BB
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr12.yaml
+++ b/arch/csr/I/pmpaddr12.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr12
 long_name: PMP Address 12
 address: 0x3BC
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr13.yaml
+++ b/arch/csr/I/pmpaddr13.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr13
 long_name: PMP Address 13
 address: 0x3BD
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr14.yaml
+++ b/arch/csr/I/pmpaddr14.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr14
 long_name: PMP Address 14
 address: 0x3BE
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr15.yaml
+++ b/arch/csr/I/pmpaddr15.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr15
 long_name: PMP Address 15
 address: 0x3BF
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr16.yaml
+++ b/arch/csr/I/pmpaddr16.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr16
 long_name: PMP Address 16
 address: 0x3C0
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr17.yaml
+++ b/arch/csr/I/pmpaddr17.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr17
 long_name: PMP Address 17
 address: 0x3C1
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr18.yaml
+++ b/arch/csr/I/pmpaddr18.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr18
 long_name: PMP Address 18
 address: 0x3C2
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr19.yaml
+++ b/arch/csr/I/pmpaddr19.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr19
 long_name: PMP Address 19
 address: 0x3C3
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr2.yaml
+++ b/arch/csr/I/pmpaddr2.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr2
 long_name: PMP Address 2
 address: 0x3B2
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr20.yaml
+++ b/arch/csr/I/pmpaddr20.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr20
 long_name: PMP Address 20
 address: 0x3C4
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr21.yaml
+++ b/arch/csr/I/pmpaddr21.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr21
 long_name: PMP Address 21
 address: 0x3C5
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr22.yaml
+++ b/arch/csr/I/pmpaddr22.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr22
 long_name: PMP Address 22
 address: 0x3C6
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr23.yaml
+++ b/arch/csr/I/pmpaddr23.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr23
 long_name: PMP Address 23
 address: 0x3C7
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr24.yaml
+++ b/arch/csr/I/pmpaddr24.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr24
 long_name: PMP Address 24
 address: 0x3C8
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr25.yaml
+++ b/arch/csr/I/pmpaddr25.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr25
 long_name: PMP Address 25
 address: 0x3C9
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr26.yaml
+++ b/arch/csr/I/pmpaddr26.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr26
 long_name: PMP Address 26
 address: 0x3CA
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr27.yaml
+++ b/arch/csr/I/pmpaddr27.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr27
 long_name: PMP Address 27
 address: 0x3CB
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr28.yaml
+++ b/arch/csr/I/pmpaddr28.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr28
 long_name: PMP Address 28
 address: 0x3CC
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr29.yaml
+++ b/arch/csr/I/pmpaddr29.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr29
 long_name: PMP Address 29
 address: 0x3CD
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr3.yaml
+++ b/arch/csr/I/pmpaddr3.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr3
 long_name: PMP Address 3
 address: 0x3B3
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr30.yaml
+++ b/arch/csr/I/pmpaddr30.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr30
 long_name: PMP Address 30
 address: 0x3CE
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr31.yaml
+++ b/arch/csr/I/pmpaddr31.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr31
 long_name: PMP Address 31
 address: 0x3CF
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr32.yaml
+++ b/arch/csr/I/pmpaddr32.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr32
 long_name: PMP Address 32
 address: 0x3D0
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr33.yaml
+++ b/arch/csr/I/pmpaddr33.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr33
 long_name: PMP Address 33
 address: 0x3D1
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr34.yaml
+++ b/arch/csr/I/pmpaddr34.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr34
 long_name: PMP Address 34
 address: 0x3D2
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr35.yaml
+++ b/arch/csr/I/pmpaddr35.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr35
 long_name: PMP Address 35
 address: 0x3D3
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr36.yaml
+++ b/arch/csr/I/pmpaddr36.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr36
 long_name: PMP Address 36
 address: 0x3D4
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr37.yaml
+++ b/arch/csr/I/pmpaddr37.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr37
 long_name: PMP Address 37
 address: 0x3D5
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr38.yaml
+++ b/arch/csr/I/pmpaddr38.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr38
 long_name: PMP Address 38
 address: 0x3D6
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr39.yaml
+++ b/arch/csr/I/pmpaddr39.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr39
 long_name: PMP Address 39
 address: 0x3D7
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr4.yaml
+++ b/arch/csr/I/pmpaddr4.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr4
 long_name: PMP Address 4
 address: 0x3B4
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr40.yaml
+++ b/arch/csr/I/pmpaddr40.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr40
 long_name: PMP Address 40
 address: 0x3D8
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr41.yaml
+++ b/arch/csr/I/pmpaddr41.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr41
 long_name: PMP Address 41
 address: 0x3D9
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr42.yaml
+++ b/arch/csr/I/pmpaddr42.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr42
 long_name: PMP Address 42
 address: 0x3DA
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr43.yaml
+++ b/arch/csr/I/pmpaddr43.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr43
 long_name: PMP Address 43
 address: 0x3DB
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr44.yaml
+++ b/arch/csr/I/pmpaddr44.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr44
 long_name: PMP Address 44
 address: 0x3DC
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr45.yaml
+++ b/arch/csr/I/pmpaddr45.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr45
 long_name: PMP Address 45
 address: 0x3DD
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr46.yaml
+++ b/arch/csr/I/pmpaddr46.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr46
 long_name: PMP Address 46
 address: 0x3DE
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr47.yaml
+++ b/arch/csr/I/pmpaddr47.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr47
 long_name: PMP Address 47
 address: 0x3DF
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr48.yaml
+++ b/arch/csr/I/pmpaddr48.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr48
 long_name: PMP Address 48
 address: 0x3E0
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr49.yaml
+++ b/arch/csr/I/pmpaddr49.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr49
 long_name: PMP Address 49
 address: 0x3E1
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr5.yaml
+++ b/arch/csr/I/pmpaddr5.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr5
 long_name: PMP Address 5
 address: 0x3B5
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr50.yaml
+++ b/arch/csr/I/pmpaddr50.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr50
 long_name: PMP Address 50
 address: 0x3E2
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr51.yaml
+++ b/arch/csr/I/pmpaddr51.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr51
 long_name: PMP Address 51
 address: 0x3E3
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr52.yaml
+++ b/arch/csr/I/pmpaddr52.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr52
 long_name: PMP Address 52
 address: 0x3E4
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr53.yaml
+++ b/arch/csr/I/pmpaddr53.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr53
 long_name: PMP Address 53
 address: 0x3E5
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr54.yaml
+++ b/arch/csr/I/pmpaddr54.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr54
 long_name: PMP Address 54
 address: 0x3E6
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr55.yaml
+++ b/arch/csr/I/pmpaddr55.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr55
 long_name: PMP Address 55
 address: 0x3E7
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr56.yaml
+++ b/arch/csr/I/pmpaddr56.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr56
 long_name: PMP Address 56
 address: 0x3E8
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr57.yaml
+++ b/arch/csr/I/pmpaddr57.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr57
 long_name: PMP Address 57
 address: 0x3E9
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr58.yaml
+++ b/arch/csr/I/pmpaddr58.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr58
 long_name: PMP Address 58
 address: 0x3EA
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr59.yaml
+++ b/arch/csr/I/pmpaddr59.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr59
 long_name: PMP Address 59
 address: 0x3EB
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr6.yaml
+++ b/arch/csr/I/pmpaddr6.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr6
 long_name: PMP Address 6
 address: 0x3B6
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr60.yaml
+++ b/arch/csr/I/pmpaddr60.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr60
 long_name: PMP Address 60
 address: 0x3EC
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr61.yaml
+++ b/arch/csr/I/pmpaddr61.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr61
 long_name: PMP Address 61
 address: 0x3ED
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr62.yaml
+++ b/arch/csr/I/pmpaddr62.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr62
 long_name: PMP Address 62
 address: 0x3EE
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr63.yaml
+++ b/arch/csr/I/pmpaddr63.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr63
 long_name: PMP Address 63
 address: 0x3EF
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr7.yaml
+++ b/arch/csr/I/pmpaddr7.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr7
 long_name: PMP Address 7
 address: 0x3B7
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr8.yaml
+++ b/arch/csr/I/pmpaddr8.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr8
 long_name: PMP Address 8
 address: 0x3B8
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpaddr9.yaml
+++ b/arch/csr/I/pmpaddr9.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpaddr9
 long_name: PMP Address 9
 address: 0x3B9
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry address

--- a/arch/csr/I/pmpcfg0.yaml
+++ b/arch/csr/I/pmpcfg0.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpcfg0
 long_name: PMP Configuration Register 0
 address: 0x3A0
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/I/pmpcfg1.yaml
+++ b/arch/csr/I/pmpcfg1.yaml
@@ -8,6 +8,7 @@ name: pmpcfg1
 base: 32 # odd numbered pmpcfg registers do not exist in RV64
 long_name: PMP Configuration Register 1
 address: 0x3A1
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/I/pmpcfg10.yaml
+++ b/arch/csr/I/pmpcfg10.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpcfg10
 long_name: PMP Configuration Register 10
 address: 0x3AA
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/I/pmpcfg11.yaml
+++ b/arch/csr/I/pmpcfg11.yaml
@@ -8,6 +8,7 @@ name: pmpcfg11
 base: 32 # odd numbered pmpcfg registers do not exist in RV64
 long_name: PMP Configuration Register 11
 address: 0x3AB
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/I/pmpcfg12.yaml
+++ b/arch/csr/I/pmpcfg12.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpcfg12
 long_name: PMP Configuration Register 12
 address: 0x3AC
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/I/pmpcfg13.yaml
+++ b/arch/csr/I/pmpcfg13.yaml
@@ -8,6 +8,7 @@ name: pmpcfg13
 base: 32 # odd numbered pmpcfg registers do not exist in RV64
 long_name: PMP Configuration Register 13
 address: 0x3AD
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/I/pmpcfg14.yaml
+++ b/arch/csr/I/pmpcfg14.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpcfg14
 long_name: PMP Configuration Register 14
 address: 0x3AE
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/I/pmpcfg15.yaml
+++ b/arch/csr/I/pmpcfg15.yaml
@@ -8,6 +8,7 @@ name: pmpcfg15
 base: 32 # odd numbered pmpcfg registers do not exist in RV64
 long_name: PMP Configuration Register 15
 address: 0x3AF
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/I/pmpcfg2.yaml
+++ b/arch/csr/I/pmpcfg2.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpcfg2
 long_name: PMP Configuration Register 2
 address: 0x3A2
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/I/pmpcfg3.yaml
+++ b/arch/csr/I/pmpcfg3.yaml
@@ -8,6 +8,7 @@ name: pmpcfg3
 base: 32 # odd numbered pmpcfg registers do not exist in RV64
 long_name: PMP Configuration Register 3
 address: 0x3A3
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/I/pmpcfg4.yaml
+++ b/arch/csr/I/pmpcfg4.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpcfg4
 long_name: PMP Configuration Register 4
 address: 0x3A4
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/I/pmpcfg5.yaml
+++ b/arch/csr/I/pmpcfg5.yaml
@@ -8,6 +8,7 @@ name: pmpcfg5
 base: 32 # odd numbered pmpcfg registers do not exist in RV64
 long_name: PMP Configuration Register 5
 address: 0x3A5
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/I/pmpcfg6.yaml
+++ b/arch/csr/I/pmpcfg6.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpcfg6
 long_name: PMP Configuration Register 6
 address: 0x3A6
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/I/pmpcfg7.yaml
+++ b/arch/csr/I/pmpcfg7.yaml
@@ -8,6 +8,7 @@ name: pmpcfg7
 base: 32 # odd numbered pmpcfg registers do not exist in RV64
 long_name: PMP Configuration Register 7
 address: 0x3A7
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/I/pmpcfg8.yaml
+++ b/arch/csr/I/pmpcfg8.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: pmpcfg8
 long_name: PMP Configuration Register 8
 address: 0x3A8
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/I/pmpcfg9.yaml
+++ b/arch/csr/I/pmpcfg9.yaml
@@ -8,6 +8,7 @@ name: pmpcfg9
 base: 32 # odd numbered pmpcfg registers do not exist in RV64
 long_name: PMP Configuration Register 9
 address: 0x3A9
+writeable: true
 priv_mode: M
 length: MXLEN
 description: PMP entry configuration

--- a/arch/csr/S/scounteren.yaml
+++ b/arch/csr/S/scounteren.yaml
@@ -6,6 +6,7 @@ kind: csr
 name: scounteren
 long_name: Supervisor Counter Enable
 address: 0x106
+writeable: true
 priv_mode: S
 length: 32
 description: |

--- a/arch/csr/Smrnmi/mncause.yaml
+++ b/arch/csr/Smrnmi/mncause.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mncause
 long_name: Resumable NMI cause
 address: 0x742
+writeable: true
 priv_mode: M
 length: MXLEN
 definedBy: Smrnmi

--- a/arch/csr/Smrnmi/mnepc.yaml
+++ b/arch/csr/Smrnmi/mnepc.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mnepc
 long_name: Machine Exception Program Counter
 address: 0x741
+writeable: true
 priv_mode: M
 length: MXLEN
 description: |

--- a/arch/csr/Smrnmi/mnscratch.yaml
+++ b/arch/csr/Smrnmi/mnscratch.yaml
@@ -5,9 +5,12 @@ kind: csr
 name: mnscratch
 long_name: Machine Scratch Register
 address: 0x740
+writeable: true
 priv_mode: M
 length: MXLEN
-description: Scratch register for software use in NMI / double trap. Bits are not interpreted by hardware.
+description:
+  Scratch register for software use in NMI / double trap. Bits are not
+  interpreted by hardware.
 definedBy: Smrnmi
 fields:
   SCRATCH:

--- a/arch/csr/Smrnmi/mnstatus.yaml
+++ b/arch/csr/Smrnmi/mnstatus.yaml
@@ -5,11 +5,14 @@ kind: csr
 name: mnstatus
 long_name: Machine NMI Status
 address: 0x744
+writeable: true
 priv_mode: M
 
 # length is MXLEN-bit
 length: MXLEN
-description: The mnstatus register tracks and controls the hart's current NMI operating state.
+description:
+  The mnstatus register tracks and controls the hart's current NMI operating
+  state.
 definedBy: Smrnmi
 fields:
   MNPP:

--- a/arch/csr/Zicntr/mcountinhibit.yaml
+++ b/arch/csr/Zicntr/mcountinhibit.yaml
@@ -6,6 +6,7 @@ kind: csr
 name: mcountinhibit
 long_name: Machine Counter Inhibit
 address: 0x320
+writeable: true
 priv_mode: M
 length: 32
 description: |

--- a/arch/csr/Zihpm/hpmcounter10.yaml
+++ b/arch/csr/Zihpm/hpmcounter10.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter10
 long_name: User-mode Hardware Performance Counter 7
 address: 0xC0A
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter10`.
 

--- a/arch/csr/Zihpm/hpmcounter10h.yaml
+++ b/arch/csr/Zihpm/hpmcounter10h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter10h
 long_name: User-mode Hardware Performance Counter 7, high half
 address: 0xC8A
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter10h`.
 

--- a/arch/csr/Zihpm/hpmcounter10h.yaml
+++ b/arch/csr/Zihpm/hpmcounter10h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter10h
 long_name: User-mode Hardware Performance Counter 7, high half
 address: 0xC8A
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter10h`.
 

--- a/arch/csr/Zihpm/hpmcounter11.yaml
+++ b/arch/csr/Zihpm/hpmcounter11.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter11
 long_name: User-mode Hardware Performance Counter 8
 address: 0xC0B
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter11`.
 

--- a/arch/csr/Zihpm/hpmcounter11h.yaml
+++ b/arch/csr/Zihpm/hpmcounter11h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter11h
 long_name: User-mode Hardware Performance Counter 8, high half
 address: 0xC8B
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter11h`.
 

--- a/arch/csr/Zihpm/hpmcounter11h.yaml
+++ b/arch/csr/Zihpm/hpmcounter11h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter11h
 long_name: User-mode Hardware Performance Counter 8, high half
 address: 0xC8B
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter11h`.
 

--- a/arch/csr/Zihpm/hpmcounter12.yaml
+++ b/arch/csr/Zihpm/hpmcounter12.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter12
 long_name: User-mode Hardware Performance Counter 9
 address: 0xC0C
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter12`.
 

--- a/arch/csr/Zihpm/hpmcounter12h.yaml
+++ b/arch/csr/Zihpm/hpmcounter12h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter12h
 long_name: User-mode Hardware Performance Counter 9, high half
 address: 0xC8C
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter12h`.
 

--- a/arch/csr/Zihpm/hpmcounter12h.yaml
+++ b/arch/csr/Zihpm/hpmcounter12h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter12h
 long_name: User-mode Hardware Performance Counter 9, high half
 address: 0xC8C
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter12h`.
 

--- a/arch/csr/Zihpm/hpmcounter13.yaml
+++ b/arch/csr/Zihpm/hpmcounter13.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter13
 long_name: User-mode Hardware Performance Counter 10
 address: 0xC0D
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter13`.
 

--- a/arch/csr/Zihpm/hpmcounter13h.yaml
+++ b/arch/csr/Zihpm/hpmcounter13h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter13h
 long_name: User-mode Hardware Performance Counter 10, high half
 address: 0xC8D
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter13h`.
 

--- a/arch/csr/Zihpm/hpmcounter13h.yaml
+++ b/arch/csr/Zihpm/hpmcounter13h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter13h
 long_name: User-mode Hardware Performance Counter 10, high half
 address: 0xC8D
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter13h`.
 

--- a/arch/csr/Zihpm/hpmcounter14.yaml
+++ b/arch/csr/Zihpm/hpmcounter14.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter14
 long_name: User-mode Hardware Performance Counter 11
 address: 0xC0E
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter14`.
 

--- a/arch/csr/Zihpm/hpmcounter14h.yaml
+++ b/arch/csr/Zihpm/hpmcounter14h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter14h
 long_name: User-mode Hardware Performance Counter 11, high half
 address: 0xC8E
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter14h`.
 

--- a/arch/csr/Zihpm/hpmcounter14h.yaml
+++ b/arch/csr/Zihpm/hpmcounter14h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter14h
 long_name: User-mode Hardware Performance Counter 11, high half
 address: 0xC8E
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter14h`.
 

--- a/arch/csr/Zihpm/hpmcounter15.yaml
+++ b/arch/csr/Zihpm/hpmcounter15.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter15
 long_name: User-mode Hardware Performance Counter 12
 address: 0xC0F
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter15`.
 

--- a/arch/csr/Zihpm/hpmcounter15h.yaml
+++ b/arch/csr/Zihpm/hpmcounter15h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter15h
 long_name: User-mode Hardware Performance Counter 12, high half
 address: 0xC8F
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter15h`.
 

--- a/arch/csr/Zihpm/hpmcounter15h.yaml
+++ b/arch/csr/Zihpm/hpmcounter15h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter15h
 long_name: User-mode Hardware Performance Counter 12, high half
 address: 0xC8F
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter15h`.
 

--- a/arch/csr/Zihpm/hpmcounter16.yaml
+++ b/arch/csr/Zihpm/hpmcounter16.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter16
 long_name: User-mode Hardware Performance Counter 13
 address: 0xC10
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter16`.
 

--- a/arch/csr/Zihpm/hpmcounter16h.yaml
+++ b/arch/csr/Zihpm/hpmcounter16h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter16h
 long_name: User-mode Hardware Performance Counter 13, high half
 address: 0xC90
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter16h`.
 

--- a/arch/csr/Zihpm/hpmcounter16h.yaml
+++ b/arch/csr/Zihpm/hpmcounter16h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter16h
 long_name: User-mode Hardware Performance Counter 13, high half
 address: 0xC90
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter16h`.
 

--- a/arch/csr/Zihpm/hpmcounter17.yaml
+++ b/arch/csr/Zihpm/hpmcounter17.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter17
 long_name: User-mode Hardware Performance Counter 14
 address: 0xC11
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter17`.
 

--- a/arch/csr/Zihpm/hpmcounter17h.yaml
+++ b/arch/csr/Zihpm/hpmcounter17h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter17h
 long_name: User-mode Hardware Performance Counter 14, high half
 address: 0xC91
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter17h`.
 

--- a/arch/csr/Zihpm/hpmcounter17h.yaml
+++ b/arch/csr/Zihpm/hpmcounter17h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter17h
 long_name: User-mode Hardware Performance Counter 14, high half
 address: 0xC91
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter17h`.
 

--- a/arch/csr/Zihpm/hpmcounter18.yaml
+++ b/arch/csr/Zihpm/hpmcounter18.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter18
 long_name: User-mode Hardware Performance Counter 15
 address: 0xC12
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter18`.
 

--- a/arch/csr/Zihpm/hpmcounter18h.yaml
+++ b/arch/csr/Zihpm/hpmcounter18h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter18h
 long_name: User-mode Hardware Performance Counter 15, high half
 address: 0xC92
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter18h`.
 

--- a/arch/csr/Zihpm/hpmcounter18h.yaml
+++ b/arch/csr/Zihpm/hpmcounter18h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter18h
 long_name: User-mode Hardware Performance Counter 15, high half
 address: 0xC92
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter18h`.
 

--- a/arch/csr/Zihpm/hpmcounter19.yaml
+++ b/arch/csr/Zihpm/hpmcounter19.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter19
 long_name: User-mode Hardware Performance Counter 16
 address: 0xC13
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter19`.
 

--- a/arch/csr/Zihpm/hpmcounter19h.yaml
+++ b/arch/csr/Zihpm/hpmcounter19h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter19h
 long_name: User-mode Hardware Performance Counter 16, high half
 address: 0xC93
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter19h`.
 

--- a/arch/csr/Zihpm/hpmcounter19h.yaml
+++ b/arch/csr/Zihpm/hpmcounter19h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter19h
 long_name: User-mode Hardware Performance Counter 16, high half
 address: 0xC93
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter19h`.
 

--- a/arch/csr/Zihpm/hpmcounter20.yaml
+++ b/arch/csr/Zihpm/hpmcounter20.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter20
 long_name: User-mode Hardware Performance Counter 17
 address: 0xC14
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter20`.
 

--- a/arch/csr/Zihpm/hpmcounter20h.yaml
+++ b/arch/csr/Zihpm/hpmcounter20h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter20h
 long_name: User-mode Hardware Performance Counter 17, high half
 address: 0xC94
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter20h`.
 

--- a/arch/csr/Zihpm/hpmcounter20h.yaml
+++ b/arch/csr/Zihpm/hpmcounter20h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter20h
 long_name: User-mode Hardware Performance Counter 17, high half
 address: 0xC94
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter20h`.
 

--- a/arch/csr/Zihpm/hpmcounter21.yaml
+++ b/arch/csr/Zihpm/hpmcounter21.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter21
 long_name: User-mode Hardware Performance Counter 18
 address: 0xC15
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter21`.
 

--- a/arch/csr/Zihpm/hpmcounter21h.yaml
+++ b/arch/csr/Zihpm/hpmcounter21h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter21h
 long_name: User-mode Hardware Performance Counter 18, high half
 address: 0xC95
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter21h`.
 

--- a/arch/csr/Zihpm/hpmcounter21h.yaml
+++ b/arch/csr/Zihpm/hpmcounter21h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter21h
 long_name: User-mode Hardware Performance Counter 18, high half
 address: 0xC95
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter21h`.
 

--- a/arch/csr/Zihpm/hpmcounter22.yaml
+++ b/arch/csr/Zihpm/hpmcounter22.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter22
 long_name: User-mode Hardware Performance Counter 19
 address: 0xC16
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter22`.
 

--- a/arch/csr/Zihpm/hpmcounter22h.yaml
+++ b/arch/csr/Zihpm/hpmcounter22h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter22h
 long_name: User-mode Hardware Performance Counter 19, high half
 address: 0xC96
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter22h`.
 

--- a/arch/csr/Zihpm/hpmcounter22h.yaml
+++ b/arch/csr/Zihpm/hpmcounter22h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter22h
 long_name: User-mode Hardware Performance Counter 19, high half
 address: 0xC96
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter22h`.
 

--- a/arch/csr/Zihpm/hpmcounter23.yaml
+++ b/arch/csr/Zihpm/hpmcounter23.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter23
 long_name: User-mode Hardware Performance Counter 20
 address: 0xC17
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter23`.
 

--- a/arch/csr/Zihpm/hpmcounter23h.yaml
+++ b/arch/csr/Zihpm/hpmcounter23h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter23h
 long_name: User-mode Hardware Performance Counter 20, high half
 address: 0xC97
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter23h`.
 

--- a/arch/csr/Zihpm/hpmcounter23h.yaml
+++ b/arch/csr/Zihpm/hpmcounter23h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter23h
 long_name: User-mode Hardware Performance Counter 20, high half
 address: 0xC97
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter23h`.
 

--- a/arch/csr/Zihpm/hpmcounter24.yaml
+++ b/arch/csr/Zihpm/hpmcounter24.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter24
 long_name: User-mode Hardware Performance Counter 21
 address: 0xC18
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter24`.
 

--- a/arch/csr/Zihpm/hpmcounter24h.yaml
+++ b/arch/csr/Zihpm/hpmcounter24h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter24h
 long_name: User-mode Hardware Performance Counter 21, high half
 address: 0xC98
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter24h`.
 

--- a/arch/csr/Zihpm/hpmcounter24h.yaml
+++ b/arch/csr/Zihpm/hpmcounter24h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter24h
 long_name: User-mode Hardware Performance Counter 21, high half
 address: 0xC98
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter24h`.
 

--- a/arch/csr/Zihpm/hpmcounter25.yaml
+++ b/arch/csr/Zihpm/hpmcounter25.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter25
 long_name: User-mode Hardware Performance Counter 22
 address: 0xC19
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter25`.
 

--- a/arch/csr/Zihpm/hpmcounter25h.yaml
+++ b/arch/csr/Zihpm/hpmcounter25h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter25h
 long_name: User-mode Hardware Performance Counter 22, high half
 address: 0xC99
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter25h`.
 

--- a/arch/csr/Zihpm/hpmcounter25h.yaml
+++ b/arch/csr/Zihpm/hpmcounter25h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter25h
 long_name: User-mode Hardware Performance Counter 22, high half
 address: 0xC99
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter25h`.
 

--- a/arch/csr/Zihpm/hpmcounter26.yaml
+++ b/arch/csr/Zihpm/hpmcounter26.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter26
 long_name: User-mode Hardware Performance Counter 23
 address: 0xC1A
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter26`.
 

--- a/arch/csr/Zihpm/hpmcounter26h.yaml
+++ b/arch/csr/Zihpm/hpmcounter26h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter26h
 long_name: User-mode Hardware Performance Counter 23, high half
 address: 0xC9A
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter26h`.
 

--- a/arch/csr/Zihpm/hpmcounter26h.yaml
+++ b/arch/csr/Zihpm/hpmcounter26h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter26h
 long_name: User-mode Hardware Performance Counter 23, high half
 address: 0xC9A
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter26h`.
 

--- a/arch/csr/Zihpm/hpmcounter27.yaml
+++ b/arch/csr/Zihpm/hpmcounter27.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter27
 long_name: User-mode Hardware Performance Counter 24
 address: 0xC1B
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter27`.
 

--- a/arch/csr/Zihpm/hpmcounter27h.yaml
+++ b/arch/csr/Zihpm/hpmcounter27h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter27h
 long_name: User-mode Hardware Performance Counter 24, high half
 address: 0xC9B
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter27h`.
 

--- a/arch/csr/Zihpm/hpmcounter27h.yaml
+++ b/arch/csr/Zihpm/hpmcounter27h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter27h
 long_name: User-mode Hardware Performance Counter 24, high half
 address: 0xC9B
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter27h`.
 

--- a/arch/csr/Zihpm/hpmcounter28.yaml
+++ b/arch/csr/Zihpm/hpmcounter28.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter28
 long_name: User-mode Hardware Performance Counter 25
 address: 0xC1C
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter28`.
 

--- a/arch/csr/Zihpm/hpmcounter28h.yaml
+++ b/arch/csr/Zihpm/hpmcounter28h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter28h
 long_name: User-mode Hardware Performance Counter 25, high half
 address: 0xC9C
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter28h`.
 

--- a/arch/csr/Zihpm/hpmcounter28h.yaml
+++ b/arch/csr/Zihpm/hpmcounter28h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter28h
 long_name: User-mode Hardware Performance Counter 25, high half
 address: 0xC9C
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter28h`.
 

--- a/arch/csr/Zihpm/hpmcounter29.yaml
+++ b/arch/csr/Zihpm/hpmcounter29.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter29
 long_name: User-mode Hardware Performance Counter 26
 address: 0xC1D
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter29`.
 

--- a/arch/csr/Zihpm/hpmcounter29h.yaml
+++ b/arch/csr/Zihpm/hpmcounter29h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter29h
 long_name: User-mode Hardware Performance Counter 26, high half
 address: 0xC9D
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter29h`.
 

--- a/arch/csr/Zihpm/hpmcounter29h.yaml
+++ b/arch/csr/Zihpm/hpmcounter29h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter29h
 long_name: User-mode Hardware Performance Counter 26, high half
 address: 0xC9D
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter29h`.
 

--- a/arch/csr/Zihpm/hpmcounter3.yaml
+++ b/arch/csr/Zihpm/hpmcounter3.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter3
 long_name: User-mode Hardware Performance Counter 0
 address: 0xC03
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter3`.
 

--- a/arch/csr/Zihpm/hpmcounter30.yaml
+++ b/arch/csr/Zihpm/hpmcounter30.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter30
 long_name: User-mode Hardware Performance Counter 27
 address: 0xC1E
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter30`.
 

--- a/arch/csr/Zihpm/hpmcounter30h.yaml
+++ b/arch/csr/Zihpm/hpmcounter30h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter30h
 long_name: User-mode Hardware Performance Counter 27, high half
 address: 0xC9E
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter30h`.
 

--- a/arch/csr/Zihpm/hpmcounter30h.yaml
+++ b/arch/csr/Zihpm/hpmcounter30h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter30h
 long_name: User-mode Hardware Performance Counter 27, high half
 address: 0xC9E
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter30h`.
 

--- a/arch/csr/Zihpm/hpmcounter31.yaml
+++ b/arch/csr/Zihpm/hpmcounter31.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter31
 long_name: User-mode Hardware Performance Counter 28
 address: 0xC1F
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter31`.
 

--- a/arch/csr/Zihpm/hpmcounter31h.yaml
+++ b/arch/csr/Zihpm/hpmcounter31h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter31h
 long_name: User-mode Hardware Performance Counter 28, high half
 address: 0xC9F
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter31h`.
 

--- a/arch/csr/Zihpm/hpmcounter31h.yaml
+++ b/arch/csr/Zihpm/hpmcounter31h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter31h
 long_name: User-mode Hardware Performance Counter 28, high half
 address: 0xC9F
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter31h`.
 

--- a/arch/csr/Zihpm/hpmcounter3h.yaml
+++ b/arch/csr/Zihpm/hpmcounter3h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter3h
 long_name: User-mode Hardware Performance Counter 0, high half
 address: 0xC83
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter3h`.
 

--- a/arch/csr/Zihpm/hpmcounter3h.yaml
+++ b/arch/csr/Zihpm/hpmcounter3h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter3h
 long_name: User-mode Hardware Performance Counter 0, high half
 address: 0xC83
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter3h`.
 

--- a/arch/csr/Zihpm/hpmcounter4.yaml
+++ b/arch/csr/Zihpm/hpmcounter4.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter4
 long_name: User-mode Hardware Performance Counter 1
 address: 0xC04
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter4`.
 

--- a/arch/csr/Zihpm/hpmcounter4h.yaml
+++ b/arch/csr/Zihpm/hpmcounter4h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter4h
 long_name: User-mode Hardware Performance Counter 1, high half
 address: 0xC84
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter4h`.
 

--- a/arch/csr/Zihpm/hpmcounter4h.yaml
+++ b/arch/csr/Zihpm/hpmcounter4h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter4h
 long_name: User-mode Hardware Performance Counter 1, high half
 address: 0xC84
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter4h`.
 

--- a/arch/csr/Zihpm/hpmcounter5.yaml
+++ b/arch/csr/Zihpm/hpmcounter5.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter5
 long_name: User-mode Hardware Performance Counter 2
 address: 0xC05
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter5`.
 

--- a/arch/csr/Zihpm/hpmcounter5h.yaml
+++ b/arch/csr/Zihpm/hpmcounter5h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter5h
 long_name: User-mode Hardware Performance Counter 2, high half
 address: 0xC85
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter5h`.
 

--- a/arch/csr/Zihpm/hpmcounter5h.yaml
+++ b/arch/csr/Zihpm/hpmcounter5h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter5h
 long_name: User-mode Hardware Performance Counter 2, high half
 address: 0xC85
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter5h`.
 

--- a/arch/csr/Zihpm/hpmcounter6.yaml
+++ b/arch/csr/Zihpm/hpmcounter6.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter6
 long_name: User-mode Hardware Performance Counter 3
 address: 0xC06
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter6`.
 

--- a/arch/csr/Zihpm/hpmcounter6h.yaml
+++ b/arch/csr/Zihpm/hpmcounter6h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter6h
 long_name: User-mode Hardware Performance Counter 3, high half
 address: 0xC86
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter6h`.
 

--- a/arch/csr/Zihpm/hpmcounter6h.yaml
+++ b/arch/csr/Zihpm/hpmcounter6h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter6h
 long_name: User-mode Hardware Performance Counter 3, high half
 address: 0xC86
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter6h`.
 

--- a/arch/csr/Zihpm/hpmcounter7.yaml
+++ b/arch/csr/Zihpm/hpmcounter7.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter7
 long_name: User-mode Hardware Performance Counter 4
 address: 0xC07
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter7`.
 

--- a/arch/csr/Zihpm/hpmcounter7h.yaml
+++ b/arch/csr/Zihpm/hpmcounter7h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter7h
 long_name: User-mode Hardware Performance Counter 4, high half
 address: 0xC87
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter7h`.
 

--- a/arch/csr/Zihpm/hpmcounter7h.yaml
+++ b/arch/csr/Zihpm/hpmcounter7h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter7h
 long_name: User-mode Hardware Performance Counter 4, high half
 address: 0xC87
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter7h`.
 

--- a/arch/csr/Zihpm/hpmcounter8.yaml
+++ b/arch/csr/Zihpm/hpmcounter8.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter8
 long_name: User-mode Hardware Performance Counter 5
 address: 0xC08
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter8`.
 

--- a/arch/csr/Zihpm/hpmcounter8h.yaml
+++ b/arch/csr/Zihpm/hpmcounter8h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter8h
 long_name: User-mode Hardware Performance Counter 5, high half
 address: 0xC88
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter8h`.
 

--- a/arch/csr/Zihpm/hpmcounter8h.yaml
+++ b/arch/csr/Zihpm/hpmcounter8h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter8h
 long_name: User-mode Hardware Performance Counter 5, high half
 address: 0xC88
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter8h`.
 

--- a/arch/csr/Zihpm/hpmcounter9.yaml
+++ b/arch/csr/Zihpm/hpmcounter9.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter9
 long_name: User-mode Hardware Performance Counter 6
 address: 0xC09
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter9`.
 

--- a/arch/csr/Zihpm/hpmcounter9h.yaml
+++ b/arch/csr/Zihpm/hpmcounter9h.yaml
@@ -7,7 +7,6 @@ kind: csr
 name: hpmcounter9h
 long_name: User-mode Hardware Performance Counter 6, high half
 address: 0xC89
-base: 32
 description: |
   Alias for M-mode CSR `mhpmcounter9h`.
 

--- a/arch/csr/Zihpm/hpmcounter9h.yaml
+++ b/arch/csr/Zihpm/hpmcounter9h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: hpmcounter9h
 long_name: User-mode Hardware Performance Counter 6, high half
 address: 0xC89
+writeable: false
 description: |
   Alias for M-mode CSR `mhpmcounter9h`.
 

--- a/arch/csr/Zihpm/mhpmcounter10.yaml
+++ b/arch/csr/Zihpm/mhpmcounter10.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter10
 long_name: Machine Hardware Performance Counter 10
 address: 0xB0A
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter10h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter10h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter10h
 long_name: Machine Hardware Performance Counter 10, Upper half
 address: 0xB8A
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter11.yaml
+++ b/arch/csr/Zihpm/mhpmcounter11.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter11
 long_name: Machine Hardware Performance Counter 11
 address: 0xB0B
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter11h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter11h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter11h
 long_name: Machine Hardware Performance Counter 11, Upper half
 address: 0xB8B
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter12.yaml
+++ b/arch/csr/Zihpm/mhpmcounter12.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter12
 long_name: Machine Hardware Performance Counter 12
 address: 0xB0C
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter12h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter12h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter12h
 long_name: Machine Hardware Performance Counter 12, Upper half
 address: 0xB8C
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter13.yaml
+++ b/arch/csr/Zihpm/mhpmcounter13.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter13
 long_name: Machine Hardware Performance Counter 13
 address: 0xB0D
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter13h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter13h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter13h
 long_name: Machine Hardware Performance Counter 13, Upper half
 address: 0xB8D
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter14.yaml
+++ b/arch/csr/Zihpm/mhpmcounter14.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter14
 long_name: Machine Hardware Performance Counter 14
 address: 0xB0E
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter14h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter14h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter14h
 long_name: Machine Hardware Performance Counter 14, Upper half
 address: 0xB8E
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter15.yaml
+++ b/arch/csr/Zihpm/mhpmcounter15.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter15
 long_name: Machine Hardware Performance Counter 15
 address: 0xB0F
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter15h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter15h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter15h
 long_name: Machine Hardware Performance Counter 15, Upper half
 address: 0xB8F
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter16.yaml
+++ b/arch/csr/Zihpm/mhpmcounter16.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter16
 long_name: Machine Hardware Performance Counter 16
 address: 0xB10
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter16h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter16h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter16h
 long_name: Machine Hardware Performance Counter 16, Upper half
 address: 0xB90
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter17.yaml
+++ b/arch/csr/Zihpm/mhpmcounter17.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter17
 long_name: Machine Hardware Performance Counter 17
 address: 0xB11
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter17h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter17h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter17h
 long_name: Machine Hardware Performance Counter 17, Upper half
 address: 0xB91
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter18.yaml
+++ b/arch/csr/Zihpm/mhpmcounter18.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter18
 long_name: Machine Hardware Performance Counter 18
 address: 0xB12
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter18h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter18h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter18h
 long_name: Machine Hardware Performance Counter 18, Upper half
 address: 0xB92
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter19.yaml
+++ b/arch/csr/Zihpm/mhpmcounter19.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter19
 long_name: Machine Hardware Performance Counter 19
 address: 0xB13
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter19h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter19h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter19h
 long_name: Machine Hardware Performance Counter 19, Upper half
 address: 0xB93
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter20.yaml
+++ b/arch/csr/Zihpm/mhpmcounter20.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter20
 long_name: Machine Hardware Performance Counter 20
 address: 0xB14
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter20h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter20h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter20h
 long_name: Machine Hardware Performance Counter 20, Upper half
 address: 0xB94
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter21.yaml
+++ b/arch/csr/Zihpm/mhpmcounter21.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter21
 long_name: Machine Hardware Performance Counter 21
 address: 0xB15
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter21h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter21h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter21h
 long_name: Machine Hardware Performance Counter 21, Upper half
 address: 0xB95
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter22.yaml
+++ b/arch/csr/Zihpm/mhpmcounter22.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter22
 long_name: Machine Hardware Performance Counter 22
 address: 0xB16
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter22h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter22h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter22h
 long_name: Machine Hardware Performance Counter 22, Upper half
 address: 0xB96
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter23.yaml
+++ b/arch/csr/Zihpm/mhpmcounter23.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter23
 long_name: Machine Hardware Performance Counter 23
 address: 0xB17
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter23h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter23h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter23h
 long_name: Machine Hardware Performance Counter 23, Upper half
 address: 0xB97
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter24.yaml
+++ b/arch/csr/Zihpm/mhpmcounter24.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter24
 long_name: Machine Hardware Performance Counter 24
 address: 0xB18
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter24h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter24h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter24h
 long_name: Machine Hardware Performance Counter 24, Upper half
 address: 0xB98
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter25.yaml
+++ b/arch/csr/Zihpm/mhpmcounter25.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter25
 long_name: Machine Hardware Performance Counter 25
 address: 0xB19
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter25h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter25h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter25h
 long_name: Machine Hardware Performance Counter 25, Upper half
 address: 0xB99
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter26.yaml
+++ b/arch/csr/Zihpm/mhpmcounter26.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter26
 long_name: Machine Hardware Performance Counter 26
 address: 0xB1A
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter26h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter26h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter26h
 long_name: Machine Hardware Performance Counter 26, Upper half
 address: 0xB9A
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter27.yaml
+++ b/arch/csr/Zihpm/mhpmcounter27.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter27
 long_name: Machine Hardware Performance Counter 27
 address: 0xB1B
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter27h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter27h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter27h
 long_name: Machine Hardware Performance Counter 27, Upper half
 address: 0xB9B
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter28.yaml
+++ b/arch/csr/Zihpm/mhpmcounter28.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter28
 long_name: Machine Hardware Performance Counter 28
 address: 0xB1C
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter28h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter28h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter28h
 long_name: Machine Hardware Performance Counter 28, Upper half
 address: 0xB9C
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter29.yaml
+++ b/arch/csr/Zihpm/mhpmcounter29.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter29
 long_name: Machine Hardware Performance Counter 29
 address: 0xB1D
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter29h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter29h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter29h
 long_name: Machine Hardware Performance Counter 29, Upper half
 address: 0xB9D
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter3.yaml
+++ b/arch/csr/Zihpm/mhpmcounter3.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter3
 long_name: Machine Hardware Performance Counter 3
 address: 0xB03
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter30.yaml
+++ b/arch/csr/Zihpm/mhpmcounter30.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter30
 long_name: Machine Hardware Performance Counter 30
 address: 0xB1E
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter30h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter30h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter30h
 long_name: Machine Hardware Performance Counter 30, Upper half
 address: 0xB9E
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter31.yaml
+++ b/arch/csr/Zihpm/mhpmcounter31.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter31
 long_name: Machine Hardware Performance Counter 31
 address: 0xB1F
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter31h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter31h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter31h
 long_name: Machine Hardware Performance Counter 31, Upper half
 address: 0xB9F
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter3h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter3h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter3h
 long_name: Machine Hardware Performance Counter 3, Upper half
 address: 0xB83
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter4.yaml
+++ b/arch/csr/Zihpm/mhpmcounter4.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter4
 long_name: Machine Hardware Performance Counter 4
 address: 0xB04
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter4h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter4h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter4h
 long_name: Machine Hardware Performance Counter 4, Upper half
 address: 0xB84
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter5.yaml
+++ b/arch/csr/Zihpm/mhpmcounter5.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter5
 long_name: Machine Hardware Performance Counter 5
 address: 0xB05
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter5h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter5h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter5h
 long_name: Machine Hardware Performance Counter 5, Upper half
 address: 0xB85
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter6.yaml
+++ b/arch/csr/Zihpm/mhpmcounter6.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter6
 long_name: Machine Hardware Performance Counter 6
 address: 0xB06
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter6h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter6h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter6h
 long_name: Machine Hardware Performance Counter 6, Upper half
 address: 0xB86
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter7.yaml
+++ b/arch/csr/Zihpm/mhpmcounter7.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter7
 long_name: Machine Hardware Performance Counter 7
 address: 0xB07
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter7h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter7h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter7h
 long_name: Machine Hardware Performance Counter 7, Upper half
 address: 0xB87
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter8.yaml
+++ b/arch/csr/Zihpm/mhpmcounter8.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter8
 long_name: Machine Hardware Performance Counter 8
 address: 0xB08
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter8h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter8h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter8h
 long_name: Machine Hardware Performance Counter 8, Upper half
 address: 0xB88
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmcounter9.yaml
+++ b/arch/csr/Zihpm/mhpmcounter9.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter9
 long_name: Machine Hardware Performance Counter 9
 address: 0xB09
+writeable: true
 priv_mode: M
 length: 64
 description: Programmable hardware performance counter.

--- a/arch/csr/Zihpm/mhpmcounter9h.yaml
+++ b/arch/csr/Zihpm/mhpmcounter9h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmcounter9h
 long_name: Machine Hardware Performance Counter 9, Upper half
 address: 0xB89
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent10.yaml
+++ b/arch/csr/Zihpm/mhpmevent10.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent10
 long_name: Machine Hardware Performance Counter 10 Control
 address: 0x32A
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter10 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter10 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[10]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter10 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter10 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[10] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter10 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter10 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[10] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter10 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter10 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[10]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter10 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter10 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[10] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent10h.yaml
+++ b/arch/csr/Zihpm/mhpmevent10h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent10h
 long_name: Machine Hardware Performance Counter 10 Control, High half
 address: 0x72A
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent11.yaml
+++ b/arch/csr/Zihpm/mhpmevent11.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent11
 long_name: Machine Hardware Performance Counter 11 Control
 address: 0x32B
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter11 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter11 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[11]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter11 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter11 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[11] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter11 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter11 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[11] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter11 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter11 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[11]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter11 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter11 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[11] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent11h.yaml
+++ b/arch/csr/Zihpm/mhpmevent11h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent11h
 long_name: Machine Hardware Performance Counter 11 Control, High half
 address: 0x72B
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent12.yaml
+++ b/arch/csr/Zihpm/mhpmevent12.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent12
 long_name: Machine Hardware Performance Counter 12 Control
 address: 0x32C
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter12 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter12 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[12]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter12 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter12 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[12] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter12 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter12 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[12] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter12 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter12 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[12]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter12 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter12 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[12] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent12h.yaml
+++ b/arch/csr/Zihpm/mhpmevent12h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent12h
 long_name: Machine Hardware Performance Counter 12 Control, High half
 address: 0x72C
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent13.yaml
+++ b/arch/csr/Zihpm/mhpmevent13.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent13
 long_name: Machine Hardware Performance Counter 13 Control
 address: 0x32D
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter13 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter13 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[13]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter13 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter13 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[13] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter13 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter13 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[13] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter13 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter13 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[13]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter13 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter13 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[13] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent13h.yaml
+++ b/arch/csr/Zihpm/mhpmevent13h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent13h
 long_name: Machine Hardware Performance Counter 13 Control, High half
 address: 0x72D
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent14.yaml
+++ b/arch/csr/Zihpm/mhpmevent14.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent14
 long_name: Machine Hardware Performance Counter 14 Control
 address: 0x32E
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter14 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter14 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[14]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter14 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter14 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[14] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter14 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter14 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[14] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter14 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter14 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[14]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter14 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter14 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[14] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent14h.yaml
+++ b/arch/csr/Zihpm/mhpmevent14h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent14h
 long_name: Machine Hardware Performance Counter 14 Control, High half
 address: 0x72E
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent15.yaml
+++ b/arch/csr/Zihpm/mhpmevent15.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent15
 long_name: Machine Hardware Performance Counter 15 Control
 address: 0x32F
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter15 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter15 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[15]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter15 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter15 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[15] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter15 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter15 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[15] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter15 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter15 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[15]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter15 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter15 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[15] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent15h.yaml
+++ b/arch/csr/Zihpm/mhpmevent15h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent15h
 long_name: Machine Hardware Performance Counter 15 Control, High half
 address: 0x72F
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent16.yaml
+++ b/arch/csr/Zihpm/mhpmevent16.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent16
 long_name: Machine Hardware Performance Counter 16 Control
 address: 0x330
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter16 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter16 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[16]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter16 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter16 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[16] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter16 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter16 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[16] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter16 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter16 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[16]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter16 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter16 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[16] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent16h.yaml
+++ b/arch/csr/Zihpm/mhpmevent16h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent16h
 long_name: Machine Hardware Performance Counter 16 Control, High half
 address: 0x730
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent17.yaml
+++ b/arch/csr/Zihpm/mhpmevent17.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent17
 long_name: Machine Hardware Performance Counter 17 Control
 address: 0x331
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter17 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter17 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[17]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter17 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter17 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[17] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter17 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter17 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[17] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter17 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter17 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[17]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter17 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter17 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[17] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent17h.yaml
+++ b/arch/csr/Zihpm/mhpmevent17h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent17h
 long_name: Machine Hardware Performance Counter 17 Control, High half
 address: 0x731
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent18.yaml
+++ b/arch/csr/Zihpm/mhpmevent18.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent18
 long_name: Machine Hardware Performance Counter 18 Control
 address: 0x332
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter18 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter18 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[18]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter18 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter18 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[18] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter18 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter18 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[18] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter18 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter18 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[18]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter18 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter18 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[18] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent18h.yaml
+++ b/arch/csr/Zihpm/mhpmevent18h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent18h
 long_name: Machine Hardware Performance Counter 18 Control, High half
 address: 0x732
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent19.yaml
+++ b/arch/csr/Zihpm/mhpmevent19.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent19
 long_name: Machine Hardware Performance Counter 19 Control
 address: 0x333
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter19 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter19 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[19]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter19 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter19 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[19] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter19 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter19 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[19] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter19 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter19 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[19]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter19 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter19 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[19] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent19h.yaml
+++ b/arch/csr/Zihpm/mhpmevent19h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent19h
 long_name: Machine Hardware Performance Counter 19 Control, High half
 address: 0x733
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent20.yaml
+++ b/arch/csr/Zihpm/mhpmevent20.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent20
 long_name: Machine Hardware Performance Counter 20 Control
 address: 0x334
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter20 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter20 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[20]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter20 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter20 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[20] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter20 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter20 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[20] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter20 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter20 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[20]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter20 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter20 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[20] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent20h.yaml
+++ b/arch/csr/Zihpm/mhpmevent20h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent20h
 long_name: Machine Hardware Performance Counter 20 Control, High half
 address: 0x734
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent21.yaml
+++ b/arch/csr/Zihpm/mhpmevent21.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent21
 long_name: Machine Hardware Performance Counter 21 Control
 address: 0x335
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter21 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter21 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[21]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter21 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter21 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[21] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter21 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter21 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[21] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter21 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter21 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[21]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter21 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter21 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[21] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent21h.yaml
+++ b/arch/csr/Zihpm/mhpmevent21h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent21h
 long_name: Machine Hardware Performance Counter 21 Control, High half
 address: 0x735
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent22.yaml
+++ b/arch/csr/Zihpm/mhpmevent22.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent22
 long_name: Machine Hardware Performance Counter 22 Control
 address: 0x336
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter22 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter22 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[22]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter22 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter22 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[22] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter22 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter22 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[22] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter22 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter22 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[22]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter22 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter22 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[22] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent22h.yaml
+++ b/arch/csr/Zihpm/mhpmevent22h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent22h
 long_name: Machine Hardware Performance Counter 22 Control, High half
 address: 0x736
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent23.yaml
+++ b/arch/csr/Zihpm/mhpmevent23.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent23
 long_name: Machine Hardware Performance Counter 23 Control
 address: 0x337
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter23 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter23 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[23]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter23 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter23 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[23] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter23 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter23 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[23] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter23 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter23 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[23]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter23 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter23 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[23] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent23h.yaml
+++ b/arch/csr/Zihpm/mhpmevent23h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent23h
 long_name: Machine Hardware Performance Counter 23 Control, High half
 address: 0x737
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent24.yaml
+++ b/arch/csr/Zihpm/mhpmevent24.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent24
 long_name: Machine Hardware Performance Counter 24 Control
 address: 0x338
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter24 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter24 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[24]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter24 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter24 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[24] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter24 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter24 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[24] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter24 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter24 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[24]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter24 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter24 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[24] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent24h.yaml
+++ b/arch/csr/Zihpm/mhpmevent24h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent24h
 long_name: Machine Hardware Performance Counter 24 Control, High half
 address: 0x738
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent25.yaml
+++ b/arch/csr/Zihpm/mhpmevent25.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent25
 long_name: Machine Hardware Performance Counter 25 Control
 address: 0x339
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter25 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter25 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[25]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter25 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter25 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[25] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter25 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter25 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[25] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter25 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter25 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[25]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter25 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter25 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[25] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent25h.yaml
+++ b/arch/csr/Zihpm/mhpmevent25h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent25h
 long_name: Machine Hardware Performance Counter 25 Control, High half
 address: 0x739
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent26.yaml
+++ b/arch/csr/Zihpm/mhpmevent26.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent26
 long_name: Machine Hardware Performance Counter 26 Control
 address: 0x33A
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter26 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter26 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[26]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter26 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter26 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[26] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter26 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter26 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[26] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter26 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter26 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[26]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter26 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter26 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[26] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent26h.yaml
+++ b/arch/csr/Zihpm/mhpmevent26h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent26h
 long_name: Machine Hardware Performance Counter 26 Control, High half
 address: 0x73A
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent27.yaml
+++ b/arch/csr/Zihpm/mhpmevent27.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent27
 long_name: Machine Hardware Performance Counter 27 Control
 address: 0x33B
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter27 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter27 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[27]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter27 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter27 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[27] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter27 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter27 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[27] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter27 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter27 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[27]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter27 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter27 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[27] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent27h.yaml
+++ b/arch/csr/Zihpm/mhpmevent27h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent27h
 long_name: Machine Hardware Performance Counter 27 Control, High half
 address: 0x73B
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent28.yaml
+++ b/arch/csr/Zihpm/mhpmevent28.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent28
 long_name: Machine Hardware Performance Counter 28 Control
 address: 0x33C
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter28 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter28 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[28]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter28 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter28 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[28] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter28 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter28 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[28] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter28 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter28 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[28]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter28 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter28 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[28] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent28h.yaml
+++ b/arch/csr/Zihpm/mhpmevent28h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent28h
 long_name: Machine Hardware Performance Counter 28 Control, High half
 address: 0x73C
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent29.yaml
+++ b/arch/csr/Zihpm/mhpmevent29.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent29
 long_name: Machine Hardware Performance Counter 29 Control
 address: 0x33D
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter29 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter29 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[29]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter29 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter29 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[29] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter29 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter29 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[29] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter29 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter29 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[29]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter29 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter29 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[29] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent29h.yaml
+++ b/arch/csr/Zihpm/mhpmevent29h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent29h
 long_name: Machine Hardware Performance Counter 29 Control, High half
 address: 0x73D
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent3.yaml
+++ b/arch/csr/Zihpm/mhpmevent3.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent3
 long_name: Machine Hardware Performance Counter 3 Control
 address: 0x323
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter3 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter3 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[3]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter3 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter3 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[3] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter3 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter3 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[3] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter3 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter3 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[3]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter3 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter3 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[3] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent30.yaml
+++ b/arch/csr/Zihpm/mhpmevent30.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent30
 long_name: Machine Hardware Performance Counter 30 Control
 address: 0x33E
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter30 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter30 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[30]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter30 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter30 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[30] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter30 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter30 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[30] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter30 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter30 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[30]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter30 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter30 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[30] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent30h.yaml
+++ b/arch/csr/Zihpm/mhpmevent30h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent30h
 long_name: Machine Hardware Performance Counter 30 Control, High half
 address: 0x73E
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent31.yaml
+++ b/arch/csr/Zihpm/mhpmevent31.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent31
 long_name: Machine Hardware Performance Counter 31 Control
 address: 0x33F
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter31 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter31 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[31]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter31 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter31 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[31] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter31 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter31 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[31] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter31 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter31 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[31]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter31 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter31 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[31] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent31h.yaml
+++ b/arch/csr/Zihpm/mhpmevent31h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent31h
 long_name: Machine Hardware Performance Counter 31 Control, High half
 address: 0x73F
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent3h.yaml
+++ b/arch/csr/Zihpm/mhpmevent3h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent3h
 long_name: Machine Hardware Performance Counter 3 Control, High half
 address: 0x723
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent4.yaml
+++ b/arch/csr/Zihpm/mhpmevent4.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent4
 long_name: Machine Hardware Performance Counter 4 Control
 address: 0x324
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter4 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter4 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[4]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter4 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter4 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[4] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter4 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter4 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[4] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter4 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter4 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[4]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter4 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter4 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[4] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent4h.yaml
+++ b/arch/csr/Zihpm/mhpmevent4h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent4h
 long_name: Machine Hardware Performance Counter 4 Control, High half
 address: 0x724
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent5.yaml
+++ b/arch/csr/Zihpm/mhpmevent5.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent5
 long_name: Machine Hardware Performance Counter 5 Control
 address: 0x325
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter5 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter5 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[5]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter5 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter5 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[5] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter5 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter5 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[5] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter5 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter5 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[5]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter5 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter5 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[5] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent5h.yaml
+++ b/arch/csr/Zihpm/mhpmevent5h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent5h
 long_name: Machine Hardware Performance Counter 5 Control, High half
 address: 0x725
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent6.yaml
+++ b/arch/csr/Zihpm/mhpmevent6.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent6
 long_name: Machine Hardware Performance Counter 6 Control
 address: 0x326
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter6 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter6 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[6]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter6 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter6 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[6] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter6 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter6 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[6] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter6 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter6 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[6]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter6 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter6 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[6] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent6h.yaml
+++ b/arch/csr/Zihpm/mhpmevent6h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent6h
 long_name: Machine Hardware Performance Counter 6 Control, High half
 address: 0x726
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent7.yaml
+++ b/arch/csr/Zihpm/mhpmevent7.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent7
 long_name: Machine Hardware Performance Counter 7 Control
 address: 0x327
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter7 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter7 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[7]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter7 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter7 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[7] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter7 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter7 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[7] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter7 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter7 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[7]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter7 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter7 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[7] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent7h.yaml
+++ b/arch/csr/Zihpm/mhpmevent7h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent7h
 long_name: Machine Hardware Performance Counter 7 Control, High half
 address: 0x727
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent8.yaml
+++ b/arch/csr/Zihpm/mhpmevent8.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent8
 long_name: Machine Hardware Performance Counter 8 Control
 address: 0x328
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter8 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter8 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[8]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter8 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter8 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[8] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter8 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter8 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[8] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter8 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter8 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[8]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter8 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter8 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[8] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent8h.yaml
+++ b/arch/csr/Zihpm/mhpmevent8h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent8h
 long_name: Machine Hardware Performance Counter 8 Control, High half
 address: 0x728
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/Zihpm/mhpmevent9.yaml
+++ b/arch/csr/Zihpm/mhpmevent9.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent9
 long_name: Machine Hardware Performance Counter 9 Control
 address: 0x329
+writeable: true
 priv_mode: M
 length: 64
 description: |
@@ -42,7 +43,9 @@ fields:
     definedBy: Sscofpmf
   MINH:
     location: 62
-    description: When set, mhpmcounter9 does not increment while the hart in operating in M-mode.
+    description:
+      When set, mhpmcounter9 does not increment while the hart in operating
+      in M-mode.
     type(): |
       if (HPM_COUNTER_EN[9]) {
         return CsrFieldType::RW;
@@ -58,7 +61,9 @@ fields:
     definedBy: Sscofpmf
   SINH:
     location: 61
-    description: When set, mhpmcounter9 does not increment while the hart in operating in (H)S-mode.
+    description:
+      When set, mhpmcounter9 does not increment while the hart in operating
+      in (H)S-mode.
     type(): |
       if (HPM_COUNTER_EN[9] && implemented?(ExtensionName::S) && (CSR[misa].S == 1'b1)) {
         return CsrFieldType::RW;
@@ -74,7 +79,9 @@ fields:
     definedBy: Sscofpmf
   UINH:
     location: 60
-    description: When set, mhpmcounter9 does not increment while the hart in operating in U-mode.
+    description:
+      When set, mhpmcounter9 does not increment while the hart in operating
+      in U-mode.
     type(): |
       if (HPM_COUNTER_EN[9] && implemented?(ExtensionName::U) && (CSR[misa].U == 1'b1)) {
         return CsrFieldType::RW;
@@ -90,7 +97,9 @@ fields:
     definedBy: Sscofpmf
   VSINH:
     location: 59
-    description: When set, mhpmcounter9 does not increment while the hart in operating in VS-mode.
+    description:
+      When set, mhpmcounter9 does not increment while the hart in operating
+      in VS-mode.
     type(): |
       if ((HPM_COUNTER_EN[9]) && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;
@@ -106,7 +115,9 @@ fields:
     definedBy: Sscofpmf
   VUINH:
     location: 58
-    description: When set, mhpmcounter9 does not increment while the hart in operating in VU-mode.
+    description:
+      When set, mhpmcounter9 does not increment while the hart in operating
+      in VU-mode.
     type(): |
       if (HPM_COUNTER_EN[9] && implemented?(ExtensionName::H) && (CSR[misa].H == 1'b1)) {
         return CsrFieldType::RW;

--- a/arch/csr/Zihpm/mhpmevent9h.yaml
+++ b/arch/csr/Zihpm/mhpmevent9h.yaml
@@ -7,6 +7,7 @@ kind: csr
 name: mhpmevent9h
 long_name: Machine Hardware Performance Counter 9 Control, High half
 address: 0x729
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/cycle.yaml
+++ b/arch/csr/cycle.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: cycle
 long_name: Cycle counter for RDCYCLE Instruction
 address: 0xC00
+writeable: false
 description: |
   Alias for M-mode CSR `mcycle`.
 

--- a/arch/csr/cycleh.yaml
+++ b/arch/csr/cycleh.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: cycleh
 long_name: High-half cycle counter for RDCYCLE Instruction
 address: 0xC80
+writeable: false
 base: 32
 description: |
   Alias for M-mode CSR `mcycleh`.

--- a/arch/csr/hedeleg.yaml
+++ b/arch/csr/hedeleg.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: hedeleg
 long_name: Hypervisor Exception Delegation
 address: 0x602
+writeable: true
 priv_mode: S
 length: 64
 description: |

--- a/arch/csr/hedelegh.yaml
+++ b/arch/csr/hedelegh.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: hedelegh
 long_name: Hypervisor Exception Delegation High
 address: 0x612
+writeable: true
 base: 32
 priv_mode: S
 length: 32

--- a/arch/csr/hstatus.yaml
+++ b/arch/csr/hstatus.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: hstatus
 long_name: Hypervisor Status
 address: 0x600
+writeable: true
 priv_mode: S
 length: SXLEN
 description: |

--- a/arch/csr/instret.yaml
+++ b/arch/csr/instret.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: instret
 long_name: Instructions retired counter for RDINSTRET Instruction
 address: 0xC02
+writeable: false
 description: |
   Alias for M-mode CSR `minstret`.
 

--- a/arch/csr/instreth.yaml
+++ b/arch/csr/instreth.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: instreth
 long_name: Instructions retired counter, high bits
 address: 0xC82
+writeable: false
 base: 32
 description: |
   Alias for high bits of M-mode CSR `minstret`[63:32].

--- a/arch/csr/marchid.yaml
+++ b/arch/csr/marchid.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: marchid
 long_name: Machine Architecture ID
 address: 0xf12
+writeable: false
 priv_mode: M
 length: MXLEN
 description: |

--- a/arch/csr/mcause.yaml
+++ b/arch/csr/mcause.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mcause
 long_name: Machine Cause
 address: 0x342
+writeable: true
 priv_mode: M
 length: MXLEN
 description: Reports the cause of the latest exception.

--- a/arch/csr/mconfigptr.yaml
+++ b/arch/csr/mconfigptr.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mconfigptr
 long_name: Machine Configuration Pointer
 address: 0xF15
+writeable: false
 description: |
   Holds a physical address pointer to the unified discovery data structure in Memory.
 
@@ -45,7 +46,9 @@ fields:
   ADDRESS:
     location_rv32: 31-0
     location_rv64: 63-0
-    description: Pointer to physical address of the Unified Discovery configuration data structure.
+    description:
+      Pointer to physical address of the Unified Discovery configuration
+      data structure.
     type: RO
     reset_value(): |
       return CONFIG_PTR_ADDRESS;

--- a/arch/csr/mcycle.yaml
+++ b/arch/csr/mcycle.yaml
@@ -6,6 +6,7 @@ name: mcycle
 long_name: Machine Cycle Counter
 definedBy: Zicntr
 address: 0xB00
+writeable: true
 description: |
   Counts the number of clock cycles executed by the processor core on which
   the hart is running.

--- a/arch/csr/mcycleh.yaml
+++ b/arch/csr/mcycleh.yaml
@@ -6,6 +6,7 @@ name: mcycleh
 long_name: High-half machine Cycle Counter
 definedBy: Zicntr
 address: 0xB80
+writeable: true
 description: |
   High-half alias of `mcycle`.
 priv_mode: M

--- a/arch/csr/medeleg.yaml
+++ b/arch/csr/medeleg.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: medeleg
 long_name: Machine Exception Delegation
 address: 0x302
+writeable: true
 priv_mode: M
 length: 64
 description: |

--- a/arch/csr/medelegh.yaml
+++ b/arch/csr/medelegh.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: medelegh
 long_name: Machine Exception Delegation, High bits
 address: 0x312
+writeable: true
 priv_mode: M
 length: 32
 base: 32

--- a/arch/csr/menvcfg.yaml
+++ b/arch/csr/menvcfg.yaml
@@ -4,6 +4,7 @@ $schema: "csr_schema.json#"
 kind: csr
 name: menvcfg
 address: 0x30A
+writeable: true
 long_name: Machine Environment Configuration
 description: |
   Contains fields that control certain characteristics of the execution environment

--- a/arch/csr/menvcfgh.yaml
+++ b/arch/csr/menvcfgh.yaml
@@ -4,6 +4,7 @@ $schema: "csr_schema.json#"
 kind: csr
 name: menvcfgh
 address: 0x31A
+writeable: true
 base: 32
 long_name: Machine Environment Configuration
 description: Contains bits to enable/disable extensions

--- a/arch/csr/mepc.yaml
+++ b/arch/csr/mepc.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mepc
 long_name: Machine Exception Program Counter
 address: 0x341
+writeable: true
 priv_mode: M
 length: MXLEN
 description: |

--- a/arch/csr/mhartid.yaml
+++ b/arch/csr/mhartid.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mhartid
 long_name: Machine Hart ID
 address: 0xf14
+writeable: false
 priv_mode: M
 length: MXLEN
 description: Reports the unique hart-specific ID in the system.

--- a/arch/csr/mideleg.yaml
+++ b/arch/csr/mideleg.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mideleg
 long_name: Machine Interrupt Delegation
 address: 0x303
+writeable: true
 priv_mode: M
 length: MXLEN
 definedBy:

--- a/arch/csr/mie.yaml
+++ b/arch/csr/mie.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mie
 long_name: Machine Interrupt Enable
 address: 0x304
+writeable: true
 priv_mode: M
 length: MXLEN
 definedBy: Sm

--- a/arch/csr/mimpid.yaml
+++ b/arch/csr/mimpid.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mimpid
 long_name: Machine Implementation ID
 address: 0xf13
+writeable: false
 priv_mode: M
 length: MXLEN
 description: |

--- a/arch/csr/minstret.yaml
+++ b/arch/csr/minstret.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: minstret
 long_name: Machine Instructions Retired Counter
 address: 0xB02
+writeable: true
 description: |
   Counts the number of instructions retired by this hart from some arbitrary start point in the past.
 

--- a/arch/csr/minstreth.yaml
+++ b/arch/csr/minstreth.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: minstreth
 long_name: Machine Instructions Retired Counter
 address: 0xB82
+writeable: true
 description: |
   Upper half of 64-bit instructions retired counters.
 

--- a/arch/csr/mip.yaml
+++ b/arch/csr/mip.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mip
 long_name: Machine Interrupt Pending
 address: 0x344
+writeable: true
 priv_mode: M
 
 # Description is shared with mie CSR (it copies it from here).

--- a/arch/csr/misa.yaml
+++ b/arch/csr/misa.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: misa
 long_name: Machine ISA Control
 address: 0x301
+writeable: true
 priv_mode: M
 length: MXLEN
 description: Reports the XLEN and "major" extensions supported by the ISA.

--- a/arch/csr/mscratch.yaml
+++ b/arch/csr/mscratch.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mscratch
 long_name: Machine Scratch Register
 address: 0x340
+writeable: true
 priv_mode: M
 length: MXLEN
 description: Scratch register for software use. Bits are not interpreted by hardware.

--- a/arch/csr/mseccfg.yaml
+++ b/arch/csr/mseccfg.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mseccfg
 long_name: Machine Security Configuration
 address: 0x747
+writeable: true
 priv_mode: M
 length: 64
 description: Machine Security Configuration

--- a/arch/csr/mseccfgh.yaml
+++ b/arch/csr/mseccfgh.yaml
@@ -6,6 +6,7 @@ name: mseccfgh
 long_name: Most significant 32 bits of Machine Security Configuration
 base: 32
 address: 0x757
+writeable: true
 priv_mode: M
 length: 32
 description: Machine Security Configuration

--- a/arch/csr/mstatus.yaml
+++ b/arch/csr/mstatus.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mstatus
 long_name: Machine Status
 address: 0x300
+writeable: true
 priv_mode: M
 
 # length is MXLEN-bit
@@ -12,7 +13,9 @@ priv_mode: M
 # MXLEN cannot change dynamically, so this will be converted to an integer
 # in the generated, configuration-dependent spec
 length: MXLEN
-description: The mstatus register tracks and controls the hart's current operating state.
+description:
+  The mstatus register tracks and controls the hart's current operating
+  state.
 definedBy: Sm
 fields:
   SD:

--- a/arch/csr/mstatush.yaml
+++ b/arch/csr/mstatush.yaml
@@ -5,10 +5,13 @@ kind: csr
 name: mstatush
 long_name: Machine Status High
 address: 0x310
+writeable: true
 priv_mode: M
 base: 32
 length: 32
-description: The mstatus register tracks and controls the hart's current operating state.
+description:
+  The mstatus register tracks and controls the hart's current operating
+  state.
 definedBy:
   name: Sm
   version: ">= 1.12"

--- a/arch/csr/mtval.yaml
+++ b/arch/csr/mtval.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mtval
 long_name: Machine Trap Value
 address: 0x343
+writeable: true
 description: Holds trap-specific information
 priv_mode: M
 length: MXLEN

--- a/arch/csr/mtvec.yaml
+++ b/arch/csr/mtvec.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mtvec
 long_name: Machine Trap Vector Control
 address: 0x305
+writeable: true
 priv_mode: M
 length: MXLEN
 description: Controls where traps jump.

--- a/arch/csr/mvendorid.yaml
+++ b/arch/csr/mvendorid.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: mvendorid
 long_name: Machine Vendor ID
 address: 0xf11
+writeable: false
 priv_mode: M
 length: 32
 description: Reports the JEDEC manufacturer ID of the core.

--- a/arch/csr/satp.yaml
+++ b/arch/csr/satp.yaml
@@ -4,8 +4,11 @@ $schema: "csr_schema.json#"
 kind: csr
 name: satp
 address: 0x180
+writeable: true
 long_name: Supervisor Address Translation and Protection
-description: Controls the translation mode in (H)S-mode and U-mode, and holds the current ASID and page table base pointer.
+description:
+  Controls the translation mode in (H)S-mode and U-mode, and holds the
+  current ASID and page table base pointer.
 priv_mode: S
 length: SXLEN
 definedBy: S

--- a/arch/csr/scause.yaml
+++ b/arch/csr/scause.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: scause
 long_name: Supervisor Cause
 address: 0x142
+writeable: true
 priv_mode: S
 length: SXLEN
 description: Reports the cause of the latest exception.

--- a/arch/csr/senvcfg.yaml
+++ b/arch/csr/senvcfg.yaml
@@ -4,6 +4,7 @@ $schema: "csr_schema.json#"
 kind: csr
 name: senvcfg
 address: 0x10A
+writeable: true
 long_name: Supervisor Environment Configuration
 description: |
   Contains fields that control certain characteristics of the U-mode execution environment.

--- a/arch/csr/sepc.yaml
+++ b/arch/csr/sepc.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: sepc
 long_name: Supervisor Exception Program Counter
 address: 0x141
+writeable: true
 priv_mode: S
 length: 64
 description: |

--- a/arch/csr/sip.yaml
+++ b/arch/csr/sip.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: sip
 long_name: Supervisor Interrupt Pending
 address: 0x144
+writeable: true
 priv_mode: S
 description: |
   A restricted view of the interrupt pending bits in `mip`.

--- a/arch/csr/sscratch.yaml
+++ b/arch/csr/sscratch.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: sscratch
 long_name: Supervisor Scratch Register
 address: 0x140
+writeable: true
 priv_mode: S
 length: 64
 description: Scratch register for software use. Bits are not interpreted by hardware.

--- a/arch/csr/sstatus.yaml
+++ b/arch/csr/sstatus.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: sstatus
 long_name: Supervisor Status
 address: 0x100
+writeable: true
 priv_mode: S
 length: SXLEN
 description: |

--- a/arch/csr/stval.yaml
+++ b/arch/csr/stval.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: stval
 long_name: Supervisor Trap Value
 address: 0x143
+writeable: true
 description: Holds trap-specific information
 priv_mode: S
 length: 64

--- a/arch/csr/stvec.yaml
+++ b/arch/csr/stvec.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: stvec
 long_name: Supervisor Trap Vector
 address: 0x105
+writeable: true
 priv_mode: S
 length: 64
 description: Controls where traps jump.

--- a/arch/csr/time.yaml
+++ b/arch/csr/time.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: time
 long_name: Timer for RDTIME Instruction
 address: 0xC01
+writeable: false
 description: |
   [when,"TIME_CSR_IMPLEMENTED == false"]
   This CSR does not exist, and access will cause an IllegalInstruction exception.

--- a/arch/csr/timeh.yaml
+++ b/arch/csr/timeh.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: timeh
 long_name: High-half timer for RDTIME Instruction
 address: 0xC81
+writeable: false
 base: 32
 description: |
   [when,"TIME_CSR_IMPLEMENTED == false"]

--- a/arch/csr/vscause.yaml
+++ b/arch/csr/vscause.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: vscause
 long_name: Virtual Supervisor Cause
 address: 0x242
+writeable: true
 virtual_address: 0x142
 priv_mode: VS
 length: VSXLEN

--- a/arch/csr/vsepc.yaml
+++ b/arch/csr/vsepc.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: vsepc
 long_name: Virtual Supervisor Exception Program Counter
 address: 0x241
+writeable: true
 virtual_address: 0x141
 priv_mode: VS
 length: 64

--- a/arch/csr/vsstatus.yaml
+++ b/arch/csr/vsstatus.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: vsstatus
 long_name: Virtual Supervisor Status
 address: 0x200
+writeable: true
 virtual_address: 0x100
 priv_mode: VS
 length: VSXLEN

--- a/arch/csr/vstval.yaml
+++ b/arch/csr/vstval.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: vstval
 long_name: Virtual supervisor Trap Value
 address: 0x243
+writeable: true
 virtual_address: 0x143
 description: Holds trap-specific information
 priv_mode: S

--- a/arch/csr/vstvec.yaml
+++ b/arch/csr/vstvec.yaml
@@ -5,6 +5,7 @@ kind: csr
 name: vstvec
 long_name: Supervisor Trap Vector
 address: 0x205
+writeable: true
 virtual_address: 0x105
 priv_mode: S
 length: 64

--- a/arch/inst/Zicsr/csrrc.yaml
+++ b/arch/inst/Zicsr/csrrc.yaml
@@ -24,16 +24,26 @@ access:
   vu: always
 data_independent_timing: false
 operation(): |
-  Boolean will_write = xs1 != 0;
-  check_csr(csr, will_write, $encoding);
+  Csr csr_handle = direct_csr_lookup(csr);
 
-  XReg initial_csr_value = CSR[csr].sw_read();
+  Boolean will_write = xs1 != 0;
+
+  # permission checks
+  if (csr_handle.valid == false) {
+    unimplemented_csr($encoding);
+  } else if (!compatible_mode?(csr_handle.mode, mode())) {
+    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  } else if (will_write && csr_handle.writable == false) {
+    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  }
+
+  XReg initial_csr_value = csr_sw_read(csr_handle);
 
   if (xs1 != 0) {
     # clear bits using the mask
     # performing any WARL transformations first
     XReg mask = X[xs1];
-    CSR[csr].sw_write(initial_csr_value & ~mask);
+    csr_sw_write(csr_handle, initial_csr_value & ~mask);
   }
 
   X[xd] = initial_csr_value;

--- a/arch/inst/Zicsr/csrrci.yaml
+++ b/arch/inst/Zicsr/csrrci.yaml
@@ -25,15 +25,25 @@ access:
 data_independent_timing: false
 operation(): |
   Boolean will_write = uimm != 0;
-  check_csr(csr, will_write, $encoding);
 
-  XReg initial_csr_value = CSR[csr].sw_read();
+  Csr csr_handle = direct_csr_lookup(csr);
 
-  if (uimm != 0) {
+  # permission checks
+  if (csr_handle.valid == false) {
+    unimplemented_csr($encoding);
+  } else if (!compatible_mode?(csr_handle.mode, mode())) {
+    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  } else if (will_write && csr_handle.writable == false) {
+    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  }
+
+  XReg initial_csr_value = csr_sw_read(csr_handle);
+
+  if (will_write) {
     # set bits using the mask
     # performing any WARL transformations first
     XReg mask = uimm;
-    CSR[csr].sw_write(initial_csr_value & ~mask);
+    csr_sw_write(csr_handle, initial_csr_value & ~mask);
   }
 
   X[xd] = initial_csr_value;

--- a/arch/inst/Zicsr/csrrs.yaml
+++ b/arch/inst/Zicsr/csrrs.yaml
@@ -31,15 +31,25 @@ access:
   vu: always
 operation(): |
   Boolean will_write = rs1 != 0;
-  check_csr(csr, will_write, $encoding);
 
-  XReg initial_csr_value = CSR[csr].sw_read();
+  Csr csr_handle = direct_csr_lookup(csr);
+
+  # permission checks
+  if (csr_handle.valid == false) {
+    unimplemented_csr($encoding);
+  } else if (!compatible_mode?(csr_handle.mode, mode())) {
+    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  } else if (will_write && csr_handle.writable == false) {
+    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  }
+
+  XReg initial_csr_value = csr_sw_read(csr_handle);
 
   if (will_write) {
     # set bits using the mask
     # performing any WARL transformations first
     XReg mask = X[rs1];
-    CSR[csr].sw_write(initial_csr_value | mask);
+    csr_sw_write(csr_handle, initial_csr_value | mask);
   }
 
   X[rd] = initial_csr_value;

--- a/arch/inst/Zicsr/csrrsi.yaml
+++ b/arch/inst/Zicsr/csrrsi.yaml
@@ -25,15 +25,25 @@ access:
 data_independent_timing: false
 operation(): |
   Boolean will_write = uimm != 0;
-  check_csr(csr, will_write, $encoding);
 
-  XReg initial_csr_value = CSR[csr].sw_read();
+  Csr csr_handle = direct_csr_lookup(csr);
+
+  # permission checks
+  if (csr_handle.valid == false) {
+    unimplemented_csr($encoding);
+  } else if (!compatible_mode?(csr_handle.mode, mode())) {
+    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  } else if (will_write && csr_handle.writable == false) {
+    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  }
+
+  XReg initial_csr_value = csr_sw_read(csr_handle);
 
   if (will_write) {
     # set bits using the mask
     # performing any WARL transformations first
     XReg mask = uimm;
-    CSR[csr].sw_write(initial_csr_value | mask);
+    csr_sw_write(csr_handle, initial_csr_value | mask);
   }
 
   X[xd] = initial_csr_value;

--- a/arch/inst/Zicsr/csrrw.yaml
+++ b/arch/inst/Zicsr/csrrw.yaml
@@ -29,17 +29,26 @@ access:
   vs: always
   vu: always
 operation(): |
-  check_csr(csr, true, $encoding);
+  Csr csr_handle = direct_csr_lookup(csr);
 
   Bits<XLEN> initial_value = X[xs1];
 
+  # permission checks
+  if (csr_handle.valid == false) {
+    unimplemented_csr($encoding);
+  } else if (!compatible_mode?(csr_handle.mode, mode())) {
+    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  } else if (csr_handle.writable == false) {
+    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  }
+
   if (xd != 0) {
-    X[xd] = CSR[csr].sw_read();
+    X[xd] = csr_sw_read(csr_handle);
   }
 
   # writes the value in X[xs1] to the CSR,
   # performing any WARL transformations first
-  CSR[csr].sw_write(initial_value);
+  csr_sw_write(csr_handle, initial_value);
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/arch/inst/Zicsr/csrrwi.yaml
+++ b/arch/inst/Zicsr/csrrwi.yaml
@@ -29,15 +29,24 @@ access:
   vs: always
   vu: always
 operation(): |
-  check_csr(csr, true, $encoding);
+  Csr csr_handle = direct_csr_lookup(csr);
+
+  # permission checks
+  if (csr_handle.valid == false) {
+    unimplemented_csr($encoding);
+  } else if (!compatible_mode?(csr_handle.mode, mode())) {
+    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  } else if (csr_handle.writable == false) {
+    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  }
 
   if (rd != 0) {
-    X[rd] = CSR[csr].sw_read();
+    X[rd] = csr_sw_read(csr_handle);
   }
 
   # writes the zero-extended immediate to the CSR,
   # performing any WARL transformations first
-  CSR[csr].sw_write({{XLEN-5{1'b0}}, imm});
+  csr_sw_write(csr_handle, {{XLEN-5{1'b0}}, imm});
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/arch/isa/builtin_functions.idl
+++ b/arch/isa/builtin_functions.idl
@@ -24,6 +24,75 @@ generated function implemented_csr? {
   }
 }
 
+enum CsrAddressType {
+  Direct     # accessible with csrrw, etc.
+  Indirect   # only accessible with csrind
+}
+
+struct Csr {
+  Boolean valid;
+  String name;
+  CsrAddressType addr_type;
+  Bits<64> address;
+  PrivilegeMode mode;
+  Boolean writable;
+}
+
+# implementation is generated from CSR YAML defintions
+generated function direct_csr_lookup {
+  returns Csr
+  arguments
+    Bits<12> csr_addr
+  description {
+    Return CSR info for a CSR with direct address +csr_addr+.
+
+    If no CSR exists, <return_value>.valid == false
+  }
+}
+
+# implementation is generated from CSR YAML defintions
+generated function indirect_csr_lookup {
+  returns Csr
+  arguments
+    Bits<XLEN> csr_addr
+  description {
+    Return CSR info for a CSR with indirect address +csr_addr+.
+
+    If no CSR exists, <return_value>.valid == false
+  }
+}
+
+generated function csr_hw_read {
+  returns Bits<64>   # even in rv32, there are 64-bit CSRs
+  arguments
+    Csr csr
+  description {
+    Returns the raw value of csr
+  }
+}
+
+# implementation is generated from CSR YAML defintions
+generated function csr_sw_read {
+  returns Bits<64>   # even in rv32, there are 64-bit CSRs
+  arguments
+    Csr csr
+  description {
+    Returns the result of CSR[csr].sw_read(); i.e., the software view of the register
+  }
+}
+
+# implementation is generated from CSR YAML defintions
+generated function csr_sw_write {
+  arguments
+    Csr csr,
+    Bits<XLEN> value
+  description {
+    Writes +value+ to +csr+, applying an WARL transformations first.
+
+    Uses the sw_write(...) functions of CSR field definitions.
+  }
+}
+
 builtin function unpredictable {
   arguments String why
   description {

--- a/arch/isa/globals.isa
+++ b/arch/isa/globals.isa
@@ -267,6 +267,41 @@ function set_mode {
   }
 }
 
+function compatible_mode? {
+  returns Boolean
+  arguments
+    PrivilegeMode target_mode,
+    PrivilegeMode actual_mode
+  description {
+    Returns true if +target_mode+ is more privileged than +actual_mode+.
+  }
+  body {
+    if (target_mode == PrivilegeMode::M) {
+      return actual_mode == PrivilegeMode::M;
+    } else if (target_mode == PrivilegeMode::S) {
+      return
+        (actual_mode == PrivilegeMode::M) ||
+        (actual_mode == PrivilegeMode::S);
+    } else if (target_mode == PrivilegeMode::U) {
+      return
+        (actual_mode == PrivilegeMode::M) ||
+        (actual_mode == PrivilegeMode::S) ||
+        (actual_mode == PrivilegeMode::U);
+    } else if (target_mode == PrivilegeMode::VS) {
+      return
+        (actual_mode == PrivilegeMode::M) ||
+        (actual_mode == PrivilegeMode::S) ||
+        (actual_mode == PrivilegeMode::VS);
+    } else if (target_mode == PrivilegeMode::VU) {
+      return
+        (actual_mode == PrivilegeMode::M) ||
+        (actual_mode == PrivilegeMode::S) ||
+        (actual_mode == PrivilegeMode::VS) ||
+        (actual_mode == PrivilegeMode::VU);
+    }
+  }
+}
+
 function exception_handling_mode {
   returns PrivilegeMode
   arguments ExceptionCode exception_code
@@ -511,79 +546,6 @@ function stval_for {
       return tval;
     } else {
       return 0;
-    }
-  }
-}
-
-function csr? {
-  returns Boolean
-  arguments Bits<12> csr_addr
-  description {
-    Returns true if csr_addr is an implemented csr, and the defining extension is not disabled
-  }
-  body {
-    if (!implemented_csr?(csr_addr)) {
-      return false;
-    }
-
-    if (implemented?(ExtensionName::S)
-        && !CSR[csr_addr].implemented_without?(ExtensionName::S)) {
-
-      return CSR[misa].S == 1'b1;
-
-    } else if (implemented?(ExtensionName::U)
-               && !CSR[csr_addr].implemented_without?(ExtensionName::U)) {
-
-      return CSR[misa].U == 1'b1;
-
-    } else if (implemented?(ExtensionName::H)
-               && !CSR[csr_addr].implemented_without?(ExtensionName::H)) {
-
-      return CSR[misa].H == 1'b1;
-    }
-
-    return true;
-  }
-}
-
-function check_csr {
-  arguments Bits<12> csr_addr, Boolean for_write, Bits<INSTR_ENC_SIZE> encoding
-  description {
-    Checks if 'csr_addr' is a valid address, can be read in the current mode,
-    and, if for_write is true, can be written in the current mode.
-
-    If the check fails, will either raise IllegalInsruction or cause
-    unpredictable behavior, depending on TRAP_ON_UNIMPLEMENTED_CSR
-  }
-  body {
-    if (!csr?(csr_addr)) {
-      if (TRAP_ON_UNIMPLEMENTED_CSR) {
-        raise(ExceptionCode::IllegalInstruction, mode(), encoding);
-      } else {
-        unpredictable("Attempt to read unimplemented CSR");
-      }
-    }
-    PrivilegeMode priv_mode;
-    if (csr_addr[9:8] == 2'b00) {
-      priv_mode = PrivilegeMode::M;
-    } else if (csr_addr[9:8] == 2'b01 || csr_addr[9:8] == 2'b10) {
-      priv_mode = PrivilegeMode::S;
-    } else {
-      priv_mode = PrivilegeMode::U;
-    }
-    if (priv_mode == PrivilegeMode::M) {
-      if (mode() != PrivilegeMode::M) {
-        raise(ExceptionCode::IllegalInstruction, mode(), encoding);
-      }
-    } else if (priv_mode == PrivilegeMode::S) {
-      if (mode() == PrivilegeMode::U || mode() == PrivilegeMode::VU) {
-        raise(ExceptionCode::IllegalInstruction, mode(), encoding);
-      }
-    }
-
-    if (for_write && csr_addr[11:10] == 2'b11) {
-      # write to read-only CSR
-      raise(ExceptionCode::IllegalInstruction, mode(), encoding);
     }
   }
 }
@@ -1024,8 +986,13 @@ function pmp_match_64 {
       # get the registers for this PMP entry
       Bits<12> pmpcfg_idx = pmpcfg0_addr + (i/8)*2;
       Bits<6> shamt = (i % 8)*8;
-      PmpCfg cfg = ($bits(CSR[pmpcfg0_addr]) >> shamt)[7:0];
+
+      Csr pmpcfg_csr = direct_csr_lookup(pmpcfg_idx);
+      PmpCfg cfg = (csr_hw_read(pmpcfg_csr) >> shamt)[7:0];
+
       Bits<12> pmpaddr_idx = pmpaddr0_addr + i;
+      Csr pmpaddr_csr = direct_csr_lookup(pmpaddr_idx);
+      Bits<64> pmpaddr_csr_value = csr_sw_read(pmpaddr_csr);
 
       # set up the default range limits, which will result in NoMatch when
       # compared to the access
@@ -1038,9 +1005,10 @@ function pmp_match_64 {
           range_lo = 0;
         } else {
           # otherwise, it's the address in the next lowest pmpaddr register
-          range_lo = ($bits(CSR[pmpaddr_idx - 1]) << 2)[PHYS_ADDR_WIDTH-1:0];
+          Csr tor_pmpaddr_csr = direct_csr_lookup(pmpaddr_idx - 1);
+          range_lo = (csr_sw_read(tor_pmpaddr_csr) << 2)[PHYS_ADDR_WIDTH-1:0];
         }
-        range_hi = ($bits(CSR[pmpaddr_idx]) << 2)[PHYS_ADDR_WIDTH-1:0];
+        range_hi = (pmpaddr_csr_value << 2)[PHYS_ADDR_WIDTH-1:0];
 
       } else if (cfg.A == $bits(PmpCfg_A::NAPOT)) {
         # Example pmpaddr: 0b00010101111
@@ -1049,14 +1017,14 @@ function pmp_match_64 {
         # mask:            0b00000011111
         # ~mask:           0b11111100000
         # len = mask + 1:  0b00000100000
-        Bits<PHYS_ADDR_WIDTH-2> pmpaddr_value = CSR[pmpaddr_idx].sw_read()[PHYS_ADDR_WIDTH-3:0];
+        Bits<PHYS_ADDR_WIDTH-2> pmpaddr_value = pmpaddr_csr_value[PHYS_ADDR_WIDTH-3:0];
         Bits<PHYS_ADDR_WIDTH-2> mask = pmpaddr_value ^ (pmpaddr_value + 1);
         range_lo = (pmpaddr_value & ~mask) << 2;
         Bits<PHYS_ADDR_WIDTH-2> len = mask + 1;
         range_hi = ((pmpaddr_value & ~mask) + len) << 2;
 
       } else if (cfg.A == $bits(PmpCfg_A::NA4)) {
-        range_lo = ($bits(CSR[pmpaddr_idx]) << 2)[PHYS_ADDR_WIDTH-1:0];
+        range_lo = (pmpaddr_csr_value << 2)[PHYS_ADDR_WIDTH-1:0];
         range_hi = range_lo + 4;
       }
 
@@ -1091,8 +1059,13 @@ function pmp_match_32 {
       # get the registers for this PMP entry
       Bits<12> pmpcfg_idx = pmpcfg0_addr + (i/4);
       Bits<6> shamt = (i % 4)*8;
-      PmpCfg cfg = ($bits(CSR[pmpcfg0_addr]) >> shamt)[7:0];
+
+      Csr pmpcfg_csr = direct_csr_lookup(pmpcfg_idx);
+      PmpCfg cfg = (csr_hw_read(pmpcfg_csr) >> shamt)[7:0];
+
       Bits<12> pmpaddr_idx = pmpaddr0_addr + i;
+      Csr pmpaddr_csr = direct_csr_lookup(pmpaddr_idx);
+      Bits<32> pmpaddr_csr_value = csr_sw_read(pmpaddr_csr);
 
       # set up the default range limits, which will result in NoMatch when
       # compared to the access
@@ -1105,9 +1078,10 @@ function pmp_match_32 {
           range_lo = 0;
         } else {
           # otherwise, it's the address in the next lowest pmpaddr register
-          range_lo = ($bits(CSR[pmpaddr_idx - 1]) << 2)[PHYS_ADDR_WIDTH-1:0];
+          Csr tor_pmpaddr_csr = direct_csr_lookup(pmpaddr_idx - 1);
+          range_lo = (csr_sw_read(tor_pmpaddr_csr) << 2)[PHYS_ADDR_WIDTH-1:0];
         }
-        range_hi = ($bits(CSR[pmpaddr_idx]) << 2)[PHYS_ADDR_WIDTH-1:0];
+        range_hi = (pmpaddr_csr_value << 2)[PHYS_ADDR_WIDTH-1:0];
 
       } else if (cfg.A == $bits(PmpCfg_A::NAPOT)) {
         # Example pmpaddr: 0b00010101111
@@ -1116,14 +1090,14 @@ function pmp_match_32 {
         # mask:            0b00000011111
         # ~mask:           0b11111100000
         # len = mask + 1:  0b00000100000
-        Bits<PHYS_ADDR_WIDTH-2> pmpaddr_value = CSR[pmpaddr_idx].sw_read()[PHYS_ADDR_WIDTH-3:0];
+        Bits<PHYS_ADDR_WIDTH-2> pmpaddr_value = pmpaddr_csr_value[PHYS_ADDR_WIDTH-3:0];
         Bits<PHYS_ADDR_WIDTH-2> mask = pmpaddr_value ^ (pmpaddr_value + 1);
         range_lo = (pmpaddr_value & ~mask) << 2;
         Bits<PHYS_ADDR_WIDTH-2> len = mask + 1;
         range_hi = ((pmpaddr_value & ~mask) + len) << 2;
 
       } else if (cfg.A == $bits(PmpCfg_A::NA4)) {
-        range_lo = ($bits(CSR[pmpaddr_idx]) << 2)[PHYS_ADDR_WIDTH-1:0];
+        range_lo = (pmpaddr_csr_value << 2)[PHYS_ADDR_WIDTH-1:0];
         range_hi = range_lo + 4;
       }
 

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.clrint.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.clrint.yaml
@@ -29,5 +29,5 @@ operation(): |
 
   XReg idx = rs1 / 32;
   XReg bit = rs1 % 32;
-  XReg pre_csr = CSR[MCLICIP0_ADDR + idx].sw_read();
-  CSR[MCLICIP0_ADDR + idx].sw_write(pre_csr & ~(1 << bit));
+  Csr pre_csr = direct_csr_lookup(MCLICIP0_ADDR + idx);
+  csr_sw_write(pre_csr, csr_sw_read(pre_csr) & ~(1 << bit));

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.setint.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.setint.yaml
@@ -29,5 +29,5 @@ operation(): |
 
   XReg idx = rs1 / 32;
   XReg bit = rs1 % 32;
-  XReg pre_csr = CSR[MCLICIP0_ADDR + idx].sw_read();
-  CSR[MCLICIP0_ADDR + idx].sw_write(pre_csr | (1 << bit));
+  Csr pre_csr = direct_csr_lookup(MCLICIP0_ADDR + idx);
+  csr_sw_write(pre_csr, csr_sw_read(pre_csr) | (1 << bit));

--- a/arch_overlay/qc_iu/inst/Xqci/qc.clrinti.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.clrinti.yaml
@@ -28,5 +28,5 @@ operation(): |
 
   XReg idx = imm / 32;
   XReg bit = imm % 32;
-  XReg pre_csr = CSR[MCLICIP0_ADDR + idx].sw_read();
-  CSR[MCLICIP0_ADDR + idx].sw_write(pre_csr & ~(1 << bit));
+  Csr pre_csr = direct_csr_lookup(MCLICIP0_ADDR + idx);
+  csr_sw_write(pre_csr, csr_sw_read(pre_csr) & ~(1 << bit));

--- a/arch_overlay/qc_iu/inst/Xqci/qc.csrrwr.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.csrrwr.yaml
@@ -35,10 +35,11 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg csr = X[rs2];
+  XReg csr_addr = X[rs2];
+  Csr csr = direct_csr_lookup(csr_addr);
   if (rd != 0) {
-    X[rd] = CSR[csr].sw_read();
+    X[rd] = csr_sw_read(csr);
   }
   # writes the value in X[rs1] to the CSR,
   # performing any WARL transformations first
-  CSR[csr].sw_write(X[rs1]);
+  csr_sw_write(csr, X[rs1]);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.csrrwri.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.csrrwri.yaml
@@ -35,10 +35,12 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg csr = X[rs2];
+  XReg csr_addr = X[rs2];
+  Csr csr = direct_csr_lookup(csr_addr);
   if (rd != 0) {
-    X[rd] = CSR[csr].sw_read();
+    X[rd] = csr_sw_read(csr_addr);
   }
   # writes the zero-extended immediate to the CSR,
-  # performing any WARL transformations first
-  CSR[csr].sw_write({{XLEN-5{1'b0}}, imm});
+  # performing any WARL transformations
+  # first
+  csr_sw_write(csr, {{XLEN-5{1'b0}}, imm});

--- a/arch_overlay/qc_iu/inst/Xqci/qc.setinti.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.setinti.yaml
@@ -28,5 +28,5 @@ operation(): |
 
   XReg idx = imm / 32;
   XReg bit = imm % 32;
-  XReg pre_csr = CSR[MCLICIP0_ADDR + idx].sw_read();
-  CSR[MCLICIP0_ADDR + idx].sw_write(pre_csr | (1 << bit));
+  Csr pre_csr = direct_csr_lookup(MCLICIP0_ADDR + idx);
+  csr_sw_write(pre_csr, csr_sw_read(pre_csr) | (1 << bit));

--- a/backends/cpp_hart_gen/cpp/include/udb/csr.hpp
+++ b/backends/cpp_hart_gen/cpp/include/udb/csr.hpp
@@ -84,6 +84,12 @@ namespace udb {
 
     virtual void reset() = 0;
 
+    // the most privileged mode that has access to this csr
+    virtual PrivilegeMode mode() const = 0;
+
+    // false if the CSR is read only
+    virtual bool writable() const = 0;
+
     // read the raw bits of a CSR value
     //
     // some CSRs are shorter than XLEN bits, but none are longer

--- a/backends/cpp_hart_gen/lib/gen_cpp.rb
+++ b/backends/cpp_hart_gen/lib/gen_cpp.rb
@@ -757,15 +757,10 @@ module Idl
   class CsrReadExpressionAst
     def gen_cpp(symtab, indent = 0, indent_spaces: 2)
       csr = csr_def(symtab)
-      if csr.nil?
-        # csr isn't known at runtime...
-        "#{' '*indent}__UDB_CSR_BY_ADDR(#{idx_expr.gen_cpp(symtab, 0, indent_spaces:)}).hw_read(__UDB_XLEN)"
+      if symtab.cfg_arch.multi_xlen? && csr.format_changes_with_xlen?
+        "#{' '*indent}__UDB_CSR_BY_NAME(#{csr.name})._hw_read(__UDB_XLEN)"
       else
-        if symtab.cfg_arch.multi_xlen? && csr.format_changes_with_xlen?
-          "#{' '*indent}__UDB_CSR_BY_NAME(#{csr.name})._hw_read(__UDB_XLEN)"
-        else
-          "#{' '*indent}__UDB_CSR_BY_NAME(#{csr.name})._hw_read()"
-        end
+        "#{' '*indent}__UDB_CSR_BY_NAME(#{csr.name})._hw_read()"
       end
     end
   end

--- a/backends/cpp_hart_gen/templates/csrs.hxx.erb
+++ b/backends/cpp_hart_gen/templates/csrs.hxx.erb
@@ -220,6 +220,8 @@ namespace udb {
     unsigned address() const override { return <%= csr.address %>; }
     static constexpr unsigned _address() { return <%= csr.address %>; }
     const std::string name() const override { return "<%= csr.name %>"; }
+    PrivilegeMode mode() const override { return PrivilegeMode::<%= csr.priv_mode %>; }
+    bool writable() const override { return <%= csr.writable %>; }
 
     void reset() override {
       <%- fields_for_xlen.each do |field| -%>

--- a/backends/cpp_hart_gen/templates/hart.hxx.erb
+++ b/backends/cpp_hart_gen/templates/hart.hxx.erb
@@ -225,7 +225,77 @@ namespace udb {
         return m_csr_addr_map.count(csr_addr) == 1;
       }
 
+      <%= name_of(:struct, "Csr", cfg_arch) %> direct_csr_lookup(const Bits<12>& csr_addr) {
+        <%= name_of(:struct, "Csr", cfg_arch) %> csr_handle;
 
+        auto csr = m_csr_addr_map.find(csr_addr);
+        if (csr == m_csr_addr_map.end()) {
+          csr_handle.valid = false;
+          return csr_handle;
+        } else {
+          csr_handle.valid = true;
+          csr_handle.name = csr->name();
+          csr_handle.addr_type = CsrAddressType::Direct;
+          csr_handle.address = csr_addr;
+          csr_handle.mode = csr->mode();
+          csr_handle.writable = csr->writable();
+          return csr_handle;
+        }
+      }
+
+      <%= name_of(:struct, "Csr", cfg_arch) %> indirect_csr_lookup(const Bits<64>& csr_indirect_addr) {
+        <%= name_of(:struct, "Csr", cfg_arch) %> csr_handle;
+
+        auto csr = m_csr_indirect_addr_map.find(csr_addr);
+        if (csr == m_csr_indirect_addr_map.end()) {
+          csr_handle.valid = false;
+          return csr_handle;
+        } else {
+          csr_handle.valid = true;
+          csr_handle.name = csr->name();
+          csr_handle.addr_type = CsrAddressType::Indirect;
+          csr_handle.address = csr_addr;
+          csr_handle.mode = csr->mode();
+          csr_handle.writable = csr->writable();
+          return csr_handle;
+        }
+      }
+
+      PossiblyUnknownBits<64> csr_hw_read(const <%= name_of(:struct, "Csr", cfg_arch) %>& csr_handle) {
+        if (csr_handle.addr_type == CsrAddressType::Direct) {
+          auto csr = m_csr_addr_map.find(csr_handle.address);
+          udb_assert(csr != m_csr_addr_map.end(), "CSR not found");
+          return csr.hw_read(xlen());
+        } else {
+          auto csr = m_csr_indirect_addr_map.find(csr_handle.address);
+          udb_assert(csr != m_csr_indirect_addr_map.end(), "CSR not found");
+          return csr.hw_read(xlen());
+        }
+      }
+
+      PossiblyUnknownBits<64> csr_sw_read(const <%= name_of(:struct, "Csr", cfg_arch) %>& csr_handle) {
+        if (csr_handle.addr_type == CsrAddressType::Direct) {
+          auto csr = m_csr_addr_map.find(csr_handle.address);
+          udb_assert(csr != m_csr_addr_map.end(), "CSR not found");
+          return csr.sw_read(xlen());
+        } else {
+          auto csr = m_csr_indirect_addr_map.find(csr_handle.address);
+          udb_assert(csr != m_csr_indirect_addr_map.end(), "CSR not found");
+          return csr.sw_read(xlen());
+        }
+      }
+
+      void csr_sw_write(const <%= name_of(:struct, "Csr", cfg_arch) %>& csr_handle, const Bits<<%= cfg_arch.mxlen %>>& value) {
+        if (csr_handle.addr_type == CsrAddressType::Direct) {
+          auto csr = m_csr_addr_map.find(csr_handle.address);
+          udb_assert(csr != m_csr_addr_map.end(), "CSR not found");
+          return csr.sw_write(value, xlen());
+        } else {
+          auto csr = m_csr_indirect_addr_map.find(csr_handle.address);
+          udb_assert(csr != m_csr_indirect_addr_map.end(), "CSR not found");
+          return csr.sw_write(value, xlen());
+        }
+      }
 
       void set_pc(uint64_t new_pc) override {
         m_pc = new_pc;
@@ -379,6 +449,7 @@ namespace udb {
       <%= name_of(:params, cfg_arch) %> m_params;
       <%= name_of(:csr_container, cfg_arch) %><SocType> m_csrs;
       std::unordered_map<Bits<12>, CsrBase*> m_csr_addr_map;
+      std::unordered_map<Bits<64>, CsrBase*> m_csr_indirect_addr_map;
       std::map<std::string, CsrBase*> m_csr_name_map;
 
       std::array<uint8_t, __MAX_INST_CPP_SIZE> m_run_one_inst_storage;

--- a/backends/cpp_hart_gen/templates/hart_impl.hxx.erb
+++ b/backends/cpp_hart_gen/templates/hart_impl.hxx.erb
@@ -43,6 +43,9 @@ namespace udb {
     <%- unless csr.address.nil? -%>
     m_csr_addr_map[<%= csr.address %>] = &m_csrs.<%= csr.name %>;
     <%- end -%>
+    <%- unless csr.indirect_address.nil? -%>
+    m_csr_indirect_addr_map[<%= csr.indirect_address %>] = &m_csrs.<%= csr.name %>;
+    <%_ end -%>
     m_csr_name_map["<%= csr.name %>"] = &m_csrs.<%= csr.name %>;
     <%- end -%>
   }

--- a/lib/arch_obj_models/csr.rb
+++ b/lib/arch_obj_models/csr.rb
@@ -33,6 +33,10 @@ class Csr < DatabaseObject
     @data["virtual_address"]
   end
 
+  def writable
+    @data["writeable"]
+  end
+
   # @return [Integer] 32 or 64, the XLEN this CSR is exclusively defined in
   # @return [nil] if this CSR is defined in all bases
   def base = @data["base"]

--- a/lib/arch_obj_models/instruction.rb
+++ b/lib/arch_obj_models/instruction.rb
@@ -158,10 +158,10 @@ class Instruction < DatabaseObject
     else
       # RubyProf.start
       ast = type_checked_operation_ast(effective_xlen)
-      print "Determining reachable funcs from #{name} (#{effective_xlen})..."
+      # print "Determining reachable funcs from #{name} (#{effective_xlen})..."
       symtab = fill_symtab(effective_xlen, ast)
       fns = ast.reachable_functions(symtab)
-      puts "done"
+      # puts "done"
       # result = RubyProf.stop
       # RubyProf::FlatPrinter.new(result).print($stdout)
       # exit

--- a/lib/cfg_arch.rb
+++ b/lib/cfg_arch.rb
@@ -215,10 +215,10 @@ class ConfiguredArchitecture < Architecture
     io.puts "Type checking IDL code for #{@config.name}..."
     progressbar =
       if show_progress
-        ProgressBar.create(title: "Instructions", total: instructions.size)
+        ProgressBar.create(title: "Instructions", total: possible_instructions.size)
       end
 
-    instructions.each do |inst|
+    possible_instructions.each do |inst|
       progressbar.increment if show_progress
       if @mxlen == 32
         inst.type_checked_operation_ast(32) if inst.rv32?
@@ -230,10 +230,10 @@ class ConfiguredArchitecture < Architecture
 
     progressbar =
       if show_progress
-        ProgressBar.create(title: "CSRs", total: csrs.size)
+        ProgressBar.create(title: "CSRs", total: possible_csrs.size)
       end
 
-    csrs.each do |csr|
+    possible_csrs.each do |csr|
       progressbar.increment if show_progress
       if csr.has_custom_sw_read?
         if (possible_xlens.include?(32) && csr.defined_in_base32?)
@@ -265,11 +265,12 @@ class ConfiguredArchitecture < Architecture
       end
     end
 
+    func_list = reachable_functions
     progressbar =
       if show_progress
-        ProgressBar.create(title: "Functions", total: functions.size)
+        ProgressBar.create(title: "Functions", total: func_list.size)
       end
-    functions.each do |func|
+    func_list.each do |func|
       progressbar.increment if show_progress
       func.type_check(@symtab)
     end

--- a/lib/idl/ast.rb
+++ b/lib/idl/ast.rb
@@ -2377,7 +2377,9 @@ module Idl
         value_else(value_result) do
           # if this is a fully configured ConfiguredArchitecture, this is an error because all constants are supposed to be known
           if symtab.cfg_arch.fully_configured?
-            type_error "Array size (#{ary_size.text_value}) must be known at compile time"
+            unless ary_size.type(symtab).template_var?
+              type_error "Array size (#{ary_size.text_value}) must be known at compile time"
+            end
           else
             # otherwise, it's ok that we don't know the value yet, as long as the value is a const
             type_error "Array size (#{ary_size.text_value}) must be a constant" unless ary_size.type(symtab).const?
@@ -4367,7 +4369,11 @@ module Idl
           end
         end
         value_else(value_result) do
-          type_error "Bit width must be known at compile time" if symtab.cfg_arch.fully_configured?
+          unless bits_expression.type(symtab).template_var?
+            if symtab.cfg_arch.fully_configured?
+              type_error "Bit width (#{bits_expression.text_value}) must be known at compile time"
+            end
+          end
         end
       end
       unless ["Bits", "String", "XReg", "Boolean", "U32", "U64"].include?(@type_name)
@@ -4906,6 +4912,16 @@ module Idl
           value_error "maybe_cache_translation is not compile-time-knowable"
         elsif name == "invalidate_translations"
           value_error "invalidate_translations is not compile-time-knowable"
+        elsif name == "direct_csr_lookup"
+          value_error "direct_csr_lookup is not compile-time-knowable"
+        elsif name == "indirect_csr_lookup"
+          value_error "indirect_csr_lookup is not compile-time-knowable"
+        elsif name == "csr_hw_read"
+          value_error "csr_hw_read is not compile-time-knowable"
+        elsif name == "csr_sw_read"
+          value_error "csr_sw_read is not compile-time-knowable"
+        elsif name == "csr_sw_write"
+          value_error "csr_sw_write is not compile-time-knowable"
         else
           internal_error "Unimplemented generated: '#{name}'"
         end
@@ -5352,7 +5368,7 @@ module Idl
       symtab = symtab.deep_clone
       symtab.push(self)
       template_names.each_with_index do |tname, index|
-        symtab.add(tname, Var.new(tname, template_types(symtab)[index]))
+        symtab.add(tname, Var.new(tname, template_types(symtab)[index], template_index: index))
       end
 
       type_check_return(symtab)
@@ -5399,6 +5415,7 @@ module Idl
         ttype = a.type(symtab)
         ttype = ttype.ref_type if ttype.kind == :enum
         ttypes << ttype.clone.make_const
+        ttypes.last.qualify(:template_var)
       end
       ttypes
     end
@@ -6109,7 +6126,7 @@ module Idl
 
   class CsrReadExpressionSyntaxNode < Treetop::Runtime::SyntaxNode
     def to_ast
-      CsrReadExpressionAst.new(input, interval, idx.text_value)
+      CsrReadExpressionAst.new(input, interval, csr_name.text_value)
     end
   end
 
@@ -6122,13 +6139,12 @@ module Idl
   class CsrReadExpressionAst < AstNode
     include Rvalue
 
-    attr_reader :idx_text
-    attr_reader :idx_expr
+    attr_reader :csr_name
 
-    def initialize(input, interval, idx)
+    def initialize(input, interval, csr_name)
       super(input, interval, [])
 
-      @idx_text = idx
+      @csr_name = csr_name
     end
 
     def freeze_tree(symtab)
@@ -6136,73 +6152,25 @@ module Idl
 
       @cfg_arch = symtab.cfg_arch # remember cfg_arch, used by gen_adoc pass
 
-      if symtab.cfg_arch.csr(@idx_text).nil?
-        parser = symtab.cfg_arch.idl_compiler.parser
-        expr = parser.parse(@idx_text, root: :expression)
+      type_error "CSR '#{@csr_name}' is not defined" if symtab.cfg_arch.csr(@csr_name).nil?
+      @csr_obj = symtab.cfg_arch.csr(@csr_name)
 
-        type_error "#{@idx_text} is not a CSR; it must be an expression" if expr.nil?
-
-        @idx_expr = expr.to_ast
-        @children << @idx_expr
-      else
-        @csr_obj = symtab.cfg_arch.csr(@idx_text)
-      end
+      @type = CsrType.new(@csr_obj, symtab.cfg_arch)
 
       @children.each { |child| child.freeze_tree(symtab) }
       freeze
     end
 
     # @!macro type
-    def type(symtab)
-      cfg_arch = symtab.cfg_arch
-
-      cd = csr_def(symtab)
-      if cd.nil?
-        # we don't know anything about this index, so we can only
-        # treat this as a generic
-        CsrType.new(:unknown, cfg_arch)
-      else
-        CsrType.new(cd, cfg_arch)
-      end
-    end
+    def type(symtab) = @type
 
     # @!macro type_check
     def type_check(symtab)
-      cfg_arch = symtab.cfg_arch
-
-      if !@csr_obj.nil?
-        # this is a known csr name
-        # nothing else to check
-
-      else
-        # this is an expression
-        @idx_expr.type_check(symtab)
-        type_error "Csr index must be integral" unless @idx_expr.type(symtab).integral?
-
-        value_try do
-          idx_value = @idx_expr.value(symtab)
-          csr_index = cfg_arch.csrs.index { |csr| csr.address == idx_value }
-          type_error "No csr number '#{idx_value}' was found" if csr_index.nil?
-          :ok
-        end
-        # OK, index doesn't have to be known
-      end
+      type_error "CSR '#{@csr_name}' is not defined" if symtab.cfg_arch.csr(@csr_name).nil?
     end
 
     def csr_def(symtab)
-      cfg_arch = symtab.cfg_arch
-      if !@csr_obj.nil?
-        # this is a known csr name
-        @csr_obj
-      else
-        # this is an expression
-        value_try do
-          idx_value = @idx_expr.value(symtab)
-          return cfg_arch.csrs.find { |csr| csr.address == idx_value }
-        end
-        # || we don't know at compile time which CSR this is...
-        nil
-      end
+      @csr_obj
     end
 
     def csr_known?(symtab)
@@ -6217,20 +6185,18 @@ module Idl
 
     # @!macro value
     def value(symtab)
-      cd = csr_def(symtab)
-      value_error "CSR number not knowable" if cd.nil?
       if symtab.cfg_arch.fully_configured?
-        value_error "CSR is not implemented" unless symtab.cfg_arch.transitive_implemented_csrs.any? { |icsr| icsr.name == cd.name }
+        value_error "CSR is not implemented" unless symtab.cfg_arch.transitive_implemented_csrs.any? { |icsr| icsr.name == @csr_obj.name }
       else
-        value_error "CSR is not defined" unless symtab.cfg_arch.csrs.any? { |icsr| icsr.name == cd.name }
+        value_error "CSR is not defined" unless symtab.cfg_arch.csrs.any? { |icsr| icsr.name == @csr_obj.name }
       end
-      cd.fields.each { |f| value_error "#{csr_name(symtab)}.#{f.name} not RO" unless f.type(symtab) == "RO" }
+      @csr_obj.fields.each { |f| value_error "#{csr_name(symtab)}.#{f.name} not RO" unless f.type(symtab) == "RO" }
 
       csr_def(symtab).fields.reduce(0) { |val, f| val | (f.value << f.location.begin) }
     end
 
     # @!macro to_idl
-    def to_idl = "CSR[#{@idx.to_idl}]"
+    def to_idl = "CSR[#{@csr_name}]"
   end
 
   class CsrSoftwareWriteSyntaxNode < Treetop::Runtime::SyntaxNode

--- a/lib/idl/idl.treetop
+++ b/lib/idl/idl.treetop
@@ -275,7 +275,7 @@ grammar Idl
 
   rule csr_register_access_expression
     # CSR register access
-    'CSR' space* '[' space* idx:(expression / csr_name) space* ']' <Idl::CsrReadExpressionSyntaxNode>
+    'CSR' space* '[' space* csr_name space* ']' <Idl::CsrReadExpressionSyntaxNode>
   end
 
   rule field_access_eligible_expression
@@ -652,7 +652,7 @@ grammar Idl
   end
 
   rule var_write
-    'CSR' space* '[' space* idx:(csr_name / int) space* ']' <Idl::CsrWriteSyntaxNode>
+    'CSR' space* '[' space* csr_name space* ']' <Idl::CsrWriteSyntaxNode>
     /
     id
   end

--- a/lib/idl/passes/gen_adoc.rb
+++ b/lib/idl/passes/gen_adoc.rb
@@ -299,24 +299,8 @@ module Idl
 
   class CsrReadExpressionAst
     def gen_adoc(indent = 0, indent_spaces: 2)
-      idx =
-        if @idx_expr.nil?
-          @idx_text
-        else
-          @idx_expr.gen_adoc(0)
-        end
-
       csr_text = "CSR[#{idx}]"
-      if idx_text =~ /[0-9]+/
-        # we don't have the symtab to map this to a csr name
-        "#{' '*indent}#{csr_text}"
-      else
-        if @cfg_arch.csr(csr_text).nil?
-          "#{' '*indent}#{csr_text}"
-        else
-          "#{' '*indent}%%LINK%csr;#{idx};#{csr_text}%%"
-        end
-      end
+      "#{' '*indent}%%LINK%csr;#{csr_name};#{csr_text}%%"
     end
   end
 

--- a/lib/idl/symbol_table.rb
+++ b/lib/idl/symbol_table.rb
@@ -14,6 +14,7 @@ module Idl
       raise ArgumentError, "Expecting a Type, got #{type.class.name}" unless type.is_a?(Type)
 
       @type = type
+      @type.qualify(:template_var)
       @type.freeze
       @value = value
       raise "unexpected" unless decode_var.is_a?(TrueClass) || decode_var.is_a?(FalseClass)

--- a/lib/idl/type.rb
+++ b/lib/idl/type.rb
@@ -22,7 +22,8 @@ module Idl
     QUALIFIERS = [
       :const,
       :signed,
-      :global
+      :global,
+      :template_var
     ].freeze
 
     # true for any type that can generally be treated as a scalar integer
@@ -392,6 +393,10 @@ module Idl
 
     def global?
       @qualifiers.include?(:global)
+    end
+
+    def template_var?
+      @qualifiers.include?(:template_var)
     end
 
     def make_signed

--- a/schemas/csr_schema.json
+++ b/schemas/csr_schema.json
@@ -234,10 +234,9 @@
           "type": "integer",
           "description": "Indirect address of the CSR, as given to the indirect CSRs of the `Smcsrind`/`Sscdrind` extensions"
         },
-        "indirect": {
+        "writeable": {
           "type": "boolean",
-          "default": false,
-          "description": "Whether or not the CSR is accessible via an indirect address"
+          "description": "Whether or not the CSR can be written by software (i.e., is read-write)"
         },
         "virtual_address": true,
         "$comment": "Conditionally required; see below",


### PR DESCRIPTION
* Adds IDL support to lookup a CSR by indirect address
* Removes `CSR[expression]` syntax for CSR direct address lookup
* Adds generated functions to lookup by direct address and read/write looked-up CSRs
* Adds a writeable field to CSR schemas