### PR TITLE
Xqccmp: Left shift `spimm` in pop instructions

### DIFF
--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.pop.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.pop.yaml
@@ -24,6 +24,7 @@ encoding:
       not: [0, 1, 2, 3]
     - name: spimm
       location: 3-2
+      left_shift: 4
 access:
   s: always
   u: always

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popret.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popret.yaml
@@ -24,6 +24,7 @@ encoding:
       not: [0, 1, 2, 3]
     - name: spimm
       location: 3-2
+      left_shift: 4
 access:
   s: always
   u: always

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popretz.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.popretz.yaml
@@ -24,6 +24,7 @@ encoding:
       not: [0, 1, 2, 3]
     - name: spimm
       location: 3-2
+      left_shift: 4
 access:
   s: always
   u: always

--- a/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.pushfp.yaml
+++ b/arch_overlay/qc_iu/inst/Xqccmp/qc.cm.pushfp.yaml
@@ -26,6 +26,7 @@ encoding:
       not: [0, 1, 2, 3, 4]
     - name: spimm
       location: 3-2
+      left_shift: 4
 access:
   s: always
   u: always


### PR DESCRIPTION
Shifting `spimm` left by 4 matches the behaviour of cm.push/cm.pop, and moreover since qc.cm.push shifts by 4 the stack address is not calculated correctly upon popping. E.g.

    qc.cm.push      {ra}, -64
    qc.cm.pop       {ra}, 64

will not recover the stack address in addition to loading incorrect values for all saved registers.