### PR TITLE
data: remove bad top nav links from antora site

### DIFF
--- a/backends/manual/templates/playbook.yml.erb
+++ b/backends/manual/templates/playbook.yml.erb
@@ -107,3 +107,19 @@ ui:
       .edit-this-page {
          display: none !important;
       }
+  - path: partials/header-content.hbs
+    contents: |
+      <header class="header">
+        <nav class="navbar">
+          <div class="navbar-brand">
+            <a class="navbar-item" href="{{{or site.url siteRootPath}}}">{{site.title}}</a>
+            {{#if env.SITE_SEARCH_PROVIDER}}
+            <div class="navbar-item search hide-for-print">
+              <div id="search-field" class="field">
+                <input id="search-input" type="text" placeholder="Search the docs"{{#if page.home}} autofocus{{/if}}>
+              </div>
+            </div>
+            {{/if}}
+          </div>
+        </nav>
+      </header>


### PR DESCRIPTION
relates to #646
Default antora bundle zip pulling in template links remove those by overriding in playbook

looks like this now: 

![image](https://github.com/user-attachments/assets/8f35011e-f56d-4cb1-964b-0f10bb746810)


In the future we could probably put useful links in the top nav, but for now this just removes the useless ones.