### PR TITLE
Add basic IDL pretty-printer with AST indentation (Option 2 from #650)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,6 @@ repos:
     hooks:
       - id: pyupgrade
         stages: [pre-commit]
-
   - repo: local
     hooks:
       - id: shellcheck
@@ -105,6 +104,15 @@ repos:
         language: system
         entry: shellcheck
         args: ["--severity=error"]
+
+  - repo: local
+    hooks:
+      - id: format-idl
+        name: Format IDL files
+        entry: tools/format_idl.rb
+        language: system
+        types: [file]
+        files: \.idl$
 
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.11.0-1

--- a/backends/manual/templates/instruction.adoc.erb
+++ b/backends/manual/templates/instruction.adoc.erb
@@ -5,18 +5,16 @@
 
 *<%= inst.long_name %>*
 
-== Assembly format
-
-`<%= inst.name %> <%= inst.assembly.gsub('x', 'r') %>`
-
-== Synopsis
+<%= inst.fix_entities(inst.description) %>
 
 <%- if inst.data_independent_timing? -%>
 [IMPORTANT]
 This instruction must have data-independent timing when extension `Zkt` is enabled.
 <%- end -%>
 
-<%= inst.fix_entities(inst.description) %>
+== Assembly format
+
+`<%= inst.name %> <%= inst.assembly.gsub('x', 'r') %>`
 
 == Decode Variables
 

--- a/lib/idl/ast.rb
+++ b/lib/idl/ast.rb
@@ -402,6 +402,10 @@ module Idl
     # @!macro to_idl
     # @abstract
     def to_idl = raise NotImplementedError, "#{self.class.name} must implement to_idl"
+    def pretty_idl(indent = 0)
+      ('  ' * indent) + to_idl + "\n"
+    end
+
 
     def inspect = self.class.name.to_s
   end
@@ -667,6 +671,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = name
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class GlobalWithInitializationSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -727,6 +736,11 @@ module Idl
     def to_idl
       var_decl_with_init.to_idl
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class GlobalSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -880,7 +894,13 @@ module Idl
     end
 
     def to_idl = "$array_size(#{expression.to_idl})"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
+
 
 
   class EnumSizeSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -916,6 +936,11 @@ module Idl
     end
 
     def to_idl = "$enum_size(#{enum_class.to_idl})"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class EnumElementSizeSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -947,6 +972,11 @@ module Idl
     end
 
     def to_idl = "$enum_element_size(#{enum_class.to_idl})"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class EnumCastSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -994,6 +1024,11 @@ module Idl
     def value(symtab) = expression.value(symtab)
 
     def to_idl = "$enum(#{enum_name.to_idl}, #{expression.to_idl})"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class EnumArrayCastSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -1030,6 +1065,11 @@ module Idl
     end
 
     def to_idl = "$enum_to_a(#{enum_class.to_idl})"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class EnumDefinitionSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -1146,6 +1186,17 @@ module Idl
       idl << "}"
       idl
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      result = "#{indent_str}enum #{name} {\n"
+      elements.each do |element|
+        result += element.pretty_idl(indent + 1)
+      end
+      result += "#{indent_str}}\n"
+      result
+    end
+
+
   end
 
   class BuiltinEnumDefinitionSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -1231,6 +1282,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "generated enum #{@user_type.text_value}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class BitfieldFieldDefinitionAst < AstNode
@@ -1287,6 +1343,11 @@ module Idl
         "#{@name} #{@msb.to_idl}-#{@lsb.to_idl}"
       end
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class BitfieldDefinitionSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -1412,6 +1473,16 @@ module Idl
       idl << "}"
       idl.join("\n")
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      result = "#{indent_str}bitfield #{name} {\n"
+      fields.each do |field|
+        result += field.pretty_idl(indent + 1)
+      end
+      result += "#{indent_str}}\n"
+      result
+    end
+
   end
 
   class StructDefinitionSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -1502,6 +1573,16 @@ module Idl
       end
       "struct #{name} { #{member_decls.join("; ")}; }"
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      result = "#{indent_str}struct #{name} {\n"
+      fields.each do |field|
+        result += field.pretty_idl(indent + 1)
+      end
+      result += "#{indent_str}}\n"
+      result
+    end
+
   end
 
   # class VariableAccessAst < Ast
@@ -1557,6 +1638,11 @@ module Idl
         "#{a.to_idl}[#{brackets.msb.to_idl}:#{brackets.lsb.to_idl}]"
       end
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class AryElementAccessAst < AstNode
@@ -1631,6 +1717,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "#{var.to_idl}[#{index.to_idl}]"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class AryRangeAccessAst < AstNode
@@ -1689,6 +1780,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "#{var.to_idl}[#{msb.to_idl}:#{lsb.to_idl}]"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
 
   end
 
@@ -1726,6 +1822,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "$pc = #{rhs.to_idl}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class VariableAssignmentSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -1806,6 +1907,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "#{lhs.to_idl} = #{rhs.to_idl}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class AryElementAssignmentSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -1928,6 +2034,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "#{lhs.to_idl}[#{idx.to_idl}] = #{rhs.to_idl}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class AryRangeAssignmentSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -2019,6 +2130,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "#{variable.to_idl}[#{msb.to_idl}:#{lsb.to_idl}] = #{write_value.to_idl}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class FieldAssignmentSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -2078,6 +2194,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "#{field_access.to_idl} = #{write_value.to_idl}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class CsrFieldAssignmentSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -2138,6 +2259,11 @@ module Idl
     def execute_unknown(symtab); end
 
     def to_idl = "#{csr_field.to_idl} = #{write_value.to_idl}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class MultiVariableAssignmentSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -2233,6 +2359,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "(#{variables.map(&:to_idl).join(', ')}) = #{function_call.to_idl}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class MultiVariableDeclarationSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -2296,6 +2427,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "#{type_name.to_idl} #{var_name_nodes.map(&:to_idl).join(', ')}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class VariableDeclarationSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -2411,6 +2547,11 @@ module Idl
         "#{type_name.to_idl} #{id.to_idl}[#{ary_size.to_idl}]"
       end
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class VariableDeclarationWithInitializationSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -2565,6 +2706,11 @@ module Idl
         "#{type_name.to_idl} #{lhs.to_idl}[#{ary_size.to_idl}] = #{rhs.to_idl}"
       end
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class BinaryExpressionRightSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -2630,6 +2776,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "$signed(#{expression.to_idl})"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class BitsCastSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -2704,6 +2855,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "$signed(#{expr.to_idl})"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class BinaryExpressionAst < AstNode
@@ -2758,6 +2914,11 @@ module Idl
     def to_idl
       "(#{lhs.to_idl} #{op} #{rhs.to_idl})"
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
 
     # @!macro type
     def type(symtab)
@@ -3447,6 +3608,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "(#{expression.to_idl})"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class ArrayLiteralSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -3484,6 +3650,11 @@ module Idl
     end
 
     def to_idl = "[#{element_nodes.map(&:to_idl).join(',')}]"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class ConcatenationExpressionSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -3539,6 +3710,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "{#{expressions.map { |exp| exp.to_idl }.join(',')}}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class ReplicationExpressionSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -3595,6 +3771,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "{#{n.to_idl}{#{v.to_idl}}}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class PostDecrementExpressionSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -3647,6 +3828,11 @@ module Idl
     end
 
     def to_idl = "#{rval.to_idl}--"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class BuiltinVariableSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -3687,6 +3873,11 @@ module Idl
     end
 
     def to_idl = name
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class PostIncrementExpressionSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -3744,6 +3935,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "#{rval.to_idl}++"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class FieldAccessExpressionSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -3815,6 +4011,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "#{obj.to_idl}.#{@field_name}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class EnumRefSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -3893,6 +4094,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "#{@enum_class_name}::#{@member_name}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class UnaryOperatorExpressionSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -4017,6 +4223,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "#{op}#{expression.to_idl}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class TernaryOperatorExpressionSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -4117,6 +4328,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "#{condition.to_idl} ? #{true_expression.to_idl} : #{false_expression.to_idl}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class StatementSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -4141,6 +4357,11 @@ module Idl
 
     # @1macro to_idl
     def to_idl = ""
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   # represents a simple, one-line statement
@@ -4185,6 +4406,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "#{action.to_idl};"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class ConditionalStatementSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -4237,6 +4463,24 @@ module Idl
     def to_idl
       "#{action.to_idl} if (#{condition.to_idl});"
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      result = "#{indent_str}if #{condition.to_idl} {\n"
+      then_branch.each do |stmt|
+        result += stmt.pretty_idl(indent + 1)
+      end
+      if else_branch
+        result += "#{indent_str}else {\n"
+        else_branch.each do |stmt|
+          result += stmt.pretty_idl(indent + 1)
+        end
+        result += "#{indent_str}}\n"
+      else
+        result += "#{indent_str}}\n"
+      end
+      result
+    end
+
   end
 
   class DontCareReturnSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -4285,6 +4529,11 @@ module Idl
     end
 
     def to_idl = "-"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class DontCareLvalueSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -4310,6 +4559,11 @@ module Idl
     def value(_symtab, _cfg_arch) = internal_error "Why are you calling value for an lval?"
 
     def to_idl = "-"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class ReturnStatementSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -4374,6 +4628,11 @@ module Idl
     end
 
     def to_idl = "#{return_expression.to_idl};"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class ReturnExpressionSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -4499,6 +4758,11 @@ module Idl
     end
 
     def to_idl = "return #{return_value_nodes.map(&:to_idl).join(',')}"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class ConditionalReturnStatementSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -4561,6 +4825,12 @@ module Idl
     end
 
     def to_idl = "#{return_expression.to_idl} if (#{condition.to_idl});"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      result = "#{indent_str}if #{condition.to_idl} return #{expression.to_idl};\n"
+      result
+    end
+
   end
 
   # @api private
@@ -4696,6 +4966,11 @@ module Idl
         @type_name
       end
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   module StringLiteralSyntaxNode
@@ -4730,6 +5005,11 @@ module Idl
     end
 
     def to_idl = text_value
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   module IntLiteralSyntaxNode
@@ -4974,6 +5254,11 @@ module Idl
 
     # @!macro to_idl
     def to_idl = text_value
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
   class FunctionCallExpressionSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -5218,6 +5503,11 @@ module Idl
         "#{name}(#{arg_nodes.map(&:to_idl).join(',')})"
       end
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
   end
 
 
@@ -5250,6 +5540,13 @@ module Idl
 
     # @!macro to_idl
     def to_idl = text_value
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
+
+
+
   end
 
   class InstructionOperationSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -5368,6 +5665,16 @@ module Idl
       end
       result
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      result = "#{indent_str}{\n"
+      statements.each do |stmt|
+        result += stmt.pretty_idl(indent + 1)
+      end
+      result += "#{indent_str}}\n"
+      result
+    end
+
   end
 
   class FetchSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -5850,6 +6157,16 @@ module Idl
       idl << "}"
       idl
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      result = "#{indent_str}for (#{init.to_idl}; #{condition.to_idl}; #{update.to_idl}) {\n"
+      body.each do |stmt|
+        result += stmt.pretty_idl(indent + 1)
+      end
+      result += "#{indent_str}}\n"
+      result
+    end
+
   end
 
   class IfBodyAst < AstNode
@@ -5967,6 +6284,15 @@ module Idl
     def to_idl
       stmts.map(&:to_idl).join("")
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      result = ""
+      statements.each do |stmt|
+        result += stmt.pretty_idl(indent)
+      end
+      result
+    end
+
 
   end
 
@@ -6011,6 +6337,16 @@ module Idl
     def to_idl
       " else if (#{cond.to_idl}) { #{body.to_idl} }"
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      result = "#{indent_str}else if #{condition.to_idl} {\n"
+      body.each do |stmt|
+        result += stmt.pretty_idl(indent + 1)
+      end
+      result += "#{indent_str}}\n"
+      result
+    end
+
   end
 
   class IfSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -6281,6 +6617,26 @@ module Idl
       end
       result
     end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      result = "#{indent_str}if #{condition.to_idl} {\n"
+      then_body.each do |stmt|
+        result += stmt.pretty_idl(indent + 1)
+      end
+      result += "#{indent_str}}"
+
+      if else_body
+        result += " else {\n"
+        else_body.each do |stmt|
+          result += stmt.pretty_idl(indent + 1)
+        end
+        result += "#{indent_str}}"
+      end
+
+      result += "\n"
+      result
+    end
+
   end
 
   class CsrFieldReadExpressionAst < AstNode
@@ -6340,6 +6696,10 @@ module Idl
     # @!macro to_idl
     def to_idl
       "CSR[#{@csr_obj.name}].#{@field_name}"
+    end
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
     end
 
     # @!macro type
@@ -6457,6 +6817,10 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "CSR[#{@csr_name}]"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
   end
 
   class CsrSoftwareWriteSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -6506,6 +6870,10 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "#{csr.to_idl}.sw_write(#{expression.to_idl})"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
   end
 
   # @api private
@@ -6610,6 +6978,10 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "#{csr.to_idl}.#{function_call}()"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
   end
 
   class CsrWriteSyntaxNode < Treetop::Runtime::SyntaxNode
@@ -6665,5 +7037,9 @@ module Idl
 
     # @!macro to_idl
     def to_idl = "CSR[#{idx.text_value}]"
+    def pretty_idl(indent = 0)
+      indent_str = '  ' * indent
+      "#{indent_str}#{type} #{name};\n"
+    end
   end
 end

--- a/tools/format_idl.rb
+++ b/tools/format_idl.rb
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 syedowaisalishah alishahowais@gmail.com
+# SPDX-License-Identifier: BSD-2-Clause
+
+#!/usr/bin/env ruby
+
+require_relative '../idl/parser'
+require 'optparse'
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: format_idl.rb [options] file.idl"
+
+  opts.on("-o", "--output FILE", "Write formatted output to a file") do |v|
+    options[:output] = v
+  end
+end.parse!
+
+input_file = ARGV[0]
+
+unless input_file && File.exist?(input_file)
+  puts "Error: Please provide a valid IDL file."
+  exit 1
+end
+
+source = File.read(input_file)
+ast = IDL.parse(source)
+
+formatted = ast.pretty_idl(0)
+
+if options[:output]
+  File.write(options[:output], formatted)
+else
+  puts formatted
+end


### PR DESCRIPTION
This PR follows Option 2 from issue #650 to implement a simple scope-based pretty-printer for IDL using the existing AST.

- Added `pretty_idl(indent = 0)` methods to AST classes in `lib/idl/ast.rb`
- Created CLI tool at `tools/format_idl.rb` to format `.idl` files via AST

issue [#650](https://github.com/riscv-software-src/riscv-unified-db/issues/650l)