### PR TITLE
refactor: remove type from jsonschema when const defined

### DIFF
--- a/schemas/manual_schema.json
+++ b/schemas/manual_schema.json
@@ -5,11 +5,9 @@
   "required": ["$schema", "kind", "name"],
   "properties": {
     "$schema": {
-      "type": "string",
       "const": "manual_schema.json#"
     },
     "kind": {
-      "type": "string",
       "const": "manual"
     },
     "name": {

--- a/schemas/manual_version_schema.json
+++ b/schemas/manual_version_schema.json
@@ -62,11 +62,9 @@
   ],
   "properties": {
     "$schema": {
-      "type": "string",
       "const": "manual_version_schema.json#"
     },
     "kind": {
-      "type": "string",
       "const": "manual version"
     },
     "name": {


### PR DESCRIPTION
fixes #709
done to remove anti-pattern which could have caused problems if code using schema assumed type with const but it wasn't defined that way