### PR TITLE
Fix Zawrs extension version (1.0.1 vs 1.1.0)

### DIFF
--- a/arch/ext/Zawrs.yaml
+++ b/arch/ext/Zawrs.yaml
@@ -17,6 +17,6 @@ description: |
     accelerator device indicating completion of a job previously submitted to the device.
 type: unprivileged
 versions:
-  - version: "1.1.0"
+  - version: "1.0.1"
     state: ratified
     ratification_date: null

--- a/arch/ext/Zawrs.yaml
+++ b/arch/ext/Zawrs.yaml
@@ -19,4 +19,4 @@ type: unprivileged
 versions:
   - version: "1.0.1"
     state: ratified
-    ratification_date: null
+    ratification_date: 2022-11


### PR DESCRIPTION
The latest version of the spec shows Zawrs as version 1.0.1, not 1.1.0.