### PR TITLE
schema: add array form of description

### DIFF
--- a/arch/csr/hstatus.yaml
+++ b/arch/csr/hstatus.yaml
@@ -19,7 +19,8 @@ fields:
     location: 33-32
     base: 64
     description:
-      - normative: false
+      - id: csr-hstatus-vsxl-values
+        normative: false
         text: |
           Determines the effective XLEN in VS-mode. Valid values are:
 
@@ -31,11 +32,13 @@ fields:
           ! 1     ! 64
           !===
         when(): return VSXLEN == 3264;
-      - normative: false
+      - id: csr-hstatus-vsxl-rv32
+        normative: false
         text: |
           Because the implementation only supports a single VSXLEN == 32, this field is read-only-0.
         when(): return VSXLEN == 32;
-      - normative: false
+      - id: csr-hstatus-vsxl-rv64
+        normative: false
         text: |
           Because the implementation only supports a single VSXLEN == 64, this field is read-only-1.
         when(): return VSXLEN == 64;
@@ -71,12 +74,12 @@ fields:
     location: 22
     long_name: Virtual Trap SRET
     description:
-      - normative: false
+      - id: csr-hstatus-vtsr-behavior
+        normative: false
         text: |
           When `hstatus.VTSR` is set, executing the `sret` instruction in VS-mode
           raises a `Virtual Instruction` exception.
-      - normative: false
-        text: |
+
           When `hstatus.VTSR` is clear, an `sret` instruction in VS-mode returns control
           to the mode stored in `vsstatus.SPP`.
     type: RW
@@ -85,7 +88,8 @@ fields:
     location: 21
     long_name: Virtual Trap WFI
     description:
-      - normative: false
+      - id: csr-hstatus-vtw-behavior
+        normative: false
         text: |
           When `hstatus.VTW` is set, a `wfi` instruction executed in VS-mode raises
           a `Virtual Instruction` exception after waiting an implementation-defined
@@ -114,7 +118,8 @@ fields:
     location: 20
     long_name: Virtual Trap Virtual Memory
     description:
-      - normative: false
+      - id: csr-hstatus-vtvm-behavior
+        normative: false
         text: |
           When set, a 'Virtual Instruction` trap occurs when executing an `sfence.vma`, `sinval.vma`,
           or an explicit CSR access of the `satp` (really `vsatp`) register when in VS-mode.
@@ -130,7 +135,8 @@ fields:
     location: 17-12
     long_name: Virtual Guest External Interrupt Number
     description:
-      - normative: false
+      - id: csr-hstatus-vgein-behavior
+        normative: false
         text: |
           Selects the guest external interrupt source for VS-level external interrupts.
 
@@ -160,7 +166,8 @@ fields:
     location: 9
     long_name: Hypervisor in U-mode
     description:
-      - normative: false
+      - id: csr-hstatus-hu-behavior
+        normative: false
         text: |
           When set, the hypervisor load/store instructions (`hlv`, `hlvx`, and `hsv`) can be
           executed in U-mode.
@@ -172,7 +179,8 @@ fields:
     location: 8
     long_name: Supervisor Previous Virtual Privilege
     description:
-      - normative: false
+      - id: csr-hstatus-spvp-behavior
+        normative: false
         text: |
           Written by hardware:
 
@@ -191,7 +199,8 @@ fields:
     location: 7
     long_name: Supervisor Previous Virtualization Mode
     description:
-      - normative: false
+      - id: csr-hstatus-spv-behavior
+        normative: false
         text: |
           Written by hardware:
 
@@ -210,7 +219,8 @@ fields:
     location: 6
     long_name: Guest Virtual Address
     description:
-      - normative: false
+      - id: csr-hstatus-gva-behavior
+        normative: false
         text: |
           Written by hardware whenever a trap is taken into HS-mode:
 
@@ -224,17 +234,20 @@ fields:
     location: 5
     long_name: VS-mode Big Endian
     description:
-      - normative: false
+      - id: csr-hstatus-vgein-behavior
+        normative: false
         text: |
           Controls the endianness of data VS-mode (0 = little, 1 = big).
           Instructions are always little endian, regardless of the data setting.
 
-      - normative: false
+      - id: csr-hstatus-vgein-little-endian
+        normative: false
         text: |
           Since the CPU does not support big endian in VS-mode, this is hardwired to 0.
         when(): return VS_MODE_ENDIANESS == "little";
 
-      - normative: false
+      - id: csr-hstatus-vgein-big-endian
+        normative: false
         text: |
           Since the CPU does not support little endian in VS-mode, this is hardwired to 1.
         when(): return VS_MODE_ENDIANESS == "big";

--- a/arch/csr/hstatus.yaml
+++ b/arch/csr/hstatus.yaml
@@ -15,30 +15,30 @@ description: |
 definedBy: H
 fields:
   VSXL:
+    long_name: VS-mode XLen
     location: 33-32
     base: 64
-    description: |
-      *VS-mode XLen*
+    description:
+      - normative: false
+        text: |
+          Determines the effective XLEN in VS-mode. Valid values are:
 
-      [when,"VSXLEN == 3264"]
-      --
-      Determines the effective XLEN in VS-mode. Valid values are:
+          [separator="!"]
+          !===
+          ! Value ! VSXLEN
 
-      [separator="!"]
-      !===
-      ! Value ! VSXLEN
-
-      ! 0     ! 32
-      ! 1     ! 64
-      !===
-
-      --
-
-      [when,"VSXLEN = 32"]
-      Because the implementation only supports a single VSXLEN == 32, this field is read-only-0.
-
-      [when,"VSXLEN = 64"]
-      Because the implementation only supports a single VSXLEN == 64, this field is read-only-1.
+          ! 0     ! 32
+          ! 1     ! 64
+          !===
+        when(): return VSXLEN == 3264;
+      - normative: false
+        text: |
+          Because the implementation only supports a single VSXLEN == 32, this field is read-only-0.
+        when(): return VSXLEN == 32;
+      - normative: false
+        text: |
+          Because the implementation only supports a single VSXLEN == 64, this field is read-only-1.
+        when(): return VSXLEN == 64;
 
     type(): |
       if ((VSXLEN == 32) || (VSXLEN == 64)) {
@@ -69,69 +69,74 @@ fields:
       }
   VTSR:
     location: 22
-    description: |
-      *Virtual Trap SRET*
-
-      When `hstatus.VTSR` is set, executing the `sret` instruction in VS-mode
-      raises a `Virtual Instruction` exception.
-
-      When `hstatus.VTSR` is clear, an `sret` instruction in VS-mode returns control
-      to the mode stored in `vsstatus.SPP`.
+    long_name: Virtual Trap SRET
+    description:
+      - normative: false
+        text: |
+          When `hstatus.VTSR` is set, executing the `sret` instruction in VS-mode
+          raises a `Virtual Instruction` exception.
+      - normative: false
+        text: |
+          When `hstatus.VTSR` is clear, an `sret` instruction in VS-mode returns control
+          to the mode stored in `vsstatus.SPP`.
     type: RW
     reset_value: UNDEFINED_LEGAL
   VTW:
     location: 21
-    description: |
-      *Virtual Trap WFI*
+    long_name: Virtual Trap WFI
+    description:
+      - normative: false
+        text: |
+          When `hstatus.VTW` is set, a `wfi` instruction executed in VS-mode raises
+          a `Virtual Instruction` exception after waiting an implementation-defined
+          amount of time (which can be 0).
 
-      When `hstatus.VTW` is set, a `wfi` instruction executed in VS-mode raises
-      a `Virtual Instruction` exception after waiting an implementation-defined
-      amount of time (which can be 0).
+          When both `hstatus.VTW` and `mstatus.TW` are clear, a `wfi` instruction
+          executes in VS-mode without a timeout period.
 
-      When both `hstatus.VTW` and `mstatus.TW` are clear, a `wfi` instruction
-      executes in VS-mode without a timeout period.
+          The `wfi` instruction is also affected by `mstatus.TW`, as shown below:
 
-      The `wfi` instruction is also affected by `mstatus.TW`, as shown below:
+          [separator="!",%autowidth,%footer]
+          !===
+          .2+! [.rotate]#`mstatus.TW`# .2+! [.rotate]#`hstatus.VTW`# 4+^.>! `wfi` behavior
+          h! HS-mode h! U-mode h! VS-mode h! VU-mode
 
-      [separator="!",%autowidth,%footer]
-      !===
-      .2+! [.rotate]#`mstatus.TW`# .2+! [.rotate]#`hstatus.VTW`# 4+^.>! `wfi` behavior
-      h! HS-mode h! U-mode h! VS-mode h! VU-mode
+          ! 0 ! 0 ! Wait ! Trap (I) ! Wait ! Trap (V)
+          ! 0 ! 1 ! Wait ! Trap (I) ! Trap (V) ! Trap (V)
+          ! 1 ! - ! Trap (I) ! Trap (I) ! Trap (I) ! Trap (I)
 
-      ! 0 ! 0 ! Wait ! Trap (I) ! Wait ! Trap (V)
-      ! 0 ! 1 ! Wait ! Trap (I) ! Trap (V) ! Trap (V)
-      ! 1 ! - ! Trap (I) ! Trap (I) ! Trap (I) ! Trap (I)
-
-      6+! Trap (I) - Trap with `Illegal Instruction` code +
-      Trap (V) - Trap with `Virtual Instruction` code
-      !===
+          6+! Trap (I) - Trap with `Illegal Instruction` code +
+          Trap (V) - Trap with `Virtual Instruction` code
+          !===
     type: RW
     reset_value: UNDEFINED_LEGAL
   VTVM:
     location: 20
-    description: |
-      *Virtual Trap Virtual Memory*
+    long_name: Virtual Trap Virtual Memory
+    description:
+      - normative: false
+        text: |
+          When set, a 'Virtual Instruction` trap occurs when executing an `sfence.vma`, `sinval.vma`,
+          or an explicit CSR access of the `satp` (really `vsatp`) register when in VS-mode.
 
-      When set, a 'Virtual Instruction` trap occurs when executing an `sfence.vma`, `sinval.vma`,
-      or an explicit CSR access of the `satp` (really `vsatp`) register when in VS-mode.
+          When clear, the instructions execute as normal in VS-mode.
 
-      When clear, the instructions execute as normal in VS-mode.
+          Notably, `hstatus.VTVM` does *not* cause `hfence.vvma`, `sfence.w.inval`, or `sfence.inval.ir` to trap.
 
-      Notably, `hstatus.VTVM` does *not* cause `hfence.vvma`, `sfence.w.inval`, or `sfence.inval.ir` to trap.
-
-      `mstatus.TVM` does not affect the VS-mode instructions controlled by `hstatus.TVTM`.
+          `mstatus.TVM` does not affect the VS-mode instructions controlled by `hstatus.TVTM`.
     type: RW
     reset_value: UNDEFINED_LEGAL
   VGEIN:
     location: 17-12
-    description: |
-      *Virtual Guest External Interrupt Number*
+    long_name: Virtual Guest External Interrupt Number
+    description:
+      - normative: false
+        text: |
+          Selects the guest external interrupt source for VS-level external interrupts.
 
-      Selects the guest external interrupt source for VS-level external interrupts.
+          When `hstatus.VGEIN` == 0, no external interrupt source is selected.
 
-      When `hstatus.VGEIN` == 0, no external interrupt source is selected.
-
-      When `hstatus.VGEIN` != 0, it selects which bit of `hgeip` is currently active in VS-mode.
+          When `hstatus.VGEIN` != 0, it selects which bit of `hgeip` is currently active in VS-mode.
 
     type(): |
       # if NUM_EXTERNAL_GUEST_INTERRUPTS+1 is 63 (because indexing in `hgeip` starts at 1),
@@ -153,77 +158,86 @@ fields:
       }
   HU:
     location: 9
-    description: |
-      *Hypervisor in U-mode*
+    long_name: Hypervisor in U-mode
+    description:
+      - normative: false
+        text: |
+          When set, the hypervisor load/store instructions (`hlv`, `hlvx`, and `hsv`) can be
+          executed in U-mode.
 
-      When set, the hypervisor load/store instructions (`hlv`, `hlvx`, and `hsv`) can be
-      executed in U-mode.
-
-      When clear, the hypervisor load/store instructions cause an `Illegal Instruction` trap.
+          When clear, the hypervisor load/store instructions cause an `Illegal Instruction` trap.
     type: RW
     reset_value: UNDEFINED_LEGAL
   SPVP:
     location: 8
-    description: |
-      *Supervisor Previous Virtual Privilege*
+    long_name: Supervisor Previous Virtual Privilege
+    description:
+      - normative: false
+        text: |
+          Written by hardware:
 
-      Written by hardware:
+          * When taking a trap into HS-mode from VS-mode or VU-mode, `hstatus.SPVP` is written with the nominal privilege mode
 
-      * When taking a trap into HS-mode from VS-mode or VU-mode, `hstatus.SPVP` is written with the nominal privilege mode
+          Notably, unlike its analog `mstatus.SPP`, `hstatus.SPVP` is *not* cleared when returning from a trap.
 
-      Notably, unlike its analog `mstatus.SPP`, `hstatus.SPVP` is *not* cleared when returning from a trap.
+          Can also be written by software without immediate side-effect.
 
-      Can also be written by software without immediate side-effect.
+          Affects execution by:
 
-      Affects execution by:
-
-      * Controls the effective privilege level applied to the hypervisor load/store instructions, `hlv`, `hlvx`, and `hsv`.
+          * Controls the effective privilege level applied to the hypervisor load/store instructions, `hlv`, `hlvx`, and `hsv`.
     type: RW
     reset_value: UNDEFINED_LEGAL
   SPV:
     location: 7
-    description: |
-      *Supervisor Previous Virtualization Mode*
+    long_name: Supervisor Previous Virtualization Mode
+    description:
+      - normative: false
+        text: |
+          Written by hardware:
 
-      Written by hardware:
+          * On a trap into HS-mode, hardware writes 1 when the prior mode was VS-mode or VU-mode, and 0 otherwise.
 
-      * On a trap into HS-mode, hardware writes 1 when the prior mode was VS-mode or VU-mode, and 0 otherwise.
+          Can also be written by software without immediate side-effect.
 
-      Can also be written by software without immediate side-effect.
+          Affects execution by:
 
-      Affects execution by:
-
-      * When an `sret` instruction in executed in HS-mode or M-mode,
-        control returns to VS-mode or VU-mode (as selected by `mstatus.SPP`) when
-        `hstatus.SPV` is 1 and to HS-mode or U-mode otherwise.
+          * When an `sret` instruction in executed in HS-mode or M-mode,
+            control returns to VS-mode or VU-mode (as selected by `mstatus.SPP`) when
+            `hstatus.SPV` is 1 and to HS-mode or U-mode otherwise.
     type: RW
     reset_value: UNDEFINED_LEGAL
   GVA:
     location: 6
-    description: |
-      *Guest Virtual Address*
+    long_name: Guest Virtual Address
+    description:
+      - normative: false
+        text: |
+          Written by hardware whenever a trap is taken into HS-mode:
 
-      Written by hardware whenever a trap is taken into HS-mode:
+          * Writes 1 when a trap causes a guest virtual address to be written into `stval` (`Breakpoint`, `* Address Misaligned`, `* Access Fault`, `* Page Fault`, or `* Guest-Page Fault`).
+          * Writes 0 otherwise
 
-      * Writes 1 when a trap causes a guest virtual address to be written into `stval` (`Breakpoint`, `* Address Misaligned`, `* Access Fault`, `* Page Fault`, or `* Guest-Page Fault`).
-      * Writes 0 otherwise
-
-      Does not affect execution.
+          Does not affect execution.
     type: RW
     reset_value: UNDEFINED_LEGAL
   VSBE:
     location: 5
-    description: |
-      *VS-mode Big Endian*
+    long_name: VS-mode Big Endian
+    description:
+      - normative: false
+        text: |
+          Controls the endianness of data VS-mode (0 = little, 1 = big).
+          Instructions are always little endian, regardless of the data setting.
 
-      Controls the endianness of data VS-mode (0 = little, 1 = big).
-      Instructions are always little endian, regardless of the data setting.
+      - normative: false
+        text: |
+          Since the CPU does not support big endian in VS-mode, this is hardwired to 0.
+        when(): return VS_MODE_ENDIANESS == "little";
 
-      [when,"VS_MODE_ENDIANESS == little"]
-      Since the CPU does not support big endian in VS-mode, this is hardwired to 0.
-
-      [when,"VS_MODE_ENDIANESS == bit"]
-      Since the CPU does not support little endian in VS-mode, this is hardwired to 1.
+      - normative: false
+        text: |
+          Since the CPU does not support little endian in VS-mode, this is hardwired to 1.
+        when(): return VS_MODE_ENDIANESS == "big";
     type(): |
       if (VS_MODE_ENDIANESS == "dynamic") {
         # mode is mutable

--- a/arch/csr/mie.yaml
+++ b/arch/csr/mie.yaml
@@ -8,8 +8,7 @@ address: 0x304
 priv_mode: M
 length: MXLEN
 definedBy: Sm
-description:
-  $copy: "mip.yaml#/description"
+description: "mip.yaml#/description"
 fields:
   SSIE:
     location: 1

--- a/lib/arch_obj_models/csr_field.rb
+++ b/lib/arch_obj_models/csr_field.rb
@@ -29,6 +29,14 @@ class CsrField < DatabaseObject
     @parent = parent_csr
   end
 
+  # CSR fields are defined in their parent CSR YAML file
+  def __source = @parent.__source
+
+  # CSR field data starts at fields: NAME: with the YAML
+  def source_line(*path)
+    super("fields", name, *path)
+  end
+
   # For a full config, whether or not the field is implemented
   # For a partial config, whether or the it is possible for the field to be implemented
   #

--- a/lib/arch_obj_models/obj.rb
+++ b/lib/arch_obj_models/obj.rb
@@ -90,7 +90,7 @@ class DatabaseObject
     end
   end
 
-  attr_reader :data, :data_path, :name, :long_name, :description
+  attr_reader :data, :data_path, :name, :long_name
 
   # @return [Architecture] If only a specification (no config) is known
   # @return [ConfiguredArchitecture] If a specification and config is known
@@ -184,6 +184,73 @@ class DatabaseObject
     @data["definedBy"]
   end
 
+  # @param normative [Boolean] Include normative text?
+  # @param non_normative [Boolean] Include non-normative text?
+  # @param when_cb [Proc(AstNode, String)] Callback to generate text for the un-knowable ast
+  # @return [String] Descripton of the object, from YAML
+  def description(
+    normative: true,      # display normative text?
+    non_normative: true,  # display non-normative text?
+    when_cb: proc { |when_ast, text|
+      ["When `#{when_ast.gen_adoc(0)}`", text]
+    }
+  )
+    case @data['description']
+    when String
+      @data['description']
+    when Array
+      stmts = @data['description']
+      desc_lines = []
+      stmts.each_with_index do |stmt, idx|
+        if stmt.key?("when()")
+          # conditional
+          ast = @cfg_arch.idl_compiler.compile_func_body(
+            stmt["when()"],
+            return_type: Idl::Type.new(:boolean),
+            symtab: @cfg_arch.symtab,
+            name: "#{name}.description[#{idx}].when",
+            input_file: __source,
+            input_line: source_line("description", idx, "when()")
+          )
+
+          symtab = @cfg_arch.symtab.global_clone
+          symtab.push(ast)
+          unless ast.return_type(symtab).kind == :boolean
+            ast.type_error "`when` must be a Boolean in description"
+          end
+
+          value_result = ast.value_try do
+            if ast.return_value(symtab) == true
+              # condition holds, add the test
+              if (stmt["normative"] == true) && normative
+                desc_lines << stmt["text"]
+              elsif (stmt["normative"] == false) && non_normative
+                desc_lines << stmt["text"]
+              end
+            end
+            # else, value is false; don't add it
+          end
+          ast.value_else(value_result) do
+            # value of 'when' isn't known. prune out what we do know
+            # and display it
+            pruned_ast = ast.prune(symtab)
+            pruned_ast.freeze_tree(symtab)
+            desc_lines.concat(when_cb.call(pruned_ast, stmt["text"]))
+          end
+          symtab.pop
+          symtab.release
+        else
+          if (stmt["normative"] == true) && normative
+            desc_lines << stmt["text"]
+          elsif (stmt["normative"] == false) && non_normative
+            desc_lines << stmt["text"]
+          end
+        end
+      end
+      desc_lines.join("\n\n")
+    end
+  end
+
   # @param data [Hash<String,Object>] Hash with fields to be added
   # @param data_path [Pathname] Path to the data file
   def initialize(data, data_path, arch: nil)
@@ -197,7 +264,6 @@ class DatabaseObject
     @arch = arch
     @name = data["name"]
     @long_name = data["long_name"]
-    @description = data["description"]
 
     @sem = Concurrent::Semaphore.new(1)
     @cache = Concurrent::Hash.new
@@ -245,19 +311,19 @@ class DatabaseObject
   # @return [Integer] THe source line number of +path+ in the YAML file
   # @param path [Array<String>] Path to the scalar you want.
   # @example
-  #   yaml = <<~YAML
-  #     misa:
-  #       sw_read(): ...
-  #       fields:
-  #         A:
-  #           type(): ...
-  #   YAML
+  #   00: yaml = <<~YAML
+  #   01:   misa:
+  #   02:     sw_read(): ...
+  #   03:     fields:
+  #   04:       A:
+  #   05:         type(): ...
+  #   06: YAML
   #   misa_csr.source_line("sw_read()")  #=> 2
   #   mis_csr.source_line("fields", "A", "type()") #=> 5
   def source_line(*path)
 
     # find the line number of this operation() in the *original* file
-    yaml_filename = @data["$source"]
+    yaml_filename = __source
     raise "No $source for #{name}" if yaml_filename.nil?
     line = nil
     path_idx = 0
@@ -269,27 +335,46 @@ class DatabaseObject
         else
           mapping
         end
+      found = false
       while path_idx < path.size
-        idx = 0
-        while idx < data.children.size
-          if data.children[idx].value == path[path_idx]
-            if path_idx == path.size - 1
-              line = data.children[idx + 1].start_line
-              if data.children[idx + 1].style == Psych::Nodes::Scalar::LITERAL
-                line += 1 # the string actually begins on the next line
+        if data.is_a?(Psych::Nodes::Mapping)
+          idx = 0
+          while idx < data.children.size
+            if data.children[idx].value == path[path_idx]
+              if path_idx == path.size - 1
+                line = data.children[idx + 1].start_line
+                if data.children[idx + 1].style == Psych::Nodes::Scalar::LITERAL
+                  line += 1 # the string actually begins on the next line
+                end
+                return line
+              else
+                found = true
+                data = data.children[idx + 1]
+                path_idx += 1
+                break
               end
+            end
+            idx += 2
+          end
+          raise "path #{path[path_idx]} @ #{path_idx} not found for #{self.class.name}##{name}" unless found
+        elsif data.is_a?(Psych::Nodes::Sequence)
+          raise "Expecting Integer" unless path[path_idx].is_a?(Integer)
+
+          if data.children.size > path[path_idx]
+            if path_idx == path.size - 1
+              line = data.children[path[path_idx]].start_line
               return line
             else
-              data = data.children[idx + 1]
+              data = data.children[path[path_idx]]
               path_idx += 1
-              break
             end
+          else
+            raise "Index out of bounds"
           end
-          idx += 2
         end
       end
     end
-    raise "Didn't find key '#{path}' in #{@data['$source']}"
+    raise "Didn't find path '#{path}' in #{__source}"
   end
 end
 

--- a/lib/idl/ast.rb
+++ b/lib/idl/ast.rb
@@ -4080,7 +4080,7 @@ module Idl
 
     # @return [Type] The actual return type
     def return_type(symtab)
-      return_expression.retrun_type(symtab)
+      return_expression.return_type(symtab)
     end
 
     # @return [Type] The expected return type (as defined by the encolsing function)
@@ -5023,6 +5023,15 @@ module Idl
         # rescue ValueError
         #   return_value_might_be_known = false
         # end
+      end
+    end
+
+    def return_type(symtab)
+      # go through the statements, and return the first one that has a return type
+      stmts.each do |s|
+        if s.is_a?(Returns)
+          return s.return_type(symtab)
+        end
       end
     end
 

--- a/schemas/csr_schema.json
+++ b/schemas/csr_schema.json
@@ -15,6 +15,10 @@
           "type": "string",
           "description": "Name of the field. Optional because it is implied by the object key of the CSR object holding the field"
         },
+        "long_name": {
+          "type": "string",
+          "description": "Long name of the field"
+        },
         "location": {
           "$ref": "schema_defs.json#/$defs/field_location",
           "description": "Location of the field within the CSR register"
@@ -59,7 +63,7 @@
           "description": "When a CSR field is only defined in RV32, or RV64, the base that defines it. When defined in both, this field should be absent."
         },
         "description": {
-          "type": "string",
+          "$ref": "schema_defs.json#/$defs/spec_text",
           "description": "Function of the field"
         },
         "type": {
@@ -202,23 +206,8 @@
           "description": "Descriptive name for the CSR"
         },
         "description": {
-          "oneOf": [
-            {
-              "type": "string",
-              "description": "A full Asciidoc description of the CSR, intended to be used as documentation."
-            },
-            {
-              "type": "object",
-              "description": "A full Asciidoc description of the CSR, intended to be used as documentation.",
-              "properties": {
-                "$copy": {
-                  "type": "string",
-                  "format": "uri-reference"
-                }
-              },
-              "additionalProperties": false
-            }
-          ]
+          "$ref": "schema_defs.json#/$defs/spec_text",
+          "description": "Function of the field"
         },
         "definedBy": {
           "$ref": "schema_defs.json#/$defs/requires_entry",

--- a/schemas/schema_defs.json
+++ b/schemas/schema_defs.json
@@ -78,8 +78,12 @@
     },
     "tagged_text": {
       "type": "object",
-      "required": ["text", "normative"],
+      "required": ["id", "text", "normative"],
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for the statement"
+        },
         "text": {
           "type": "string",
           "description": "Asciidoctor source"

--- a/schemas/schema_defs.json
+++ b/schemas/schema_defs.json
@@ -62,6 +62,38 @@
         "nonstandard-released"
       ]
     },
+    "spec_text": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Asciidoctor source"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/tagged_text"
+          }
+        }
+      ]
+    },
+    "tagged_text": {
+      "type": "object",
+      "required": ["text", "normative"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "Asciidoctor source"
+        },
+        "normative": {
+          "type": "boolean"
+        },
+        "when()": {
+          "type": "string",
+          "description": "IDL boolean expression. When true, the text applies"
+        }
+      },
+      "additionalProperties": false
+    },
     "license": {
       "description": "License that applies to the textual documentation for this extension",
       "type": "object",


### PR DESCRIPTION
Adds an array form of "description" fields that enables tagged statements.

In this first cut, statements can be tagged as:

  - normative or non-normative.
  - conditional, using an IDL function to evaluate the condition