### PR TITLE
feat: add misa Q bit, add MUTABLE_MISA_Q parameter to Q extension

### DIFF
--- a/arch/csr/misa.yaml
+++ b/arch/csr/misa.yaml
@@ -169,6 +169,28 @@ fields:
           .. Execute every in-scope multiply extension instruction
           . check
           .. Check that every multiply extension instruction throws illegal instruction exception
+  Q:
+    location: 16
+    description: |
+      Indicates support for the `Q` (quad precision float) extension.
+
+      [when,"MUTABLE_MISA_Q == true"]
+      --
+      Writing 0 to this field will cause all quad-precision floating point instructions to raise an `IllegalInstruction` exception.
+      --
+    type(): |
+      return MUTABLE_MISA_Q ? CsrFieldType::RW : CsrFieldType::RO;
+    reset_value: 1
+    definedBy: Q
+    sw_write(csr_value): |
+      if ((csr_value.F == 0 || csr_value.D == 0) && csr_value.Q == 1) {
+        return UNDEFINED_LEGAL_DETERMINISTIC;
+      }
+
+      # fall-through; write the intended value
+      return csr_value.Q;
+    legal?(csr_value): |
+      return !(csr_value.Q == 1 && csr_value.D == 0);
   S:
     location: 18
     description: |

--- a/arch/ext/Q.yaml
+++ b/arch/ext/Q.yaml
@@ -18,3 +18,9 @@ versions:
     state: ratified
     ratification_date: null
     requires: D
+params:
+  MUTABLE_MISA_Q:
+    description: |
+      Indicates whether or not the `Q` extension can be disabled with the `misa.Q` bit.
+    schema:
+      type: boolean


### PR DESCRIPTION
This pull request introduces the following changes:

### MISA Q Bit
- Added a new field `Q` in `arch/csr/misa.yaml` to indicate support for the Q (quad precision float) extension.

### MUTABLE_MISA_Q Parameter
- Introduced a new parameter `MUTABLE_MISA_Q` in `arch/ext/Q.yaml`.

### Additional Notes
- Changes to `F` and `D` bits might be required. Looking forward to getting some feedback on this.

**Related Issue:**
- Issue #788 