### PR TITLE
Xqci: Make sure `imm` is signed for extended loads

### DIFF
--- a/arch_overlay/qc_iu/inst/Xqci/qc.e.lb.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.e.lb.yaml
@@ -30,5 +30,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg virtual_address = X[rs1] + imm;
+  XReg virtual_address = X[rs1] + $signed(imm);
   X[rd] = sext(read_memory<8>(virtual_address, $encoding), 8);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.e.lbu.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.e.lbu.yaml
@@ -30,5 +30,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg virtual_address = X[rs1] + imm;
+  XReg virtual_address = X[rs1] + $signed(imm);
   X[rd] = read_memory<8>(virtual_address, $encoding);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.e.lh.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.e.lh.yaml
@@ -30,5 +30,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg virtual_address = X[rs1] + imm;
+  XReg virtual_address = X[rs1] + $signed(imm);
   X[rd] = sext(read_memory<16>(virtual_address, $encoding), 16);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.e.lhu.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.e.lhu.yaml
@@ -30,5 +30,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg virtual_address = X[rs1] + imm;
+  XReg virtual_address = X[rs1] + $signed(imm);
   X[rd] = read_memory<16>(virtual_address, $encoding);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.e.lw.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.e.lw.yaml
@@ -30,5 +30,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg virtual_address = X[rs1] + imm;
+  XReg virtual_address = X[rs1] + $signed(imm);
   X[rd] = read_memory<32>(virtual_address, $encoding);


### PR DESCRIPTION
Otherwise loads from negative offsets such as

  qc.e.lw a0, -0x8004(a0)

won't work correctly.