### PR TITLE
Additional fixes for Xqci v0.11.0

### DIFF
--- a/arch_overlay/qc_iu/ext/Xqci.yaml
+++ b/arch_overlay/qc_iu/ext/Xqci.yaml
@@ -358,6 +358,7 @@ versions:
     email: dhower@qti.qualcomm.com
   changes:
     - Fix IDL code of qc.shlusat instruction (should use zero-extension and not sign-extension)
+    - Fix IDL code of qc.shlusat and qc.shlsat instructions (should compare values of xlen()*2 bits)
   implies:
   - { name: Xqcia, version: "0.7.0" }
   - { name: Xqciac, version: "0.3.0" }

--- a/arch_overlay/qc_iu/ext/Xqci.yaml
+++ b/arch_overlay/qc_iu/ext/Xqci.yaml
@@ -359,11 +359,22 @@ versions:
   changes:
     - Fix IDL code of qc.shlusat instruction (should use zero-extension and not sign-extension)
     - Fix IDL code of qc.shlusat and qc.shlsat instructions (should compare values of xlen()*2 bits)
+    - Fix IDL code of qc.shlusat and qc.shlsat instructions because change in IDL operators (width adjustment)
+    - Fix IDL code of qc.subsat, qc.addusat and qc.addsat instructions because change in IDL operators (width adjustment)
+    - Fix IDL code for qc.c.mileaveret, qc.c.mnret and qc.c.mret instructions because change in IDL '<<' operator
+    - Fix IDL code for qc.c.clrint, qc.c.setint, qc.clrinti and qc.setinti instructions because change in IDL '<<' operator
+    - Fix IDL code for qc.c.di, qc.c.dir, qc.c.ei, qc.c.eir and qc.c.mienter.nest instructions because change in IDL '<<' operator
+    - Fix IDL code for qc.c.sync, qc.c.syncr, qc.c.syncwf and qc.c.syncwl instructions because change in IDL '<<' operator
+    - Fix IDL code for qc.c.bseti, qc.c.extu, qc.ext and qc.extu instructions because change in IDL '<<' operator
+    - Fix IDL code for qc.extd, qc.extdu, qc.extdr and qc.extdur instructions because change in IDL '<<' operator
+    - Fix IDL code for qc.extdpr, qc.extdprh, qc.extdupr and qc.extduprh instructions because change in IDL '<<' operator
+    - Fix IDL code for qc.insb, qc.insbi, qc.insbr and qc.insbri instructions because change in IDL '<<' operator
+    - Fix IDL code for qc.insbh, qc.insbhr, qc.insbpr and qc.insbprh instructions because change in IDL '<<' operator
   implies:
   - { name: Xqcia, version: "0.7.0" }
   - { name: Xqciac, version: "0.3.0" }
   - { name: Xqcibi, version: "0.2.0" }
-  - { name: Xqcibm, version: "0.7.0" }
+  - { name: Xqcibm, version: "0.8.0" }
   - { name: Xqcicli, version: "0.3.0" }
   - { name: Xqcicm, version: "0.2.0" }
   - { name: Xqcics, version: "0.2.0" }
@@ -377,7 +388,7 @@ versions:
   - { name: Xqcilsm, version: "0.5.0" }
   - { name: Xqcisim, version: "0.2.0" }
   - { name: Xqcisls, version: "0.2.0" }
-  - { name: Xqcisync, version: "0.2.0" }
+  - { name: Xqcisync, version: "0.3.0" }
   requires:
     name: Zca
     version: ">= 1.0.0"

--- a/arch_overlay/qc_iu/ext/Xqcia.yaml
+++ b/arch_overlay/qc_iu/ext/Xqcia.yaml
@@ -92,6 +92,7 @@ versions:
     email: dhower@qti.qualcomm.com
   changes:
     - Fix IDL code of qc.shlusat instruction (should use zero-extension and not sign-extension)
+    - Fix IDL code of qc.shlusat and qc.shlsat instructions (should compare values of xlen()*2 bits)
 description: |
   The Xqcia extension includes eleven instructions to perform integer arithmetic.
 

--- a/arch_overlay/qc_iu/ext/Xqcia.yaml
+++ b/arch_overlay/qc_iu/ext/Xqcia.yaml
@@ -93,6 +93,8 @@ versions:
   changes:
     - Fix IDL code of qc.shlusat instruction (should use zero-extension and not sign-extension)
     - Fix IDL code of qc.shlusat and qc.shlsat instructions (should compare values of xlen()*2 bits)
+    - Fix IDL code of qc.shlusat and qc.shlsat instructions because change in IDL operators (width adjustment)
+    - Fix IDL code of qc.subsat, qc.addusat and qc.addsat instructions because change in IDL operators (width adjustment)
 description: |
   The Xqcia extension includes eleven instructions to perform integer arithmetic.
 

--- a/arch_overlay/qc_iu/ext/Xqcibm.yaml
+++ b/arch_overlay/qc_iu/ext/Xqcibm.yaml
@@ -105,6 +105,23 @@ versions:
     - Fix IDL code and description increasing shift to 6 bit for qc.extdpr and qc.extdprh instructions
     - Fix IDL code and description increasing shift to 6 bit for qc.extdupr and qc.extduprh instructions
   requires: { name: Zca, version: ">= 1.0.0" }
+- version: "0.8.0"
+  state: frozen
+  ratification_date: null
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  changes:
+    - Fix IDL code for qc.c.bseti, qc.c.extu, qc.ext and qc.extu instructions because change in IDL '<<' operator
+    - Fix IDL code for qc.extd, qc.extdu, qc.extdr and qc.extdur instructions because change in IDL '<<' operator
+    - Fix IDL code for qc.extdpr, qc.extdprh, qc.extdupr and qc.extduprh instructions because change in IDL '<<' operator
+    - Fix IDL code for qc.insb, qc.insbi, qc.insbr and qc.insbri instructions because change in IDL '<<' operator
+    - Fix IDL code for qc.insbh, qc.insbhr, qc.insbpr and qc.insbprh instructions because change in IDL '<<' operator
+  requires: { name: Zca, version: ">= 1.0.0" }
 description: |
   The Xqcibm extension includes thirty eight instructions that perform bit manipulation,
   include insertion and extraction.

--- a/arch_overlay/qc_iu/ext/Xqciint.yaml
+++ b/arch_overlay/qc_iu/ext/Xqciint.yaml
@@ -106,6 +106,21 @@ versions:
   changes:
     - Fix IDL code for Smdbltrp and Smrnmi spec compatibility for qc.c.mileaveret instruction
   requires: { name: Zca, version: ">= 1.0.0" }
+- version: "0.8.0"
+  state: frozen
+  ratification_date: null
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  changes:
+    - Fix IDL code for qc.c.mileaveret, qc.c.mnret and qc.c.mret instructions because change in IDL '<<' operator
+    - Fix IDL code for qc.c.clrint, qc.c.setint, qc.clrinti and qc.setinti instructions because change in IDL '<<' operator
+    - Fix IDL code for qc.c.di, qc.c.dir, qc.c.ei, qc.c.eir and qc.c.mienter.nest instructions because change in IDL '<<' operator
+  requires: { name: Zca, version: ">= 1.0.0" }
 description: |
   The Xqciint extension includes eleven instructions to accelerate interrupt
   servicing by performing common actions during ISR prologue/epilogue.

--- a/arch_overlay/qc_iu/ext/Xqcisync.yaml
+++ b/arch_overlay/qc_iu/ext/Xqcisync.yaml
@@ -30,6 +30,19 @@ versions:
     - Fix decoding of qc.c.delay instruction (state that immediate cannot be 0)
     - Add requirement to include Zca extension since has 16-bit instructions
   requires: { name: Zca, version: ">= 1.0.0" }
+- version: "0.3.0"
+  state: frozen
+  ratification_date: null
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  changes:
+    - Fix IDL code for qc.c.sync, qc.c.syncr, qc.c.syncwf and qc.c.syncwl instructions because change in IDL '<<' operator
+  requires: { name: Zca, version: ">= 1.0.0" }
 description: |
   The Xqcisync extension includes nine instructions, eight for non-memory-mapped devices synchronization and delay instruction.
   Synchronization instructions are kind of IO fences that work with special devices synchronization signals.

--- a/arch_overlay/qc_iu/inst/Xqci/qc.addsat.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.addsat.yaml
@@ -31,9 +31,9 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg sum = X[rs1] + X[rs2];
-  XReg most_negative_number = 1 << (xlen() - 1);
-  XReg most_positive_number = (1 << (xlen() - 1)) - 1;
+  Bits<xlen()+1> sum = X[rs1] `+ X[rs2];
+  Bits<xlen()+1> most_negative_number = {2'b11,{(xlen()-1){1'b0}}};
+  Bits<xlen()+1> most_positive_number = {2'b00,{(xlen()-1){1'b1}}};
   # overflow occurs if the operands are the same sign and the result is a different sign
   if (X[rs1][xlen()-1] == X[rs2][xlen()-1]) {
     if (sum[xlen()-1] != X[rs1][xlen()-1]) {
@@ -45,4 +45,4 @@ operation(): |
     }
   }
   # otherwise, overflow did not occur
-  X[rd] = sum;
+  X[rd] = sum[(xlen() - 1):0];

--- a/arch_overlay/qc_iu/inst/Xqci/qc.addusat.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.addusat.yaml
@@ -31,14 +31,11 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg sum = X[rs1] + X[rs2];
+  Bits<xlen()+1> sum = X[rs1] `+ X[rs2];
+  Bits<xlen()+1> largest_unsigned_value = {1'b0, {xlen(){1'b1}}};
 
-  # overflow occurs if the msb of at least one operand is 1 and the msb of the sum is not
-  if ((X[rs1][xlen()-1] == 1) || (X[rs2][xlen()-1] == 1)) {
-    if (sum[xlen()-1] == 0) {
-      sum = ~{MXLEN{1'b0}}; # return largest number
-    }
+  if (sum > largest_unsigned_value) {
+    X[rd] = largest_unsigned_value[(xlen() - 1):0];
+  } else {
+    X[rd] = sum[(xlen() - 1):0];
   }
-
-  # otherwise, overflow did not occur
-  X[rd] = sum;

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.bseti.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.bseti.yaml
@@ -30,4 +30,4 @@ access:
 operation(): |
   XReg index = shamt & (xlen() - 1);
   XReg reg = creg2reg(rd);
-  X[reg] = X[reg] | (1 << index);
+  X[reg] = X[reg] | (MXLEN'b1 << index);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.clrint.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.clrint.yaml
@@ -30,4 +30,4 @@ operation(): |
   XReg idx = rs1 / 32;
   XReg bit = rs1 % 32;
   Csr pre_csr = direct_csr_lookup(MCLICIP0_ADDR + idx);
-  csr_sw_write(pre_csr, csr_sw_read(pre_csr) & ~(1 << bit));
+  csr_sw_write(pre_csr, csr_sw_read(pre_csr) & ~(32'b1 << bit));

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.di.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.di.yaml
@@ -24,4 +24,4 @@ access:
 operation(): |
   CSR[mstatus].MIE = 0;
   XReg pre_qc_mcause = CSR[qc.mcause].sw_read();
-  CSR[qc.mcause].sw_write(pre_qc_mcause & ~(1<<26));
+  CSR[qc.mcause].sw_write(pre_qc_mcause & ~(32'b1<<26));

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.dir.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.dir.yaml
@@ -29,5 +29,5 @@ operation(): |
   XReg pre_mstatus = CSR[mstatus].sw_read();
   CSR[mstatus].MIE = 0;
   XReg pre_qc_mcause = CSR[qc.mcause].sw_read();
-  CSR[qc.mcause].sw_write(pre_qc_mcause & ~(1<<26));
+  CSR[qc.mcause].sw_write(pre_qc_mcause & ~(32'b1<<26));
   X[rd] = pre_mstatus;

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.ei.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.ei.yaml
@@ -24,4 +24,4 @@ access:
 operation(): |
   CSR[mstatus].MIE = 1;
   XReg pre_qc_mcause = CSR[qc.mcause].sw_read();
-  CSR[qc.mcause].sw_write(pre_qc_mcause | (1<<26));
+  CSR[qc.mcause].sw_write(pre_qc_mcause | (32'b1<<26));

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.eir.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.eir.yaml
@@ -29,5 +29,5 @@ operation(): |
   Bits<1> mie_val = (X[rs1] >> 3) & 1;
   CSR[mstatus].MIE = mie_val;
   XReg pre_qc_mcause = CSR[qc.mcause].sw_read();
-  XReg pre_qc_mcause_masked = pre_qc_mcause & ~(1<<26);
-  CSR[qc.mcause].sw_write(pre_qc_mcause | (mie_val<<26));
+  XReg pre_qc_mcause_masked = pre_qc_mcause & ~(32'b1<<26);
+  CSR[qc.mcause].sw_write(pre_qc_mcause | (mie_val`<<26));

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.extu.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.extu.yaml
@@ -30,4 +30,4 @@ access:
   vu: always
 operation(): |
   XReg width = width_minus1 + 1;
-  X[rd] = (X[rd] >> 0) & ((1 << width) - 1);
+  X[rd] = (X[rd] >> 0) & ((32'b1 << width) - 1);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.mienter.nest.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.mienter.nest.yaml
@@ -53,4 +53,4 @@ operation(): |
   X[8] = X[2];
   X[2] = X[2] - 96;
   CSR[mstatus].MIE = 1'b1;
-  CSR[qc.mcause].sw_write(qc_mcause_val | (1 << 26));
+  CSR[qc.mcause].sw_write(qc_mcause_val | (32'b1 << 26));

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.mileaveret.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.mileaveret.yaml
@@ -47,7 +47,7 @@ operation(): |
   X[31] = read_memory<32>(virtual_address - 80, $encoding);
   X[2] = X[2] + 96;
   if (nmie_val == 1'b1) {
-    XReg qc_mcause_val_masked = qc_mcause_val & ~(1<<26) & ~(1<<27) & ~(1<<29) & ~(0xFF<<12);
+    XReg qc_mcause_val_masked = qc_mcause_val & ~(32'b1<<26) & ~(32'b1<<27) & ~(32'b1<<29) & ~(32'hFF<<12);
     Bits<1> mpie_val = (qc_mcause_val >> 27) & 1;
     Bits<1> mpdt_val = (qc_mcause_val >> 29) & 1;
     Bits<4> mpil_val = (qc_mcause_val >> 16) & 0xF;
@@ -57,8 +57,8 @@ operation(): |
       CSR[mstatush].MDT = mpdt_val;
     }
     CSR[qc.mcause].sw_write(qc_mcause_val_masked |
-                            (1<<27) | (mpie_val<<26) | (0<<29) |
-                            (mpil_val << 12) | (0xF << 16));
+                            (32'b1<<27) | (mpie_val`<<26) | (32'b0<<29) |
+                            (mpil_val `<< 12) | (32'b1111 << 16));
     if (mpdt_val == 1'b0) {
       if (CSR[mstatus].MPP != 2'b11) {
         CSR[mstatus].MPRV = 0;
@@ -74,14 +74,14 @@ operation(): |
     }
     $pc = CSR[mepc].sw_read();
   } else {
-    XReg qc_mcause_val_masked = qc_mcause_val & ~(1<<26) & ~(1<<28) & ~(1<<30) & ~(0xF<<12) & ~(0xF<<20);
+    XReg qc_mcause_val_masked = qc_mcause_val & ~(32'b1<<26) & ~(32'b1<<28) & ~(32'b1<<30) & ~(32'b1111<<12) & ~(32'b1111<<20);
     Bits<1> mnpie_val = (qc_mcause_val >> 28) & 1;
     Bits<4> mnpil_val = (qc_mcause_val >> 20) & 0xF;
     CSR[mstatus].MIE = mnpie_val;
     CSR[mnstatus].NMIE = 1'b1;
     CSR[qc.mcause].sw_write(qc_mcause_val_masked |
-                            (1<<28) | (mnpie_val<<26) | (1<<30) |
-                            (mnpil_val << 12) | (0xF << 20));
+                            (32'b1<<28) | (mnpie_val`<<26) | (32'b1<<30) |
+                            (mnpil_val `<< 12) | (32'b1111 << 20));
     if (CSR[mnstatus].MNPP != 2'b11) {
       CSR[mstatus].MPRV = 0;
       if (implemented?(ExtensionName::Smdbltrp)) {

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.mnret.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.mnret.yaml
@@ -22,14 +22,14 @@ encoding:
   match: "0001100110010010"
 operation(): |
   XReg qc_mcause_val = CSR[qc.mcause].sw_read();
-  XReg qc_mcause_val_masked = qc_mcause_val & ~(1<<26) & ~(1<<28) & ~(1<<30) & ~(0xF<<12) & ~(0xF<<20);
+  XReg qc_mcause_val_masked = qc_mcause_val & ~(32'b1<<26) & ~(32'b1<<28) & ~(32'b1<<30) & ~(32'b1111<<12) & ~(32'b1111<<20);
   Bits<1> mnpie_val = (qc_mcause_val >> 28) & 1;
   Bits<4> mnpil_val = (qc_mcause_val >> 20) & 0xF;
   CSR[mstatus].MIE = mnpie_val;
   CSR[mnstatus].NMIE = 1'b1;
   CSR[qc.mcause].sw_write(qc_mcause_val_masked |
-                          (1<<28) | (mnpie_val<<26) | (1<<30) |
-                          (mnpil_val << 12) | (0xF << 20));
+                          (32'b1<<28) | (mnpie_val`<<26) | (32'b1<<30) |
+                          (mnpil_val `<< 12) | (32'b1111 << 20));
   if (CSR[mnstatus].MNPP != 2'b11) {
     CSR[mstatus].MPRV = 0;
     if (implemented?(ExtensionName::Smdbltrp)) {

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.mret.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.mret.yaml
@@ -22,7 +22,7 @@ encoding:
   match: "0001100100010010"
 operation(): |
   XReg qc_mcause_val = CSR[qc.mcause].sw_read();
-  XReg qc_mcause_val_masked = qc_mcause_val & ~(1<<26) & ~(1<<27) & ~(1<<29) & ~(0xFF<<12);
+  XReg qc_mcause_val_masked = qc_mcause_val & ~(32'b1<<26) & ~(32'b1<<27) & ~(32'b1<<29) & ~(32'hFF<<12);
   Bits<1> mpie_val = (qc_mcause_val >> 27) & 1;
   Bits<1> mpdt_val = (qc_mcause_val >> 29) & 1;
   Bits<4> mpil_val = (qc_mcause_val >> 16) & 0xF;
@@ -32,8 +32,8 @@ operation(): |
     CSR[mstatush].MDT = mpdt_val;
   }
   CSR[qc.mcause].sw_write(qc_mcause_val_masked |
-                          (1<<27) | (mpie_val<<26) | (0<<29) |
-                          (mpil_val << 12) | (0xF << 16));
+                          (32'b1<<27) | (mpie_val`<<26) | (32'b0<<29) |
+                          (mpil_val `<< 12) | (32'b1111 << 16));
   if (mpdt_val == 1'b0) {
     if (CSR[mstatus].MPP != 2'b11) {
       CSR[mstatus].MPRV = 0;

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.setint.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.setint.yaml
@@ -30,4 +30,4 @@ operation(): |
   XReg idx = rs1 / 32;
   XReg bit = rs1 % 32;
   Csr pre_csr = direct_csr_lookup(MCLICIP0_ADDR + idx);
-  csr_sw_write(pre_csr, csr_sw_read(pre_csr) | (1 << bit));
+  csr_sw_write(pre_csr, csr_sw_read(pre_csr) | (32'b1 << bit));

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.sync.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.sync.yaml
@@ -34,10 +34,10 @@ operation(): |
     bitmask = 0;
   } else if (slist < 6) {
     XReg shift = slist - 1;
-    bitmask = (1 << shift);
+    bitmask = (5'b1 << shift);
   } else {
     XReg shift = slist - 2;
-    bitmask = (1 << shift) - 1;
+    bitmask = (5'b1 << shift) - 1;
   }
   fence_tso();
   sync_read_after_write_device(true,bitmask);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.syncr.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.syncr.yaml
@@ -34,10 +34,10 @@ operation(): |
     bitmask = 0;
   } else if (slist < 6) {
     XReg shift = slist - 1;
-    bitmask = (1 << shift);
+    bitmask = (5'b1 << shift);
   } else {
     XReg shift = slist - 2;
-    bitmask = (1 << shift) - 1;
+    bitmask = (5'b1 << shift) - 1;
   }
   fence_tso();
   sync_read_after_write_device(false,bitmask);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.syncwf.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.syncwf.yaml
@@ -34,10 +34,10 @@ operation(): |
     bitmask = 0;
   } else if (slist < 6) {
     XReg shift = slist - 1;
-    bitmask = (1 << shift);
+    bitmask = (5'b1 << shift);
   } else {
     XReg shift = slist - 2;
-    bitmask = (1 << shift) - 1;
+    bitmask = (5'b1 << shift) - 1;
   }
   fence_tso();
   sync_write_after_read_device(false,bitmask);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.syncwl.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.syncwl.yaml
@@ -34,10 +34,10 @@ operation(): |
     bitmask = 0;
   } else if (slist < 6) {
     XReg shift = slist - 1;
-    bitmask = (1 << shift);
+    bitmask = (5'b1 << shift);
   } else {
     XReg shift = slist - 2;
-    bitmask = (1 << shift) - 1;
+    bitmask = (5'b1 << shift) - 1;
   }
   fence_tso();
   sync_write_after_read_device(true,bitmask);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.clrinti.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.clrinti.yaml
@@ -29,4 +29,4 @@ operation(): |
   XReg idx = imm / 32;
   XReg bit = imm % 32;
   Csr pre_csr = direct_csr_lookup(MCLICIP0_ADDR + idx);
-  csr_sw_write(pre_csr, csr_sw_read(pre_csr) & ~(1 << bit));
+  csr_sw_write(pre_csr, csr_sw_read(pre_csr) & ~(32'b1 << bit));

--- a/arch_overlay/qc_iu/inst/Xqci/qc.ext.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.ext.yaml
@@ -35,5 +35,5 @@ access:
   vu: always
 operation(): |
   XReg width = width_minus1 + 1;
-  XReg unsigned_extraction = (X[rs1] >> shamt) & ((1 << width) - 1);
+  XReg unsigned_extraction = (X[rs1] >> shamt) & ((32'b1 << width) - 1);
   X[rd] = sext(unsigned_extraction, width);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extd.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extd.yaml
@@ -36,4 +36,4 @@ access:
 operation(): |
   Bits<{1'b0, MXLEN}*2> pair = {X[rs1 + 1], X[rs1]};
   XReg width = width_minus1 + 1;
-  X[rd] = sext((pair >> shamt) & ((1 << width) - 1), width);
+  X[rd] = sext((pair >> shamt) & ((32'b1 << width) - 1), width);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extdpr.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extdpr.yaml
@@ -40,7 +40,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][5:0];
   if (width > 0) {
-    X[rd] = sext((pair >> shamt) & ((1 << width) - 1), width);
+    X[rd] = sext((pair >> shamt) & ((32'b1 << width) - 1), width);
   } else {
     X[rd] = 0;
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extdprh.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extdprh.yaml
@@ -40,7 +40,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][21:16];
   if (width > 0) {
-    X[rd] = sext((pair >> shamt) & ((1 << width) - 1), width);
+    X[rd] = sext((pair >> shamt) & ((32'b1 << width) - 1), width);
   } else {
     X[rd] = 0;
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extdr.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extdr.yaml
@@ -40,7 +40,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][5:0];
   if (width > 0) {
-    X[rd] = sext((pair >> shamt) & ((1 << width) - 1), width);
+    X[rd] = sext((pair >> shamt) & ((32'b1 << width) - 1), width);
   } else {
     X[rd] = 0;
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extdu.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extdu.yaml
@@ -36,4 +36,4 @@ access:
 operation(): |
   Bits<{1'b0, MXLEN}*2> pair = {X[rs1 + 1], X[rs1]};
   XReg width = width_minus1 + 1;
-  X[rd] = (pair >> shamt) & ((1 << width) - 1);
+  X[rd] = (pair >> shamt) & ((32'b1 << width) - 1);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extdupr.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extdupr.yaml
@@ -40,7 +40,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][5:0];
   if (width > 0) {
-    X[rd] = (pair >> shamt) & ((1 << width) - 1);
+    X[rd] = (pair >> shamt) & ((32'b1 << width) - 1);
   } else {
     X[rd] = 0;
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extduprh.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extduprh.yaml
@@ -40,7 +40,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][21:16];
   if (width > 0) {
-    X[rd] = (pair >> shamt) & ((1 << width) - 1);
+    X[rd] = (pair >> shamt) & ((32'b1 << width) - 1);
   } else {
     X[rd] = 0;
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extdur.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extdur.yaml
@@ -40,7 +40,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][5:0];
   if (width > 0) {
-    X[rd] = (pair >> shamt) & ((1 << width) - 1);
+    X[rd] = (pair >> shamt) & ((32'b1 << width) - 1);
   } else {
     X[rd] = 0;
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.extu.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.extu.yaml
@@ -35,4 +35,4 @@ access:
   vu: always
 operation(): |
   XReg width = width_minus1 + 1;
-  X[rd] = (X[rs1] >> shamt) & ((1 << width) - 1);
+  X[rd] = (X[rs1] >> shamt) & ((32'b1 << width) - 1);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.insb.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.insb.yaml
@@ -34,6 +34,6 @@ access:
   vu: always
 operation(): |
   XReg width = width_minus1 + 1;
-  XReg mask = ((1 << width) - 1) << shamt;
+  XReg mask = ((32'b1 << width) - 1) << shamt;
   XReg orig_val = X[rd];
   X[rd] = (orig_val & ~mask) | ((X[rs1] << shamt) & mask);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.insbh.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.insbh.yaml
@@ -40,7 +40,7 @@ access:
 operation(): |
   XReg width = width_minus1 + 1;
   if (width + shamt > 32) {
-    XReg shifted_one = 1 << (width + shamt - 32);
+    XReg shifted_one = 32'b1 << (width + shamt - 32);
     XReg mask = (shifted_one - 1);
     XReg orig_val = X[rd];
     XReg shifted_rs1 = X[rs1] >> (32 - shamt);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.insbhr.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.insbhr.yaml
@@ -42,7 +42,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][4:0];
   if ((width + shamt > 32) && (width > 0)) {
-    XReg shifted_one = 1 << (width + shamt - 32);
+    XReg shifted_one = 32'b1 << (width + shamt - 32);
     XReg mask = (shifted_one - 1);
     XReg orig_val = X[rd];
     XReg shifted_rs1 = X[rs1] >> (32 - shamt);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.insbi.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.insbi.yaml
@@ -34,6 +34,6 @@ access:
   vu: always
 operation(): |
   XReg width = width_minus1 + 1;
-  XReg mask = ((1 << width) - 1) << shamt;
+  XReg mask = ((32'b1 << width) - 1) << shamt;
   XReg orig_val = X[rd];
   X[rd] = (orig_val & ~mask) | ((imm << shamt) & mask);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.insbpr.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.insbpr.yaml
@@ -38,7 +38,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][4:0];
   if (width > 0) {
-    XReg mask = ((1 << width) - 1) << shamt;
+    XReg mask = ((32'b1 << width) - 1) << shamt;
     XReg orig_val = X[rd];
     X[rd] = (orig_val & ~mask) | ((X[rs1] << shamt) & mask);
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.insbprh.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.insbprh.yaml
@@ -38,7 +38,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][20:16];
   if (width > 0) {
-    XReg mask = ((1 << width) - 1) << shamt;
+    XReg mask = ((32'b1 << width) - 1) << shamt;
     XReg orig_val = X[rd];
     X[rd] = (orig_val & ~mask) | ((X[rs1] << shamt) & mask);
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.insbr.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.insbr.yaml
@@ -38,7 +38,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][4:0];
   if (width > 0) {
-    XReg mask = ((1 << width) - 1) << shamt;
+    XReg mask = ((32'b1 << width) - 1) << shamt;
     XReg orig_val = X[rd];
     X[rd] = (orig_val & ~mask) | ((X[rs1] << shamt) & mask);
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.insbri.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.insbri.yaml
@@ -38,7 +38,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs1][4:0];
   if (width > 0) {
-    XReg mask = ((1 << width) - 1) << shamt;
+    XReg mask = ((32'b1 << width) - 1) << shamt;
     XReg orig_val = X[rd];
     X[rd] = (orig_val & ~mask) | ((imm << shamt) & mask);
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.setinti.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.setinti.yaml
@@ -29,4 +29,4 @@ operation(): |
   XReg idx = imm / 32;
   XReg bit = imm % 32;
   Csr pre_csr = direct_csr_lookup(MCLICIP0_ADDR + idx);
-  csr_sw_write(pre_csr, csr_sw_read(pre_csr) | (1 << bit));
+  csr_sw_write(pre_csr, csr_sw_read(pre_csr) | (32'b1 << bit));

--- a/arch_overlay/qc_iu/inst/Xqci/qc.shlsat.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.shlsat.yaml
@@ -31,10 +31,10 @@ access:
   vs: always
   vu: always
 operation(): |
-  Bits<xlen()*2> sext_double_width_rs1 = {{xlen(){X[rs1][xlen()-1]}}, X[rs1]};
-  Bits<xlen()*2> shifted_value = sext_double_width_rs1 << X[rs2][4:0];
-  Bits<xlen()*2> most_negative_number = {{(xlen()+1){1'b1}}, {(xlen()-1){1'b0}}};
-  Bits<xlen()*2> most_positive_number = (1 << (xlen() - 1)) - 1;
+  Bits<xlen()`*2> sext_double_width_rs1 = {{xlen(){X[rs1][xlen()-1]}}, X[rs1]};
+  Bits<xlen()`*2> shifted_value = sext_double_width_rs1 << X[rs2][4:0];
+  Bits<xlen()`*2> most_negative_number = {{(xlen()+1){1'b1}}, {(xlen()-1){1'b0}}};
+  Bits<xlen()`*2> most_positive_number = {{(xlen()+1){1'b0}}, {(xlen()-1){1'b1}}};
 
   if ($signed(shifted_value) < $signed(most_negative_number)) {
     X[rd] = most_negative_number[(xlen() - 1):0];

--- a/arch_overlay/qc_iu/inst/Xqci/qc.shlsat.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.shlsat.yaml
@@ -31,15 +31,15 @@ access:
   vs: always
   vu: always
 operation(): |
-  Bits<{1'b0, MXLEN}*2> sext_double_width_rs1 = {{MXLEN{X[rs1][xlen()-1]}}, X[rs1]};
-  Bits<{1'b0, MXLEN}*2> shifted_value = sext_double_width_rs1 << X[rs2][4:0];
-  XReg most_negative_number = 1 << (xlen() - 1);
-  XReg most_positive_number = (1 << (xlen() - 1)) - 1;
+  Bits<xlen()*2> sext_double_width_rs1 = {{xlen(){X[rs1][xlen()-1]}}, X[rs1]};
+  Bits<xlen()*2> shifted_value = sext_double_width_rs1 << X[rs2][4:0];
+  Bits<xlen()*2> most_negative_number = {{(xlen()+1){1'b1}}, {(xlen()-1){1'b0}}};
+  Bits<xlen()*2> most_positive_number = (1 << (xlen() - 1)) - 1;
 
   if ($signed(shifted_value) < $signed(most_negative_number)) {
-    X[rd] = most_negative_number;
+    X[rd] = most_negative_number[(xlen() - 1):0];
   } else if ($signed(shifted_value) > $signed(most_positive_number)) {
-    X[rd] = most_positive_number;
+    X[rd] = most_positive_number[(xlen() - 1):0];
   } else {
-    X[rd] = shifted_value;
+    X[rd] = shifted_value[(xlen() - 1):0];
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.shlusat.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.shlusat.yaml
@@ -31,9 +31,9 @@ access:
   vs: always
   vu: always
 operation(): |
-  Bits<xlen()*2> zext_double_width_rs1 = {{xlen(){1'b0}}, X[rs1]};
-  Bits<xlen()*2> shifted_value = zext_double_width_rs1 << X[rs2][4:0];
-  Bits<xlen()*2> largest_unsigned_value = {xlen(){1'b1}};
+  Bits<xlen()`*2> zext_double_width_rs1 = {{xlen(){1'b0}}, X[rs1]};
+  Bits<xlen()`*2> shifted_value = zext_double_width_rs1 << X[rs2][4:0];
+  Bits<xlen()`*2> largest_unsigned_value = {{xlen(){1'b0}}, {xlen(){1'b1}}};
 
   if (shifted_value > largest_unsigned_value) {
     X[rd] = largest_unsigned_value[(xlen() - 1):0];

--- a/arch_overlay/qc_iu/inst/Xqci/qc.shlusat.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.shlusat.yaml
@@ -31,12 +31,12 @@ access:
   vs: always
   vu: always
 operation(): |
-  Bits<{1'b0, MXLEN}*2> zext_double_width_rs1 = {{MXLEN{1'b0}}, X[rs1]};
-  Bits<{1'b0, MXLEN}*2> shifted_value = zext_double_width_rs1 << X[rs2][4:0];
-  XReg largest_unsigned_value = {MXLEN{1'b1}};
+  Bits<xlen()*2> zext_double_width_rs1 = {{xlen(){1'b0}}, X[rs1]};
+  Bits<xlen()*2> shifted_value = zext_double_width_rs1 << X[rs2][4:0];
+  Bits<xlen()*2> largest_unsigned_value = {xlen(){1'b1}};
 
   if (shifted_value > largest_unsigned_value) {
-    X[rd] = largest_unsigned_value;
+    X[rd] = largest_unsigned_value[(xlen() - 1):0];
   } else {
-    X[rd] = shifted_value;
+    X[rd] = shifted_value[(xlen() - 1):0];
   }

--- a/arch_overlay/qc_iu/inst/Xqci/qc.subsat.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.subsat.yaml
@@ -31,9 +31,9 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg result = X[rs1] - X[rs2];
-  XReg most_negative_number = 1 << (xlen() - 1);
-  XReg most_positive_number = (1 << (xlen() - 1)) - 1;
+  Bits<xlen()+1> result = X[rs1] `- X[rs2];
+  Bits<xlen()+1> most_negative_number = {2'b11,{(xlen()-1){1'b0}}};
+  Bits<xlen()+1> most_positive_number = {2'b00,{(xlen()-1){1'b1}}};
 
   # overflow occurs if the operands have different signs and the result is a different sign than the first operand
   if (X[rs1][xlen()-1] != X[rs2][xlen()-1]) {
@@ -47,4 +47,4 @@ operation(): |
   }
 
   # otherwise, overflow did not occur
-  X[rd] = result;
+  X[rd] = result[(xlen() - 1):0];


### PR DESCRIPTION
  changes:
    - Fix IDL code of qc.shlusat instruction (should use zero-extension and not sign-extension)
    - Fix IDL code of qc.shlusat and qc.shlsat instructions (should compare values of xlen()*2 bits)
    - Fix IDL code of qc.shlusat and qc.shlsat instructions because change in IDL operators (width adjustment)
    - Fix IDL code of qc.subsat, qc.addusat and qc.addsat instructions because change in IDL operators (width adjustment)
    - Fix IDL code for qc.c.mileaveret, qc.c.mnret and qc.c.mret instructions because change in IDL '<<' operator
    - Fix IDL code for qc.c.clrint, qc.c.setint, qc.clrinti and qc.setinti instructions because change in IDL '<<' operator
    - Fix IDL code for qc.c.di, qc.c.dir, qc.c.ei, qc.c.eir and qc.c.mienter.nest instructions because change in IDL '<<' operator
    - Fix IDL code for qc.c.sync, qc.c.syncr, qc.c.syncwf and qc.c.syncwl instructions because change in IDL '<<' operator
    - Fix IDL code for qc.c.bseti, qc.c.extu, qc.ext and qc.extu instructions because change in IDL '<<' operator
    - Fix IDL code for qc.extd, qc.extdu, qc.extdr and qc.extdur instructions because change in IDL '<<' operator
    - Fix IDL code for qc.extdpr, qc.extdprh, qc.extdupr and qc.extduprh instructions because change in IDL '<<' operator
    - Fix IDL code for qc.insb, qc.insbi, qc.insbr and qc.insbri instructions because change in IDL '<<' operator
    - Fix IDL code for qc.insbh, qc.insbhr, qc.insbpr and qc.insbprh instructions because change in IDL '<<' operator
 