### PR TITLE
fix(Xqci): fixing encoding and IDL code of few instructions

### DIFF
--- a/arch_overlay/qc_iu/ext/Xqci.yaml
+++ b/arch_overlay/qc_iu/ext/Xqci.yaml
@@ -379,7 +379,43 @@ versions:
   - { name: Xqcicm, version: "0.2.0" }
   - { name: Xqcics, version: "0.2.0" }
   - { name: Xqcicsr, version: "0.3.0" }
-  - { name: Xqciint, version: "0.7.0" }
+  - { name: Xqciint, version: "0.8.0" }
+  - { name: Xqciio, version: "0.1.0" }
+  - { name: Xqcilb, version: "0.2.0" }
+  - { name: Xqcili, version: "0.2.0" }
+  - { name: Xqcilia, version: "0.2.0" }
+  - { name: Xqcilo, version: "0.3.0" }
+  - { name: Xqcilsm, version: "0.6.0" }
+  - { name: Xqcisim, version: "0.2.0" }
+  - { name: Xqcisls, version: "0.2.0" }
+  - { name: Xqcisync, version: "0.3.0" }
+  requires:
+    name: Zca
+    version: ">= 1.0.0"
+- version: "0.12.0"
+  state: frozen
+  ratification_date: null
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  changes:
+    - Fix desciption of qc.c.eir instruction to match IDL code and functionality
+    - Fix encoding of qc.swm and qc.swmi instructions to state that rs3 cannot be x0
+    - Fix description and IDL code of qc.swm and qc.lwm instructions to state that length is in rs2[4:0]
+  implies:
+  - { name: Xqcia, version: "0.7.0" }
+  - { name: Xqciac, version: "0.3.0" }
+  - { name: Xqcibi, version: "0.2.0" }
+  - { name: Xqcibm, version: "0.8.0" }
+  - { name: Xqcicli, version: "0.3.0" }
+  - { name: Xqcicm, version: "0.2.0" }
+  - { name: Xqcics, version: "0.2.0" }
+  - { name: Xqcicsr, version: "0.3.0" }
+  - { name: Xqciint, version: "0.9.0" }
   - { name: Xqciio, version: "0.1.0" }
   - { name: Xqcilb, version: "0.2.0" }
   - { name: Xqcili, version: "0.2.0" }

--- a/arch_overlay/qc_iu/ext/Xqciint.yaml
+++ b/arch_overlay/qc_iu/ext/Xqciint.yaml
@@ -121,6 +121,19 @@ versions:
     - Fix IDL code for qc.c.clrint, qc.c.setint, qc.clrinti and qc.setinti instructions because change in IDL '<<' operator
     - Fix IDL code for qc.c.di, qc.c.dir, qc.c.ei, qc.c.eir and qc.c.mienter.nest instructions because change in IDL '<<' operator
   requires: { name: Zca, version: ">= 1.0.0" }
+- version: "0.9.0"
+  state: frozen
+  ratification_date: null
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  changes:
+    - Fix desciption of qc.c.eir instruction to match IDL code and functionality
+  requires: { name: Zca, version: ">= 1.0.0" }
 description: |
   The Xqciint extension includes eleven instructions to accelerate interrupt
   servicing by performing common actions during ISR prologue/epilogue.

--- a/arch_overlay/qc_iu/ext/Xqcilsm.yaml
+++ b/arch_overlay/qc_iu/ext/Xqcilsm.yaml
@@ -64,6 +64,19 @@ versions:
     email: dhower@qti.qualcomm.com
   changes:
     - Fix IDL code and description of qc.setwm instruction to state that number of words written 0..31.
+- version: "0.6.0"
+  state: frozen
+  ratification_date: null
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  changes:
+    - Fix encoding of qc.swm and qc.swmi instructions to state that rs3 cannot be x0
+    - Fix description and IDL code of qc.swm and qc.lwm instructions to state that length is in rs2[4:0]
 description: |
   The Xqcilsm extension includes six instructions that transfer multiple values
   between registers and memory.

--- a/arch_overlay/qc_iu/inst/Xqci/qc.c.eir.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.c.eir.yaml
@@ -5,8 +5,7 @@ kind: instruction
 name: qc.c.eir
 long_name: Restore interrupts (Register)
 description: |
-  Globally restore interrupts, write `rs1` to `mstatus`.
-  Equivalent to "csrrs `zero`, `mstatus`, `rs1`".
+  Globally restore interrupts, write bit 3 of rs1 to `mstatus.MIE` and `qc.mcause.MIE`.
   Instruction encoded in CI instruction format.
 definedBy:
   anyOf:

--- a/arch_overlay/qc_iu/inst/Xqci/qc.lwm.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.lwm.yaml
@@ -6,7 +6,7 @@ name: qc.lwm
 long_name: Load word multiple
 description: |
   Loads multiple words starting from address (`rs1` + `imm`) to registers, starting from `rd`.
-  The number of words is in `rs2`.
+  The number of words is in `rs2` bits [4:0].
   Instruction encoded in R instruction format.
 definedBy:
   anyOf:
@@ -35,7 +35,7 @@ access:
   vu: always
 operation(): |
   XReg vaddr = X[rs1] + imm;
-  XReg num_words = X[rs2];
+  XReg num_words = X[rs2][4:0];
   raise (ExceptionCode::IllegalInstruction, effective_ldst_mode(), $encoding) if ((rd + num_words) > 32);
   for (U32 i = 0; i < num_words; i++) {
     X[rd + i] = read_memory<32>(vaddr, $encoding);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.swm.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.swm.yaml
@@ -6,7 +6,7 @@ name: qc.swm
 long_name: Store word multiple
 description: |
   Stores multiple words from the registers starting at `rs3` to the address starting at (`rs1` + `imm`).
-  The number of words is in `rs2`.
+  The number of words is in `rs2` bits [4:0].
   Instruction encoded in R instruction format.
 definedBy:
   anyOf:
@@ -26,6 +26,7 @@ encoding:
       not: 0
     - name: rs3
       location: 11-7
+      not: 0
 assembly: " xs3, xs2, imm(xs1)"
 access:
   s: always
@@ -34,7 +35,7 @@ access:
   vu: always
 operation(): |
   XReg vaddr = X[rs1] + imm;
-  XReg num_words = X[rs2];
+  XReg num_words = X[rs2][4:0];
   raise (ExceptionCode::IllegalInstruction, effective_ldst_mode(), $encoding) if ((rs3 + num_words) > 32);
   for (U32 i = 0; i < num_words; i++) {
     write_memory<32>(vaddr, X[rs3 + i], $encoding);

--- a/arch_overlay/qc_iu/inst/Xqci/qc.swmi.yaml
+++ b/arch_overlay/qc_iu/inst/Xqci/qc.swmi.yaml
@@ -26,6 +26,7 @@ encoding:
       not: 0
     - name: rs3
       location: 11-7
+      not: 0
 assembly: " xs3, length, imm(xs1)"
 access:
   s: always


### PR DESCRIPTION
changes:
  - Fix desciption of qc.c.eir instruction to match IDL code and functionality
  - Fix encoding of qc.swm and qc.swmi instructions to state that rs3 cannot be x0
  - Fix description and IDL code of qc.swm and qc.lwm instructions to state that length is in rs2[4:0]