### PR TITLE
fix(data): remove '.' at end of 'long_name's

### DIFF
--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popret.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popret.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: qc.cm.popret
-long_name: Destroy function call stack frame and return to `ra`.
+long_name: Destroy function call stack frame and return to `ra`
 description: |
   Destroy stack frame: load ra and 0 to 12 saved registers from the stack frame, deallocate the stack frame, return to `ra`.
   This instruction pops (loads) the registers in `reg_list` from stack memory, and then adjusts the stack pointer by `stack_adj` and then return to ra.

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popretz.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popretz.yaml
@@ -3,7 +3,7 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: qc.cm.popretz
-long_name: Destroy function call stack frame, move zero to `a0` and return to `ra`.
+long_name: Destroy function call stack frame, move zero to `a0` and return to `ra`
 description: |
   Destroy stack frame: load `ra` and 0 to 12 saved registers from the stack frame, deallocate the stack frame, move zero to `a0`, return to `ra`.
   This instruction pops (loads) the registers in `reg_list` from stack memory, and then adjusts the stack pointer by `stack_adj`, move zero to `a0` and then return to `ra`.


### PR DESCRIPTION
> JSON Schema Validation Error for inst/Xqccmp/qc.cm.popretz.yaml: 'Destroy function call stack frame, move zero to `a0` and return to `ra`.' does not match '.*[^.!,]$'