### PR TITLE
Enhance wavedrom display to a number-per-cell format. 

### DIFF
--- a/backends/common_templates/adoc/inst.adoc.erb
+++ b/backends/common_templates/adoc/inst.adoc.erb
@@ -30,23 +30,23 @@ This instruction has different encodings in RV32 and RV64
 RV32::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-<%= JSON.dump inst.wavedrom_desc(32) %>
+<%= inst.processed_wavedrom_desc(32) %>
 ....
 
 RV64::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-<%= JSON.dump inst.wavedrom_desc(64) %>
+<%= inst.processed_wavedrom_desc(64) %>
 ....
 <%- else -%>
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-<%= JSON.dump inst.wavedrom_desc(inst.base.nil? ? 64 : inst.base) %>
+<%= inst.processed_wavedrom_desc(inst.base.nil? ? 64 : inst.base) %>
 ....
 <%- end -%>
 
 Description::
-<%= inst.description %>
+<%= inst.fix_entities(inst.description) %>
 
 
 Decode Variables::
@@ -89,7 +89,7 @@ RV64::
 Operation::
 [source,idl,subs="specialchars,macros"]
 ----
-<%= inst.operation_ast.gen_adoc %>
+<%= inst.fix_entities(inst.operation_ast.gen_adoc) %>
 ----
   <% end %>
 <% end %>
@@ -99,7 +99,7 @@ Operation::
 Sail::
 [source,sail]
 ----
-<%= inst.data["sail()"] %>
+<%= inst.fix_entities(inst.data["sail()"]) %>
 ----
   <% end %>
 <% end %>
@@ -111,9 +111,9 @@ Included in::
 | Extension | Version
 
 <%- inst.defined_by_condition.flat_versions.each do |r| -%>
-| *<%= r.name %>* | <%= r.requirement_specs_to_s %>
+| *<%= r.name %>* | <%= inst.fix_entities(r.requirement_specs_to_s) %>
 <%- end -%>
 |===
 <%- else -%>
-<%= inst.defined_by_condition.to_asciidoc %>
+<%= inst.fix_entities(inst.defined_by_condition.to_asciidoc) %>
 <%- end -%>

--- a/backends/instructions_appendix/templates/instructions.adoc.erb
+++ b/backends/instructions_appendix/templates/instructions.adoc.erb
@@ -1,71 +1,3 @@
-<%
-# Helper to substitute problematic entity strings with proper Unicode characters.
-def fix_entities(text)
-  text.to_s.gsub("&ne;", "≠")
-           .gsub("&pm;", "±")
-           .gsub("-&infin;", "−∞")
-           .gsub("+&infin;", "+∞")
-end
-
-# Custom JSON converter for wavedrom that handles hexadecimal literals
-def json_dump_with_hex_literals(data)
-  # First convert to standard JSON
-  json_string = JSON.dump(data)
-
-  # Replace string hex values with actual hex literals
-  json_string.gsub(/"0x([0-9a-fA-F]+)"/) do |match|
-    # Remove the quotes, leaving just the hex literal
-    "0x#{$1}"
-  end.gsub(/"name":/, '"name": ') # Add space after colon for name field
-end
-
-# Helper to process wavedrom data
-def process_wavedrom(json_data)
-  result = json_data.dup
-
-  # Process reg array if it exists
-  if result["reg"].is_a?(Array)
-    result["reg"].each do |item|
-      # For fields that are likely opcodes or immediates (type 2)
-      if item["type"] == 2
-        # Convert to number first (if it's a string)
-        if item["name"].is_a?(String)
-          if item["name"].start_with?("0x")
-            # Already hexadecimal
-            numeric_value = item["name"].to_i(16)
-          elsif item["name"] =~ /^[01]+$/
-            # Binary string without prefix
-            numeric_value = item["name"].to_i(2)
-          elsif item["name"] =~ /^\d+$/
-            # Decimal
-            numeric_value = item["name"].to_i
-          else
-            # Not a number, leave it alone
-            next
-          end
-        else
-          # Already a number
-          numeric_value = item["name"]
-        end
-
-        # Convert to hexadecimal string
-        hex_str = numeric_value.to_s(16).downcase
-
-        # Set the name to a specially formatted string that will be converted
-        # to a hex literal in our custom JSON converter
-        item["name"] = "0x" + hex_str
-      end
-
-      # Ensure bits is a number
-      if item["bits"].is_a?(String) && item["bits"] =~ /^\d+$/
-        item["bits"] = item["bits"].to_i
-      end
-    end
-  end
-
-  result
-end
-%>
 = Instruction Appendix
 :doctype: book
 :wavedrom: <%= $root %>/node_modules/.bin/wavedrom-cli
@@ -86,23 +18,23 @@ This instruction has different encodings in RV32 and RV64
 RV32::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-<%= fix_entities(json_dump_with_hex_literals(process_wavedrom(inst.wavedrom_desc(32)))) %>
+<%= inst.processed_wavedrom_desc(32) %>
 ....
 
 RV64::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-<%= fix_entities(json_dump_with_hex_literals(process_wavedrom(inst.wavedrom_desc(64)))) %>
+<%= inst.processed_wavedrom_desc(64) %>
 ....
 <%- else -%>
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-<%= fix_entities(json_dump_with_hex_literals(process_wavedrom(inst.wavedrom_desc(inst.base.nil? ? 64 : inst.base)))) %>
+<%= inst.processed_wavedrom_desc(inst.base.nil? ? 64 : inst.base) %>
 ....
 <%- end -%>
 
 Description::
-<%= fix_entities(inst.description) %>
+<%= inst.fix_entities(inst.description) %>
 
 Decode Variables::
 <%- if inst.multi_encoding? ? (inst.decode_variables(32).empty? && inst.decode_variables(64).empty?) : inst.decode_variables(inst.base.nil? ? 64 : inst.base).empty? -%>
@@ -149,12 +81,12 @@ Included in::
 |===
 | Extension | Version
 <% inst.defined_by_condition.flat_versions.each do |r| %>
-| *<%= r.name %>* | <%= fix_entities(r.requirement_specs_to_s) %>
+| *<%= r.name %>* | <%= inst.fix_entities(r.requirement_specs_to_s) %>
 <% end %>
 |===
 <%- else -%>
-<%= fix_entities(inst.defined_by_condition.to_asciidoc) %>
+<%= inst.fix_entities(inst.defined_by_condition.to_asciidoc) %>
 <%- end -%>
 
-<<<
+<
 <% end %>

--- a/backends/manual/templates/instruction.adoc.erb
+++ b/backends/manual/templates/instruction.adoc.erb
@@ -7,7 +7,7 @@
 
 This instruction is defined by:
 
-<%= inst.defined_by_condition.to_asciidoc %>
+<%= inst.fix_entities(inst.defined_by_condition.to_asciidoc) %>
 
 This instruction is included in the following profiles:
 
@@ -41,20 +41,20 @@ RV32::
 +
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-<%= JSON.dump inst.wavedrom_desc(32) %>
+<%= inst.processed_wavedrom_desc(32) %>
 ....
 
 RV64::
 +
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-<%= JSON.dump inst.wavedrom_desc(64) %>
+<%= inst.processed_wavedrom_desc(64) %>
 ....
 ====
 <%- else -%>
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-<%= JSON.dump inst.wavedrom_desc(inst.base.nil? ? 32 : inst.base) %>
+<%= inst.processed_wavedrom_desc(inst.base.nil? ? 32 : inst.base) %>
 ....
 <%- end -%>
 
@@ -69,7 +69,7 @@ RV64::
 This instruction must have data-independent timing when extension `Zkt` is enabled.
 <%- end -%>
 
-<%= inst.description %>
+<%= inst.fix_entities(inst.description) %>
 
 == Access
 [cols="^,^,^,^,^"]
@@ -84,7 +84,7 @@ This instruction must have data-independent timing when extension `Zkt` is enabl
 |===
 
 <%- if inst.access_detail? -%>
-<%= inst.access_detail %>
+<%= inst.fix_entities(inst.access_detail) %>
 <%- end -%>
 
 == Decode Variables
@@ -128,7 +128,7 @@ IDL::
 +
 [source,idl,subs="specialchars,macros"]
 ----
-<%= inst.operation_ast.gen_adoc %>
+<%= inst.fix_entities(inst.operation_ast.gen_adoc) %>
 ----
 <%- end -%>
 
@@ -137,7 +137,7 @@ Sail::
 +
 [source,sail]
 ----
-<%= inst["sail()"] %>
+<%= inst.fix_entities(inst["sail()"]) %>
 ----
 <%- end -%>
 ====
@@ -149,7 +149,7 @@ Sail::
 This instruction may result in the following synchronous exceptions:
 
   <%- exception_list.sort.each do |etype| -%>
-  * <%= etype %>
+  * <%= inst.fix_entities(etype) %>
   <%- end -%>
 
 <%- end -%>

--- a/lib/arch_obj_models/instruction.rb
+++ b/lib/arch_obj_models/instruction.rb
@@ -7,6 +7,13 @@ require "awesome_print"
 
 # model of a specific instruction in a specific base (RV32/RV64)
 class Instruction < DatabaseObject
+    def processed_wavedrom_desc(base)
+      data = wavedrom_desc(base)
+      processed_data = process_wavedrom(data)
+      TemplateHelpers.fix_entities(json_dump_with_hex_literals(processed_data))
+    end
+
+
   def self.ary_from_location(location_str_or_int)
     return [location_str_or_int] if location_str_or_int.is_a?(Integer)
 

--- a/lib/template_helpers.rb
+++ b/lib/template_helpers.rb
@@ -9,6 +9,73 @@ require "ostruct"
 
 # collection of functions that can be used inside ERB templates
 module TemplateHelpers
+
+  def fix_entities(text)
+    text.to_s.gsub("&ne;", "≠")
+             .gsub("&pm;", "±")
+             .gsub("-&infin;", "−∞")
+             .gsub("+&infin;", "+∞")
+  end
+
+  # Custom JSON converter for wavedrom that handles hexadecimal literals
+  def json_dump_with_hex_literals(data)
+    # First convert to standard JSON
+    json_string = JSON.dump(data)
+
+    # Replace string hex values with actual hex literals
+    json_string.gsub(/"0x([0-9a-fA-F]+)"/) do |match|
+      # Remove the quotes, leaving just the hex literal
+      "0x#{$1}"
+    end.gsub(/"name":/, '"name": ') # Add space after colon for name field
+  end
+
+  # Helper to process wavedrom data
+  def process_wavedrom(json_data)
+    result = json_data.dup
+
+    # Process reg array if it exists
+    if result["reg"].is_a?(Array)
+      result["reg"].each do |item|
+        # For fields that are likely opcodes or immediates (type 2)
+        if item["type"] == 2
+          # Convert to number first (if it's a string)
+          if item["name"].is_a?(String)
+            if item["name"].start_with?("0x")
+              # Already hexadecimal
+              numeric_value = item["name"].to_i(16)
+            elsif item["name"] =~ /^[01]+$/
+              # Binary string without prefix
+              numeric_value = item["name"].to_i(2)
+            elsif item["name"] =~ /^\d+$/
+              # Decimal
+              numeric_value = item["name"].to_i
+            else
+              # Not a number, leave it alone
+              next
+            end
+          else
+            # Already a number
+            numeric_value = item["name"]
+          end
+
+          # Convert to hexadecimal string
+          hex_str = numeric_value.to_s(16).downcase
+
+          # Set the name to a specially formatted string that will be converted
+          # to a hex literal in our custom JSON converter
+          item["name"] = "0x" + hex_str
+        end
+
+        # Ensure bits is a number
+        if item["bits"].is_a?(String) && item["bits"] =~ /^\d+$/
+          item["bits"] = item["bits"].to_i
+        end
+      end
+    end
+
+    result
+  end
+
   # Insert a hyperlink to an extension.
   # @param name [#to_s] Name of the extension
   def link_to_ext(name)


### PR DESCRIPTION
Add string to hexa conversion methods on instructions. Update the templates to follow the new style. Outputs appear with a number-per-cell format now.