### PR TITLE
correct: Remove periods from instruction long_names

### DIFF
--- a/arch/inst/C/c.ebreak.yaml
+++ b/arch/inst/C/c.ebreak.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: c.ebreak
-long_name: Breakpoint exception.
+long_name: Breakpoint exception
 description: |
   The C.EBREAK instruction is used by debuggers to cause control to be transferred back to
   a debugging environment. Unless overridden by an external debug environment,

--- a/arch/inst/C/c.jalr.yaml
+++ b/arch/inst/C/c.jalr.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: c.jalr
-long_name: Jump and Link Register.
+long_name: Jump and Link Register
 description: |
   C.JALR (jump and link register) performs the same operation as C.JR, but additionally writes the address of the instruction following the jump (pc+2) to the link register, x1.
   C.JALR expands to jalr x1, 0(rs1).

--- a/arch/inst/F/fclass.s.yaml
+++ b/arch/inst/F/fclass.s.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: fclass.s
-long_name: Single-precision floating-point classify.
+long_name: Single-precision floating-point classify
 description: |
   The `fclass.s` instruction examines the value in floating-point register
   _fs1_ and writes to integer register _rd_ a 10-bit mask that indicates

--- a/arch/inst/F/fcvt.w.s.yaml
+++ b/arch/inst/F/fcvt.w.s.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.w.s
-long_name: Convert single-precision float to integer word to signed 32-bit integer.
+long_name: Convert single-precision float to integer word to signed 32-bit integer
 description: |
   Converts a floating-point number in floating-point register _fs1_ to a signed 32-bit integer indicates
   integer register _rd_.

--- a/arch/inst/Smrnmi/mnret.yaml
+++ b/arch/inst/Smrnmi/mnret.yaml
@@ -3,7 +3,7 @@
 $schema: inst_schema.json#
 kind: instruction
 name: mnret
-long_name: Machine mode resume from the RNMI or Double Trap handler.
+long_name: Machine mode resume from the RNMI or Double Trap handler
 description: |
   MNRET is an M-mode-only instruction that uses the values in mnepc and mnstatus to return to the
   program counter, privilege mode, and virtualization mode of the interrupted context. This instruction

--- a/arch/inst/Zcmp/cm.popret.yaml
+++ b/arch/inst/Zcmp/cm.popret.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: cm.popret
-long_name: Destroy function call stack frame and return to `ra`.
+long_name: Destroy function call stack frame and return to `ra`
 description: |
   Destroy stack frame: load `ra` and 0 to 12 saved registers from the stack frame, deallocate the stack frame, return to `ra`.
   This instruction pops (loads) the registers in `reg_list` from stack memory, and then adjusts the stack pointer by `stack_adj` and then return to `ra`.

--- a/arch/inst/Zcmp/cm.popretz.yaml
+++ b/arch/inst/Zcmp/cm.popretz.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: cm.popretz
-long_name: Destroy function call stack frame, move zero to `a0` and return to `ra`.
+long_name: Destroy function call stack frame, move zero to `a0` and return to `ra`
 description: |
   Destroy stack frame: load `ra` and 0 to 12 saved registers from the stack frame, deallocate the stack frame, move zero to `a0`, return to `ra`.
   This instruction pops (loads) the registers in `reg_list` from stack memory, and then adjusts the stack pointer by `stack_adj`, move zero to `a0` and then return to `ra`.

--- a/arch/inst/Zicond/czero.eqz.yaml
+++ b/arch/inst/Zicond/czero.eqz.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: czero.eqz
-long_name: Conditional zero, if condition is equal to zero.
+long_name: Conditional zero, if condition is equal to zero
 description: |
   If rs2 contains the value zero, this instruction writes the value zero to rd. Otherwise, this instruction
   copies the contents of rs1 to rd.

--- a/arch/inst/Zicond/czero.nez.yaml
+++ b/arch/inst/Zicond/czero.nez.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: czero.nez
-long_name: Conditional zero, if condition is nonzero.
+long_name: Conditional zero, if condition is nonzero
 description: |
   If rs2 contains a nonzero value, this instruction writes the value zero to rd. Otherwise, this
   instruction copies the contents of rs1 to rd.

--- a/arch/inst/Zimop/mop.r.n.yaml
+++ b/arch/inst/Zimop/mop.r.n.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: mop.r.n
-long_name: May-be-operation (1 source register).
+long_name: May-be-operation (1 source register)
 description: |
   Unless redefined by another extension, this instructions simply writes 0 to X[xd].
   The encoding allows future extensions to define them to read X[xs1], as well as write X[xd].

--- a/arch/inst/Zimop/mop.rr.n.yaml
+++ b/arch/inst/Zimop/mop.rr.n.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: mop.rr.n
-long_name: May-be-operation (2 source registers).
+long_name: May-be-operation (2 source registers)
 description: |
   The Zimop extension defines 8 MOP instructions named MOP.RR.n, where n is an integer between 0
   and 7, inclusive. Unless redefined by another extension, these instructions simply write 0 to X[xd].


### PR DESCRIPTION
Remove extraneous periods at the end of instruction "long_name" fields.