### PR TITLE
feat(instruction_appendix): add assembly field based on environment variable

### DIFF
--- a/backends/instructions_appendix/tasks.rake
+++ b/backends/instructions_appendix/tasks.rake
@@ -55,7 +55,26 @@ end
 namespace :gen do
   task instruction_appendix_adoc: MERGED_INSTRUCTIONS_FILE.to_s
 
-  desc "Generate instruction appendix (merged instructions adoc and PDF)"
+  desc <<~DESC
+    Generate the instruction appendix (merged .adoc and PDF)
+
+    By default this will produce the “merged instructions” AsciiDoc file and
+    then render it to PDF.
+
+    Environment flags:
+
+     * ASSEMBLY - set to `1` to include an “Assembly” line (instruction mnemonic + operands)
+                  before the Encoding section for each instruction.
+
+    Examples:
+
+     # Just regenerate AsciiDoc + PDF:
+     $ do gen:instruction_appendix
+
+     # Include assembly templates in the docs:
+     $ do gen:instruction_appendix ASSEMBLY=1
+
+  DESC
   task :instruction_appendix do
     # Generate the merged instructions adoc.
     Rake::Task[MERGED_INSTRUCTIONS_FILE.to_s].invoke

--- a/backends/instructions_appendix/templates/instructions.adoc.erb
+++ b/backends/instructions_appendix/templates/instructions.adoc.erb
@@ -10,6 +10,12 @@
 Synopsis::
 <%= inst.long_name %>
 
+<%- if ENV['ASSEMBLY']=="1" && inst.assembly.to_s.strip != "" -%>
+Assembly::
+<%= inst.fix_entities("#{inst.name.downcase} #{inst.assembly}") %>
+<%- end -%>
+
+
 Encoding::
 <%- if inst.multi_encoding? -%>
 [NOTE]


### PR DESCRIPTION
added the Assembly field as optional to the instruction_appendix pdf output since it's already in a much more verified status