### PR TITLE
Fix for H.yaml

### DIFF
--- a/arch/ext/H.yaml
+++ b/arch/ext/H.yaml
@@ -167,7 +167,7 @@ params:
       type: integer
       minimum: 1
       maximum: 63
-      extra_validation: |
+    extra_validation: |
       # GEILEN must be <= 31 for RV32
       assert NUM_EXTERNAL_GUEST_INTERRUPTS <= 31 if SXLEN == 32
   VS_MODE_ENDIANESS:

--- a/arch/ext/H.yaml
+++ b/arch/ext/H.yaml
@@ -167,6 +167,9 @@ params:
       type: integer
       minimum: 1
       maximum: 63
+      extra_validation: |
+      # GEILEN must be <= 31 for RV32
+      assert NUM_EXTERNAL_GUEST_INTERRUPTS <= 31 if SXLEN == 32
   VS_MODE_ENDIANESS:
     description: |
       Endianness of data in VS-mode. Can be one of:


### PR DESCRIPTION
Added extra_validation to enforce `NUM_EXTERNAL_GUEST_INTERRUPTS` <= 31 when `SXLEN` == 32 as in #619.