### PR TITLE
fix: change reuse lint pre-commit hook to only look at committed files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,7 +118,7 @@ repos:
   - repo: https://github.com/fsfe/reuse-tool
     rev: v5.0.2
     hooks:
-      - id: reuse
+      - id: reuse-lint-file
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.22.0


### PR DESCRIPTION
fixes #645
previously looked at all files and didn't consider the case of dirty files that won't be committed or gitignored which is a common case