### PR TITLE
fix: too much quoting in `lib/deploy.sh`

### DIFF
--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -93,7 +93,7 @@ deploy_log "Copy isa_explorer_spreadsheet"
 deploy_cp_recursive gen/isa_explorer/spreadsheet $DEPLOY_DIR/isa_explorer
 
 deploy_log "Build manual"
-deploy_do "gen:html_manual MANUAL_NAME=isa VERSIONS=all"
+deploy_do gen:html_manual MANUAL_NAME=isa VERSIONS=all
 deploy_log "Copy manual html"
 deploy_cp_recursive gen/manual/isa/top/all/html $DEPLOY_DIR/manual
 deploy_log "Build html documentation for example_rv64_with_overlay"


### PR DESCRIPTION
Commit 4ddb999 added some nice logging, but also added a lot of quotes. A few too many, in fact, as this:
```
./do gen:html_manual MANUAL_NAME=isa VERSIONS=all
```
became:
```
deploy_do "gen:html_manual MANUAL_NAME=isa VERSIONS=all"
```

The quotes there turn "command argument argument" into a single command string where the spaces are part of the command itself.

Remove the quotes so that the arguments are again treated as arguments.