### PR TITLE
Add long_name and description to AES instructions

### DIFF
--- a/arch/inst/Zk/aes32dsi.yaml
+++ b/arch/inst/Zk/aes32dsi.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: aes32dsi
-long_name: AES final round decryption instruction for RV32.
+long_name: AES final round decryption instruction for RV32
 description: |
  This instruction sources a single byte from `rs2` according to `bs`. To this it applies the inverse AES
  SBox operation, and XOR's the result with `rs1`. This instruction must always be implemented such

--- a/arch/inst/Zk/aes32dsi.yaml
+++ b/arch/inst/Zk/aes32dsi.yaml
@@ -5,9 +5,9 @@ kind: instruction
 name: aes32dsi
 long_name: AES final round decryption instruction for RV32
 description: |
- This instruction sources a single byte from `rs2` according to `bs`. To this it applies the inverse AES
- SBox operation, and XOR's the result with `rs1`. This instruction must always be implemented such
- that its execution latency does not depend on the data being operated on.
+  This instruction sources a single byte from `rs2` according to `bs`. To this it applies the inverse AES
+  SBox operation, and XOR's the result with `rs1`. This instruction must always be implemented such
+  that its execution latency does not depend on the data being operated on.
 
 definedBy:
   anyOf: [Zk, Zkn, Zknd]

--- a/arch/inst/Zk/aes32dsi.yaml
+++ b/arch/inst/Zk/aes32dsi.yaml
@@ -3,9 +3,12 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: aes32dsi
-long_name: No synopsis available.
+long_name:  AES final round decryption instruction for RV32.
 description: |
-  No description available.
+  Sources a single byte from rs2 according to bs. To this it applies the inverse AES
+  SBox operation, and XOR’s the result with rs1. Must always be implemented such
+  that its execution latency does not depend on the data being operated on.
+
 definedBy:
   anyOf: [Zk, Zkn, Zknd]
 base: 32

--- a/arch/inst/Zk/aes32dsi.yaml
+++ b/arch/inst/Zk/aes32dsi.yaml
@@ -3,11 +3,11 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: aes32dsi
-long_name:  AES final round decryption instruction for RV32.
+long_name: AES final round decryption instruction for RV32.
 description: |
-  Sources a single byte from rs2 according to bs. To this it applies the inverse AES
-  SBox operation, and XOR’s the result with rs1. Must always be implemented such
-  that its execution latency does not depend on the data being operated on.
+ This instruction sources a single byte from `rs2` according to `bs`. To this it applies the inverse AES
+ SBox operation, and XOR's the result with `rs1`. This instruction must always be implemented such
+ that its execution latency does not depend on the data being operated on.
 
 definedBy:
   anyOf: [Zk, Zkn, Zknd]

--- a/arch/inst/Zk/aes32dsmi.yaml
+++ b/arch/inst/Zk/aes32dsmi.yaml
@@ -3,9 +3,11 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: aes32dsmi
-long_name: No synopsis available.
+long_name: AES middle round decryption instruction for RV32.
 description: |
-  No description available.
+  Sources a single byte from `rs2` according to `bs`. To this, it applies the inverse AES
+  SBox operation, and a partial inverse MixColumn, before XOR’ing the result with rs1. Must always be implemented such that its execution latency does not depend on the
+  data being operated on.
 definedBy:
   anyOf: [Zk, Zkn, Zknd]
 base: 32

--- a/arch/inst/Zk/aes32dsmi.yaml
+++ b/arch/inst/Zk/aes32dsmi.yaml
@@ -3,12 +3,12 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: aes32dsmi
-long_name: AES middle round decryption instruction for RV32.
+long_name: AES middle round decryption instruction for RV32
 description: |
-  This instruction sources a single byte from `rs2` according to `bs`. To this it applies the inverse AES  
-  SBox operation, and a partial inverse MixColumn, before XOR'ing the result with `rs1`. This  
-  instruction must always be implemented such that its execution latency does not depend on the  
-  data being operated on.  
+  This instruction sources a single byte from `rs2` according to `bs`. To this it applies the inverse AES
+  SBox operation, and a partial inverse MixColumn, before XOR'ing the result with `rs1`. This
+  instruction must always be implemented such that its execution latency does not depend on the
+  data being operated on.
 definedBy:
   anyOf: [Zk, Zkn, Zknd]
 base: 32

--- a/arch/inst/Zk/aes32dsmi.yaml
+++ b/arch/inst/Zk/aes32dsmi.yaml
@@ -5,9 +5,7 @@ kind: instruction
 name: aes32dsmi
 long_name: AES middle round decryption instruction for RV32.
 description: |
-  Sources a single byte from `rs2` according to `bs`. To this, it applies the inverse AES
-  SBox operation, and a partial inverse MixColumn, before XOR’ing the result with rs1. Must always be implemented such that its execution latency does not depend on the
-  data being operated on.
+  This instruction sources a single byte from `rs2` according to `bs`. To this it applies the inverse AES SBox operation, and a partial inverse MixColumn, before XOR'ing the result with `rs1`. This instruction must always be implemented such that its execution latency does not depend on the data being operated on.
 definedBy:
   anyOf: [Zk, Zkn, Zknd]
 base: 32

--- a/arch/inst/Zk/aes32dsmi.yaml
+++ b/arch/inst/Zk/aes32dsmi.yaml
@@ -5,7 +5,10 @@ kind: instruction
 name: aes32dsmi
 long_name: AES middle round decryption instruction for RV32.
 description: |
-  This instruction sources a single byte from `rs2` according to `bs`. To this it applies the inverse AES SBox operation, and a partial inverse MixColumn, before XOR'ing the result with `rs1`. This instruction must always be implemented such that its execution latency does not depend on the data being operated on.
+  This instruction sources a single byte from `rs2` according to `bs`. To this it applies the inverse AES  
+  SBox operation, and a partial inverse MixColumn, before XOR'ing the result with `rs1`. This  
+  instruction must always be implemented such that its execution latency does not depend on the  
+  data being operated on.  
 definedBy:
   anyOf: [Zk, Zkn, Zknd]
 base: 32


### PR DESCRIPTION
This PR is to add the missing `long_name` and `description`  in some of the YAML files as @AFOliveira shared.