### PR TITLE
Add long_name and description to AES and CSR instructions

### DIFF
--- a/arch/inst/Zicsr/csrrc.yaml
+++ b/arch/inst/Zicsr/csrrc.yaml
@@ -37,6 +37,9 @@ access:
   vs: always
   vu: always
 data_independent_timing: false
+pseudoinstructions:
+  - when: xd == 0
+    to: csrc csr,xs1
 operation(): |
   Csr csr_handle = direct_csr_lookup(csr);
 

--- a/arch/inst/Zicsr/csrrc.yaml
+++ b/arch/inst/Zicsr/csrrc.yaml
@@ -3,11 +3,25 @@
 $schema: inst_schema.json#
 kind: instruction
 name: csrrc
-long_name: No synopsis available
+long_name: Atomic Read and Clear Bits in CSR
 description: |
-  No description available.
+  -id: inst-csrrc-behavior
+  -normative: false
+  -text: |
+    The CSRRC (Atomic Read and Clear Bits in CSR) instruction reads the value of the CSR, zero-extends
+    the value to XLEN bits, and writes it to integer register `rd`. The initial value in integer register `rs1` is
+    treated as a bit mask that specifies bit positions to be cleared in the CSR. Any bit that is high in `rs1` will
+    cause the corresponding bit to be cleared in the CSR, if that CSR bit is writable.
+
+    For CSRRC, if `rs1=x0`, then the instruction will not write to the CSR at all, and so shall
+    not cause any of the side effects that might otherwise occur on a CSR write, nor raise illegal-
+    instruction exceptions on accesses to read-only CSRs. CSRRC always reads the addressed CSR and
+    cause any read side effects regardless of `rs1` and `rd` fields.
+    Note that if `rs1` specifies a register other than `x0`, and that register holds a zero value,
+    the instruction will not action any attendant per-field side effects, but will action any
+    side effects caused by writing to the entire CSR.
 definedBy: Zicsr
-assembly: xd, imm, xs1
+assembly: xd, csr, xs1
 encoding:
   match: -----------------011-----1110011
   variables:
@@ -23,9 +37,6 @@ access:
   vs: always
   vu: always
 data_independent_timing: false
-pseudoinstructions:
-  - when: xd == 0
-    to: csrc csr,xs1
 operation(): |
   Csr csr_handle = direct_csr_lookup(csr);
 

--- a/arch/inst/Zicsr/csrrci.yaml
+++ b/arch/inst/Zicsr/csrrci.yaml
@@ -3,9 +3,17 @@
 $schema: inst_schema.json#
 kind: instruction
 name: csrrci
-long_name: No synopsis available
+long_name: Atomic Read and Clear Bits in CSR with Immediate
 description: |
-  No description available.
+  -id: inst-csrrci-behavior
+  -normative: false
+  -text: |
+    The CSRRCI variant is similar to CSRRC, except this updates the CSR using an XLEN-bit value obtained
+    by zero-extending a 5-bit unsigned immediate (uimm[4:0]) field encoded in the `rs1` field instead of a
+    value from an integer register. For CSRRCI, if the `uimm[4:0]` field is zero, then this instruction
+    will not write to the CSR, and shall not cause any of the side effects that might otherwise occur on
+    a CSR write, nor raise illegal-instruction exceptions on accesses to read-only CSRs. The CSRRCI will
+    always read the CSR and cause any read side effects regardless of `rd` and `rs1` fields.
 definedBy: Zicsr
 assembly: xd, csr, uimm
 encoding:
@@ -23,9 +31,6 @@ access:
   vs: always
   vu: always
 data_independent_timing: false
-pseudoinstructions:
-  - when: xd == 0
-    to: csrci csr,uimm
 operation(): |
   Boolean will_write = uimm != 0;
 

--- a/arch/inst/Zicsr/csrrci.yaml
+++ b/arch/inst/Zicsr/csrrci.yaml
@@ -31,6 +31,9 @@ access:
   vs: always
   vu: always
 data_independent_timing: false
+pseudoinstructions:
+  - when: xd == 0
+    to: csrci csr,uimm
 operation(): |
   Boolean will_write = uimm != 0;
 

--- a/arch/inst/Zicsr/csrrsi.yaml
+++ b/arch/inst/Zicsr/csrrsi.yaml
@@ -3,9 +3,17 @@
 $schema: inst_schema.json#
 kind: instruction
 name: csrrsi
-long_name: No synopsis available
+long_name: Atomic Read and Set Bits in CSR with Immediate
 description: |
-  No description available.
+  -id: inst-csrrsi-behavior
+  -normative: false
+  -text: |
+    The CSRRSI variant is similar to CSRRS, except this updates the CSR using an XLEN-bit value obtained
+    by zero-extending a 5-bit unsigned immediate (uimm[4:0]) field encoded in the `rs1` field instead of a
+    value from an integer register. For CSRRSI, if the `uimm[4:0]` field is zero, then this instruction
+    will not write to the CSR, and shall not cause any of the side effects that might otherwise occur on
+    a CSR write, nor raise illegal-instruction exceptions on accesses to read-only CSRs. The CSRRSI will
+    always read the CSR and cause any read side effects regardless of `rd` and `rs1` fields.
 definedBy: Zicsr
 assembly: xd, csr, uimm
 encoding:
@@ -23,9 +31,6 @@ access:
   vs: always
   vu: always
 data_independent_timing: false
-pseudoinstructions:
-  - when: xd == 0
-    to: csrsi csr,uimm
 operation(): |
   Boolean will_write = uimm != 0;
 

--- a/arch/inst/Zicsr/csrrsi.yaml
+++ b/arch/inst/Zicsr/csrrsi.yaml
@@ -31,6 +31,9 @@ access:
   vs: always
   vu: always
 data_independent_timing: false
+pseudoinstructions:
+  - when: xd == 0
+    to: csrsi csr,uimm
 operation(): |
   Boolean will_write = uimm != 0;
 

--- a/arch/inst/Zkn/aes64ks1i.yaml
+++ b/arch/inst/Zkn/aes64ks1i.yaml
@@ -3,9 +3,15 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: aes64ks1i
-long_name: No synopsis available
+long_name: AES Key Schedule Instruction 1
 description: |
-  No description available.
+  -id: inst-aes64ks1i-behavior
+  -normative: true
+  -text: |
+    This instruction implements the rotation, SubBytes and Round Constant addition steps of the AES
+    block cipher Key Schedule. This instruction must _always_ be implemented such that its execution
+    latency does not depend on the data being operated on. Note that `rnum` must be in the range
+    `0x0..0xA`. The values `0xB..0xF` are reserved.
 definedBy:
   anyOf: [Zknd, Zkne]
 base: 64

--- a/arch/inst/Zkn/aes64ks2.yaml
+++ b/arch/inst/Zkn/aes64ks2.yaml
@@ -3,9 +3,14 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: aes64ks2
-long_name: No synopsis available
+long_name: AES Key Schedule Instruction 2
 description: |
-  No description available.
+  -id: instr-aes64ks2-behavior
+  -normative: true
+  -text: |
+    This instruction implements the additional XOR'ing of key words as part of the AES block cipher
+    Key Schedule. This instruction must _always_ be implemented such that its execution latency does
+    not depend on the data being operated on.
 definedBy:
   anyOf: [Zknd, Zkne]
 base: 64

--- a/arch/inst/Zknd/aes64ds.yaml
+++ b/arch/inst/Zknd/aes64ds.yaml
@@ -3,9 +3,14 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: aes64ds
-long_name: No synopsis available
+long_name: AES decrypt final round
 description: |
-  No description available.
+  -id: inst-aes64ds-behavior
+  -normative: true
+  -text: |
+    Uses the two 64-bit source registers to represent the entire AES state, and produces _half_ of the next
+    round output, applying the Inverse ShiftRows and SubBytes steps. This instruction must _always_ be
+    implemented such that its execution latency does not depend on the data being operated on.
 definedBy: Zknd
 base: 64
 assembly: xd, xs1, xs2

--- a/arch/inst/Zknd/aes64dsm.yaml
+++ b/arch/inst/Zknd/aes64dsm.yaml
@@ -3,9 +3,14 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: aes64dsm
-long_name: No synopsis available
+long_name: AES decrypt middle round
 description: |
-  No description available.
+  -id: inst-aes64dsm-behavior
+  -normative: true
+  -text: |
+    Uses the two 64-bit source registers to represent the entire AES state, and produces _half_ of the next
+    round output, applying the Inverse ShiftRows, SubBytes and MixColumns steps. This instruction must _always_
+    be implemented such that its execution latency does not depend on the data being operated on.
 definedBy: Zknd
 base: 64
 assembly: xd, xs1, xs2

--- a/arch/inst/Zknd/aes64im.yaml
+++ b/arch/inst/Zknd/aes64im.yaml
@@ -3,9 +3,16 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: aes64im
-long_name: No synopsis available
+long_name: AES Decrypt KeySchedule MixColumns
 description: |
-  No description available.
+  -id: inst-aes64im-behavior
+  -normative: true
+  -text: |
+    The instruction applies the inverse MixColumns transformation to two columns of the state array,
+    packed into a single 64-bit register. It is used to create the inverse cipher KeySchedule, according to
+    the equivalent inverse cipher construction in (NIST, 2001) (Page 23, Section 5.3.5). This
+    instruction must always be implemented such that its execution latency does not depend on the
+    data being operated on.
 definedBy: Zknd
 base: 64
 assembly: xd, xs1

--- a/arch/inst/Zkne/aes64es.yaml
+++ b/arch/inst/Zkne/aes64es.yaml
@@ -3,9 +3,14 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: aes64es
-long_name: No synopsis available
+long_name: AES encrypt final round
 description: |
-  No description available.
+  -id: inst-aes64es-behavior
+  -normative: true
+  -text: |
+    Uses the two 64-bit source registers to represent the entire AES state, and produces _half_ of the next
+    round output, applying the ShiftRows and SubBytes steps. This instruction must _always_ be
+    implemented such that its execution latency does not depend on the data being operated on.
 definedBy: Zkne
 base: 64
 assembly: xd, xs1, xs2

--- a/arch/inst/Zkne/aes64esm.yaml
+++ b/arch/inst/Zkne/aes64esm.yaml
@@ -3,9 +3,14 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: aes64esm
-long_name: No synopsis available
+long_name: AES encrypt middle round
 description: |
-  No description available.
+  -id: inst-aes64esm-behavior
+  -normative: true
+  -text: |
+    Uses the two 64-bit source registers to represent the entire AES state, and produces _half_ of the next
+    round output, applying the Inverse ShiftRows, SubBytes and MixColumns steps. This instruction must _always_
+    be implemented such that its execution latency does not depend on the data being operated on.
 definedBy: Zkne
 base: 64
 assembly: xd, xs1, xs2


### PR DESCRIPTION
This PR adds missing long_name and description to the following AES and CSR instructions:

- aes64ks1i
- aes64ks2
- es64ds
- aes64dsm
- aes64im
- aes64es
- aes64esm
- csrrc
- csrrci
- csrrsi