### PR TITLE
chore: change dependabot submodule check to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
   - package-ecosystem: gitsubmodule
     directory: /
     schedule:
-      interval: daily
+      interval: weekly


### PR DESCRIPTION
Seems like this would be a better cadence than daily 
weekly happens on monday
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#interval
