### PR TITLE
fix(data): fix assembly field introduced in wrong llvm parsing

### DIFF
--- a/arch/inst/V/vfmv.f.s.yaml
+++ b/arch/inst/V/vfmv.f.s.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: V
-assembly: vd, vs2
+assembly: fd, vs2
 encoding:
   match: 0100001-----00000001-----1010111
   variables:


### PR DESCRIPTION
Noticed by @dbrash on #705 