### PR TITLE
fix(data): AMO instructions need parentheses around address register

### DIFF
--- a/arch/inst/Zaamo/amoadd.w.yaml
+++ b/arch/inst/Zaamo/amoadd.w.yaml
@@ -12,7 +12,7 @@ description: |
     * Add the least-significant word of register _rs2_ to the loaded value
     * Write the sum to the address in _rs1_
 definedBy: Zaamo
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00000------------010-----0101111
   variables:

--- a/arch/inst/Zaamo/amoand.d.yaml
+++ b/arch/inst/Zaamo/amoand.d.yaml
@@ -13,7 +13,7 @@ description: |
     * Write the result to the address in _rs1_
 definedBy: Zaamo
 base: 64
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 01100------------011-----0101111
   variables:

--- a/arch/inst/Zaamo/amoand.w.yaml
+++ b/arch/inst/Zaamo/amoand.w.yaml
@@ -12,7 +12,7 @@ description: |
     * AND the least-significant word of register _rs2_ to the loaded value
     * Write the result to the address in _rs1_
 definedBy: Zaamo
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 01100------------010-----0101111
   variables:

--- a/arch/inst/Zaamo/amomax.d.yaml
+++ b/arch/inst/Zaamo/amomax.d.yaml
@@ -13,7 +13,7 @@ description: |
     * Write the maximum to the address in _rs1_
 definedBy: Zaamo
 base: 64
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 10100------------011-----0101111
   variables:

--- a/arch/inst/Zaamo/amomax.w.yaml
+++ b/arch/inst/Zaamo/amomax.w.yaml
@@ -12,7 +12,7 @@ description: |
     * Signed compare the least-significant word of register _rs2_ to the loaded value, and select the maximum value
     * Write the maximum to the address in _rs1_
 definedBy: Zaamo
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 10100------------010-----0101111
   variables:

--- a/arch/inst/Zaamo/amomaxu.d.yaml
+++ b/arch/inst/Zaamo/amomaxu.d.yaml
@@ -13,7 +13,7 @@ description: |
     * Write the maximum to the address in _rs1_
 definedBy: Zaamo
 base: 64
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 11100------------011-----0101111
   variables:

--- a/arch/inst/Zaamo/amomaxu.w.yaml
+++ b/arch/inst/Zaamo/amomaxu.w.yaml
@@ -12,7 +12,7 @@ description: |
     * Unsigned compare the least-significant word of register _rs2_ to the loaded value, and select the maximum value
     * Write the maximum to the address in _rs1_
 definedBy: Zaamo
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 11100------------010-----0101111
   variables:

--- a/arch/inst/Zaamo/amomin.d.yaml
+++ b/arch/inst/Zaamo/amomin.d.yaml
@@ -13,7 +13,7 @@ description: |
     * Write the minimum to the address in _rs1_
 definedBy: Zaamo
 base: 64
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 10000------------011-----0101111
   variables:

--- a/arch/inst/Zaamo/amomin.w.yaml
+++ b/arch/inst/Zaamo/amomin.w.yaml
@@ -12,7 +12,7 @@ description: |
     * Signed compare the least-significant word of register _rs2_ to the loaded value, and select the minimum value
     * Write the result to the address in _rs1_
 definedBy: Zaamo
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 10000------------010-----0101111
   variables:

--- a/arch/inst/Zaamo/amominu.d.yaml
+++ b/arch/inst/Zaamo/amominu.d.yaml
@@ -13,7 +13,7 @@ description: |
     * Write the minimum to the address in _rs1_
 definedBy: Zaamo
 base: 64
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 11000------------011-----0101111
   variables:

--- a/arch/inst/Zaamo/amominu.w.yaml
+++ b/arch/inst/Zaamo/amominu.w.yaml
@@ -12,7 +12,7 @@ description: |
     * Unsigned compare the least-significant word of register _rs2_ to the loaded word, and select the minimum value
     * Write the result to the address in _rs1_
 definedBy: Zaamo
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 11000------------010-----0101111
   variables:

--- a/arch/inst/Zaamo/amoor.d.yaml
+++ b/arch/inst/Zaamo/amoor.d.yaml
@@ -13,7 +13,7 @@ description: |
     * Write the result to the address in _rs1_
 definedBy: Zaamo
 base: 64
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 01000------------011-----0101111
   variables:

--- a/arch/inst/Zaamo/amoor.w.yaml
+++ b/arch/inst/Zaamo/amoor.w.yaml
@@ -12,7 +12,7 @@ description: |
     * OR the least-significant word of register _rs2_ to the loaded value
     * Write the result to the address in _rs1_
 definedBy: Zaamo
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 01000------------010-----0101111
   variables:

--- a/arch/inst/Zaamo/amoswap.d.yaml
+++ b/arch/inst/Zaamo/amoswap.d.yaml
@@ -12,7 +12,7 @@ description: |
     * Store the value of register _rs2_ to the address in _rs1_
 definedBy: Zaamo
 base: 64
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00001------------011-----0101111
   variables:

--- a/arch/inst/Zaamo/amoswap.w.yaml
+++ b/arch/inst/Zaamo/amoswap.w.yaml
@@ -11,7 +11,7 @@ description: |
     * Write the sign-extended value into _rd_
     * Store the least-significant word of register _rs2_ to the address in _rs1_
 definedBy: Zaamo
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00001------------010-----0101111
   variables:

--- a/arch/inst/Zaamo/amoxor.d.yaml
+++ b/arch/inst/Zaamo/amoxor.d.yaml
@@ -13,7 +13,7 @@ description: |
     * Write the result to the address in _rs1_
 definedBy: Zaamo
 base: 64
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00100------------011-----0101111
   variables:

--- a/arch/inst/Zaamo/amoxor.w.yaml
+++ b/arch/inst/Zaamo/amoxor.w.yaml
@@ -12,7 +12,7 @@ description: |
     * XOR the least-significant word of register _rs2_ to the loaded value
     * Write the result to the address in _rs1_
 definedBy: Zaamo
-assembly: xd, xs2, (xrs1)
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00100------------010-----0101111
   variables:

--- a/arch/inst/Zabha/amoadd.b.yaml
+++ b/arch/inst/Zabha/amoadd.b.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00000------------000-----0101111
   variables:

--- a/arch/inst/Zabha/amoadd.h.yaml
+++ b/arch/inst/Zabha/amoadd.h.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00000------------001-----0101111
   variables:

--- a/arch/inst/Zabha/amoand.b.yaml
+++ b/arch/inst/Zabha/amoand.b.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 01100------------000-----0101111
   variables:

--- a/arch/inst/Zabha/amoand.h.yaml
+++ b/arch/inst/Zabha/amoand.h.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 01100------------001-----0101111
   variables:

--- a/arch/inst/Zabha/amocas.b.yaml
+++ b/arch/inst/Zabha/amocas.b.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00101------------000-----0101111
   variables:

--- a/arch/inst/Zabha/amocas.h.yaml
+++ b/arch/inst/Zabha/amocas.h.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00101------------001-----0101111
   variables:

--- a/arch/inst/Zabha/amomax.b.yaml
+++ b/arch/inst/Zabha/amomax.b.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 10100------------000-----0101111
   variables:

--- a/arch/inst/Zabha/amomax.h.yaml
+++ b/arch/inst/Zabha/amomax.h.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 10100------------001-----0101111
   variables:

--- a/arch/inst/Zabha/amomaxu.b.yaml
+++ b/arch/inst/Zabha/amomaxu.b.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 11100------------000-----0101111
   variables:

--- a/arch/inst/Zabha/amomaxu.h.yaml
+++ b/arch/inst/Zabha/amomaxu.h.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 11100------------001-----0101111
   variables:

--- a/arch/inst/Zabha/amomin.b.yaml
+++ b/arch/inst/Zabha/amomin.b.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 10000------------000-----0101111
   variables:

--- a/arch/inst/Zabha/amomin.h.yaml
+++ b/arch/inst/Zabha/amomin.h.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 10000------------001-----0101111
   variables:

--- a/arch/inst/Zabha/amominu.b.yaml
+++ b/arch/inst/Zabha/amominu.b.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 11000------------000-----0101111
   variables:

--- a/arch/inst/Zabha/amominu.h.yaml
+++ b/arch/inst/Zabha/amominu.h.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 11000------------001-----0101111
   variables:

--- a/arch/inst/Zabha/amoor.b.yaml
+++ b/arch/inst/Zabha/amoor.b.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 01000------------000-----0101111
   variables:

--- a/arch/inst/Zabha/amoor.h.yaml
+++ b/arch/inst/Zabha/amoor.h.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 01000------------001-----0101111
   variables:

--- a/arch/inst/Zabha/amoswap.b.yaml
+++ b/arch/inst/Zabha/amoswap.b.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00001------------000-----0101111
   variables:

--- a/arch/inst/Zabha/amoswap.h.yaml
+++ b/arch/inst/Zabha/amoswap.h.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00001------------001-----0101111
   variables:

--- a/arch/inst/Zabha/amoxor.b.yaml
+++ b/arch/inst/Zabha/amoxor.b.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00100------------000-----0101111
   variables:

--- a/arch/inst/Zabha/amoxor.h.yaml
+++ b/arch/inst/Zabha/amoxor.h.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zabha
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00100------------001-----0101111
   variables:

--- a/arch/inst/Zacas/amocas.d.yaml
+++ b/arch/inst/Zacas/amocas.d.yaml
@@ -47,7 +47,7 @@ description: |
   An AMOCAS.D instruction always requires write permissions.
 
 definedBy: Zacas
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   RV32:
     match: 00101------------011-----0101111

--- a/arch/inst/Zacas/amocas.q.yaml
+++ b/arch/inst/Zacas/amocas.q.yaml
@@ -42,7 +42,7 @@ description: |
 
 definedBy: Zacas
 base: 64
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00101------------100-----0101111
   variables:

--- a/arch/inst/Zacas/amocas.w.yaml
+++ b/arch/inst/Zacas/amocas.w.yaml
@@ -41,7 +41,7 @@ description: |
   An AMOCAS.W instruction always requires write permissions.
 
 definedBy: Zacas
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00101------------010-----0101111
   variables:


### PR DESCRIPTION
Some AMO instructions have parentheses (arch/inst/Zaamo/amoadd.d.yaml):
```
assembly: xd, xs2, (xs1)
```

Some don't (arch/inst/Zabha/amoadd.b.yaml):
```
assembly: xd, xs2, xs1
```

They all should, so add them.

Also, some instructions use incorrect register name "xrs1".
Correct to "xs1".