### PR TITLE
fix(data): All "upper half" CSRs are RV32-only

### DIFF
--- a/arch/csr/H/htimedeltah.yaml
+++ b/arch/csr/H/htimedeltah.yaml
@@ -12,6 +12,7 @@ writable: true
 priv_mode: S
 definedBy: H
 length: 32
+base: 32
 fields:
   DELTA:
     location: 31-0

--- a/arch/csr/minstreth.yaml
+++ b/arch/csr/minstreth.yaml
@@ -12,6 +12,7 @@ description: |
   See `minstret` for details.
 priv_mode: M
 length: 32
+base: 32
 fields:
   COUNT:
     alias:


### PR DESCRIPTION
Most "upper half" CSRs are already defined "base: 32"...
except "htimedeltah" and "minstreth". Fix them.

BREAKING CHANGE: Some "upper half" CSRs no longer available to RV64.

CSRs "htimedeltah" and "minstreth" were mistakenly available to RV64.
They will no longer be available to RV64.