### PR TITLE
feature: condense overview section of inst pg tmpl

### DIFF
--- a/backends/manual/templates/instruction.adoc.erb
+++ b/backends/manual/templates/instruction.adoc.erb
@@ -5,18 +5,16 @@
 
 *<%= inst.long_name %>*
 
-== Assembly format
-
-`<%= inst.name %> <%= inst.assembly.gsub('x', 'r') %>`
-
-== Synopsis
+<%= inst.fix_entities(inst.description) %>
 
 <%- if inst.data_independent_timing? -%>
 [IMPORTANT]
 This instruction must have data-independent timing when extension `Zkt` is enabled.
 <%- end -%>
 
-<%= inst.fix_entities(inst.description) %>
+== Assembly format
+
+`<%= inst.name %> <%= inst.assembly.gsub('x', 'r') %>`
 
 == Decode Variables
 


### PR DESCRIPTION
just make synopsis implicit by removing header
and putting inst.description at top of page
fixes #745