### PR TITLE
fix(data): Fix remaining old register names

### DIFF
--- a/arch/inst/C/c.add.yaml
+++ b/arch/inst/C/c.add.yaml
@@ -5,20 +5,20 @@ kind: instruction
 name: c.add
 long_name: Add
 description: |
-  Add the value in rs2 to rd, and store the result in rd.
-  C.ADD expands into `add rd, rd, rs2`.
+  Add the value in xs2 to xd, and store the result in xd.
+  C.ADD expands into `add xd, xd, xs2`.
 definedBy:
   anyOf:
     - C
     - Zca
-assembly: xd, rs2
+assembly: xd, xs2
 encoding:
   match: 1001----------10
   variables:
-    - name: rs2
+    - name: xs2
       location: 6-2
       not: 0
-    - name: rd
+    - name: xd
       location: 11-7
       not: 0
 access:
@@ -27,9 +27,9 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg t0 = X[rd];
-  XReg t1 = X[rs2];
-  X[rd] = t0 + t1;
+  XReg t0 = X[xd];
+  XReg t1 = X[xs2];
+  X[xd] = t0 + t1;
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/arch/inst/C/c.addw.yaml
+++ b/arch/inst/C/c.addw.yaml
@@ -5,21 +5,21 @@ kind: instruction
 name: c.addw
 long_name: Add word
 description: |
-  Add the 32-bit values in rs2 from rd, and store the result in rd.
-  The rd and rs2 register indexes should be used as rd+8 and rs2+8 (registers x8-x15).
-  C.ADDW expands into `addw rd, rd, rs2`.
+  Add the 32-bit values in xs2 from xd, and store the result in xd.
+  The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+  C.ADDW expands into `addw xd, xd, xs2`.
 definedBy:
   anyOf:
     - C
     - Zca
 base: 64
-assembly: xd, rs2
+assembly: xd, xs2
 encoding:
   match: 100111---01---01
   variables:
-    - name: rs2
+    - name: xs2
       location: 4-2
-    - name: rd
+    - name: xd
       location: 9-7
 access:
   s: always
@@ -27,9 +27,9 @@ access:
   vs: always
   vu: always
 operation(): |
-  Bits<32> t0 = X[creg2reg(rd)][31:0];
-  Bits<32> t1 = X[creg2reg(rs2)][31:0];
-  X[creg2reg(rd)] = $signed(t0 + t1);
+  Bits<32> t0 = X[creg2reg(xd)][31:0];
+  Bits<32> t1 = X[creg2reg(xs2)][31:0];
+  X[creg2reg(xd)] = $signed(t0 + t1);
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/arch/inst/C/c.and.yaml
+++ b/arch/inst/C/c.and.yaml
@@ -5,20 +5,20 @@ kind: instruction
 name: c.and
 long_name: And
 description: |
-  And rd with rs2, and store the result in rd
-  The rd and rs2 register indexes should be used as rd+8 and rs2+8 (registers x8-x15).
-  C.AND expands into `and rd, rd, rs2`.
+  And xd with xs2, and store the result in xd
+  The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+  C.AND expands into `and xd, xd, xs2`.
 definedBy:
   anyOf:
     - C
     - Zca
-assembly: xd, rs2
+assembly: xd, xs2
 encoding:
   match: 100011---11---01
   variables:
-    - name: rs2
+    - name: xs2
       location: 4-2
-    - name: rd
+    - name: xd
       location: 9-7
 access:
   s: always
@@ -26,9 +26,9 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg t0 = X[creg2reg(rd)];
-  XReg t1 = X[creg2reg(rs2)];
-  X[creg2reg(rd)] = t0 & t1;
+  XReg t0 = X[creg2reg(xd)];
+  XReg t1 = X[creg2reg(xs2)];
+  X[creg2reg(xd)] = t0 & t1;
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/arch/inst/C/c.or.yaml
+++ b/arch/inst/C/c.or.yaml
@@ -5,20 +5,20 @@ kind: instruction
 name: c.or
 long_name: Or
 description: |
-  Or rd with rs2, and store the result in rd
-  The rd and rs2 register indexes should be used as rd+8 and rs2+8 (registers x8-x15).
-  C.OR expands into `or rd, rd, rs2`.
+  Or xd with xs2, and store the result in xd
+  The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+  C.OR expands into `or xd, xd, xs2`.
 definedBy:
   anyOf:
     - C
     - Zca
-assembly: xd, rs2
+assembly: xd, xs2
 encoding:
   match: 100011---10---01
   variables:
-    - name: rs2
+    - name: xs2
       location: 4-2
-    - name: rd
+    - name: xd
       location: 9-7
 access:
   s: always
@@ -26,9 +26,9 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg t0 = X[creg2reg(rd)];
-  XReg t1 = X[creg2reg(rs2)];
-  X[creg2reg(rd)] = t0 | t1;
+  XReg t0 = X[creg2reg(xd)];
+  XReg t1 = X[creg2reg(xs2)];
+  X[creg2reg(xd)] = t0 | t1;
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/arch/inst/C/c.sub.yaml
+++ b/arch/inst/C/c.sub.yaml
@@ -5,20 +5,20 @@ kind: instruction
 name: c.sub
 long_name: Subtract
 description: |
-  Subtract the value in rs2 from rd, and store the result in rd.
-  The rd and rs2 register indexes should be used as rd+8 and rs2+8 (registers x8-x15).
-  C.SUB expands into `sub rd, rd, rs2`.
+  Subtract the value in xs2 from xd, and store the result in xd.
+  The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+  C.SUB expands into `sub xd, xd, xs2`.
 definedBy:
   anyOf:
     - C
     - Zca
-assembly: xd, rs2
+assembly: xd, xs2
 encoding:
   match: 100011---00---01
   variables:
-    - name: rs2
+    - name: xs2
       location: 4-2
-    - name: rd
+    - name: xd
       location: 9-7
 access:
   s: always
@@ -26,9 +26,9 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg t0 = X[creg2reg(rd)];
-  XReg t1 = X[creg2reg(rs2)];
-  X[creg2reg(rd)] = t0 - t1;
+  XReg t0 = X[creg2reg(xd)];
+  XReg t1 = X[creg2reg(xs2)];
+  X[creg2reg(xd)] = t0 - t1;
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/arch/inst/C/c.subw.yaml
+++ b/arch/inst/C/c.subw.yaml
@@ -5,21 +5,21 @@ kind: instruction
 name: c.subw
 long_name: Subtract word
 description: |
-  Subtract the 32-bit values in rs2 from rd, and store the result in rd.
-  The rd and rs2 register indexes should be used as rd+8 and rs2+8 (registers x8-x15).
-  C.SUBW expands into `subw rd, rd, rs2`.
+  Subtract the 32-bit values in xs2 from xd, and store the result in xd.
+  The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+  C.SUBW expands into `subw xd, xd, xs2`.
 definedBy:
   anyOf:
     - C
     - Zca
 base: 64
-assembly: xd, rs2
+assembly: xd, xs2
 encoding:
   match: 100111---00---01
   variables:
-    - name: rs2
+    - name: xs2
       location: 4-2
-    - name: rd
+    - name: xd
       location: 9-7
 access:
   s: always
@@ -27,9 +27,9 @@ access:
   vs: always
   vu: always
 operation(): |
-  Bits<32> t0 = X[creg2reg(rd)][31:0];
-  Bits<32> t1 = X[creg2reg(rs2)][31:0];
-  X[creg2reg(rd)] = sext(t0 - t1, 31);
+  Bits<32> t0 = X[creg2reg(xd)][31:0];
+  Bits<32> t1 = X[creg2reg(xs2)][31:0];
+  X[creg2reg(xd)] = sext(t0 - t1, 31);
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/arch/inst/C/c.xor.yaml
+++ b/arch/inst/C/c.xor.yaml
@@ -5,20 +5,20 @@ kind: instruction
 name: c.xor
 long_name: Exclusive Or
 description: |
-  Exclusive or rd with rs2, and store the result in rd
-  The rd and rs2 register indexes should be used as rd+8 and rs2+8 (registers x8-x15).
-  C.XOR expands into `xor rd, rd, rs2`.
+  Exclusive or xd with xs2, and store the result in xd
+  The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+  C.XOR expands into `xor xd, xd, xs2`.
 definedBy:
   anyOf:
     - C
     - Zca
-assembly: xd, rs2
+assembly: xd, xs2
 encoding:
   match: 100011---01---01
   variables:
-    - name: rs2
+    - name: xs2
       location: 4-2
-    - name: rd
+    - name: xd
       location: 9-7
 access:
   s: always
@@ -26,9 +26,9 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg t0 = X[creg2reg(rd)];
-  XReg t1 = X[creg2reg(rs2)];
-  X[creg2reg(rd)] = t0 ^ t1;
+  XReg t0 = X[creg2reg(xd)];
+  XReg t1 = X[creg2reg(xs2)];
+  X[creg2reg(xd)] = t0 ^ t1;
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/arch/inst/F/froundnx.s.yaml
+++ b/arch/inst/F/froundnx.s.yaml
@@ -3,15 +3,15 @@
 $schema: "inst_schema.json#"
 kind: instruction
 name: froundnx.s
-long_name: No synopsis available
+long_name: Floating-point Round Single-precision to Integer with Inexact
 description: |
   No description available.
 definedBy: Zfa
-assembly: fd, rs1, rm
+assembly: fd, xs1, rm
 encoding:
   match: 010000000101-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12

--- a/arch/inst/Zfh/flh.yaml
+++ b/arch/inst/Zfh/flh.yaml
@@ -13,13 +13,13 @@ description: |
 
 definedBy:
   anyOf: [Zfh, Zfhmin, Zhinx]
-assembly: xd, imm12($rs1)
+assembly: xd, imm12(xs1)
 encoding:
   match: -----------------001-----0000111
   variables:
     - name: imm
       location: 31-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: fd
       location: 11-7
@@ -31,7 +31,7 @@ access:
 operation(): |
   check_f_ok($encoding);
 
-  XReg virtual_address = X[rs1] + $signed(imm);
+  XReg virtual_address = X[xs1] + $signed(imm);
 
   Bits<16> hp_value = read_memory<16>(virtual_address, $encoding);
 

--- a/arch/inst/Zfh/fli.h.yaml
+++ b/arch/inst/Zfh/fli.h.yaml
@@ -3,18 +3,18 @@
 $schema: inst_schema.json#
 kind: instruction
 name: fli.h
-long_name: No synopsis available
+long_name: Floating-point Load Immediate Half-precision
 description: |
   No description available.
 definedBy:
   allOf: [Zfa, Zfh]
-assembly: rd, imm
+assembly: fd, imm
 encoding:
   match: 111101000001-----000-----1010011
   variables:
-    - name: rs1
+    - name: imm
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fsh.yaml
+++ b/arch/inst/Zfh/fsh.yaml
@@ -6,23 +6,23 @@ name: fsh
 long_name: Half-precision floating-point store
 description: |
   The `fsh` instruction stores a half-precision floating-point value
-  from register _rd_ to memory at address _rs1_ + _imm_.
+  from register _xd_ to memory at address _xs1_ + _imm_.
 
   `fsh` does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
 
-  `fsh` ignores all but the lower 16 bits in _rs2_.
+  `fsh` ignores all but the lower 16 bits in _fs2_.
 
   `fsh` is only guaranteed to execute atomically if the effective address is naturally aligned.
 
 definedBy:
   anyOf: [Zfh, Zfhmin, Zhinx]
-assembly: xs2, imm12($rs1)
+assembly: fs2, imm12(xs1)
 encoding:
   match: -----------------001-----0100111
   variables:
     - name: imm
       location: 31-25|11-7
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: fs2
       location: 24-20
@@ -34,7 +34,7 @@ access:
 operation(): |
   check_f_ok($encoding);
 
-  XReg virtual_address = X[rs1] + $signed(imm);
+  XReg virtual_address = X[xs1] + $signed(imm);
 
   Bits<16> hp_value = f[fs2][15:0];
 

--- a/arch/inst/Zicfiss/ssrdp.yaml
+++ b/arch/inst/Zicfiss/ssrdp.yaml
@@ -3,15 +3,15 @@
 $schema: inst_schema.json#
 kind: instruction
 name: ssrdp
-long_name: No synopsis available
+long_name: Read ssp into a Register
 description: |
   No description available.
 definedBy: Zicfiss
-assembly: rd
+assembly: xd
 encoding:
   match: 11001101110000000100-----1110011
   variables:
-    - name: rd
+    - name: xd
       location: 11-7
       not: 0
 access:

--- a/arch/inst/Zilsd/sd.yaml
+++ b/arch/inst/Zilsd/sd.yaml
@@ -5,16 +5,16 @@ kind: instruction
 name: sd
 long_name: Store doubleword from even/odd register pair
 description: |
-  Stores a 64-bit value from registers rs2 and rs2+1. The effective address is obtained by adding
-  register rs1 to the sign-extended 12-bit offset.
+  Stores a 64-bit value from registers xs2 and xs2+1. The effective address is obtained by adding
+  register xs1 to the sign-extended 12-bit offset.
 definedBy: Zilsd
-assembly: rs2, offset(rs1)
+assembly: xs2, offset(xs1)
 encoding:
   match: -----------------011-----0100011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rs2
+    - name: xs2
       not: [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31]
       location: 24-20
     - name: imm
@@ -25,12 +25,12 @@ access:
   vs: always
   vu: always
 operation(): |
-  Bits<MXLEN> base = X[rs1];
+  Bits<MXLEN> base = X[xs1];
   Bits<MXLEN> offset = $signed(imm);
   Bits<MXLEN> eff_addr = base + offset;
 
-  Bits<32> lower_word = X[rs2];
-  Bits<32> upper_word = X[rs2 + 1];
+  Bits<32> lower_word = X[xs2];
+  Bits<32> upper_word = X[xs2 + 1];
   Bits<64> store_data = {upper_word, lower_word};
 
   write_memory<64>(eff_addr, store_data, $encoding);

--- a/backends/instructions_appendix/all_instructions.golden.adoc
+++ b/backends/instructions_appendix/all_instructions.golden.adoc
@@ -3109,20 +3109,20 @@ Add
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "rs2 != 0","type":4},{"bits":5,"name": "rd != 0","type":4},{"bits":4,"name": 0x9,"type":2}]}
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "xs2 != 0","type":4},{"bits":5,"name": "xd != 0","type":4},{"bits":4,"name": 0x9,"type":2}]}
 ....
 
 Description::
-Add the value in rs2 to rd, and store the result in rd.
-C.ADD expands into `add rd, rd, rs2`.
+Add the value in xs2 to xd, and store the result in xd.
+C.ADD expands into `add xd, xd, xs2`.
 
 
 Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[6:2]
-|rd |$encoding[11:7]
+|xs2 |$encoding[6:2]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -3301,21 +3301,21 @@ Add word
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "rs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "rd","type":4},{"bits":6,"name": 0x27,"type":2}]}
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x27,"type":2}]}
 ....
 
 Description::
-Add the 32-bit values in rs2 from rd, and store the result in rd.
-The rd and rs2 register indexes should be used as rd+8 and rs2+8 (registers x8-x15).
-C.ADDW expands into `addw rd, rd, rs2`.
+Add the 32-bit values in xs2 from xd, and store the result in xd.
+The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+C.ADDW expands into `addw xd, xd, xs2`.
 
 
 Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[4:2]
-|rd |$encoding[9:7]
+|xs2 |$encoding[4:2]
+|xd |$encoding[9:7]
 |===
 
 Included in::
@@ -3339,21 +3339,21 @@ And
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "rs2","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":3,"name": "rd","type":4},{"bits":6,"name": 0x23,"type":2}]}
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x23,"type":2}]}
 ....
 
 Description::
-And rd with rs2, and store the result in rd
-The rd and rs2 register indexes should be used as rd+8 and rs2+8 (registers x8-x15).
-C.AND expands into `and rd, rd, rs2`.
+And xd with xs2, and store the result in xd
+The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+C.AND expands into `and xd, xd, xs2`.
 
 
 Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[4:2]
-|rd |$encoding[9:7]
+|xs2 |$encoding[4:2]
+|xd |$encoding[9:7]
 |===
 
 Included in::
@@ -4486,21 +4486,21 @@ Or
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "rs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":3,"name": "rd","type":4},{"bits":6,"name": 0x23,"type":2}]}
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x23,"type":2}]}
 ....
 
 Description::
-Or rd with rs2, and store the result in rd
-The rd and rs2 register indexes should be used as rd+8 and rs2+8 (registers x8-x15).
-C.OR expands into `or rd, rd, rs2`.
+Or xd with xs2, and store the result in xd
+The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+C.OR expands into `or xd, xd, xs2`.
 
 
 Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[4:2]
-|rd |$encoding[9:7]
+|xs2 |$encoding[4:2]
+|xd |$encoding[9:7]
 |===
 
 Included in::
@@ -4931,21 +4931,21 @@ Subtract
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "rs2","type":4},{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "rd","type":4},{"bits":6,"name": 0x23,"type":2}]}
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x23,"type":2}]}
 ....
 
 Description::
-Subtract the value in rs2 from rd, and store the result in rd.
-The rd and rs2 register indexes should be used as rd+8 and rs2+8 (registers x8-x15).
-C.SUB expands into `sub rd, rd, rs2`.
+Subtract the value in xs2 from xd, and store the result in xd.
+The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+C.SUB expands into `sub xd, xd, xs2`.
 
 
 Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[4:2]
-|rd |$encoding[9:7]
+|xs2 |$encoding[4:2]
+|xd |$encoding[9:7]
 |===
 
 Included in::
@@ -4969,21 +4969,21 @@ Subtract word
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "rs2","type":4},{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "rd","type":4},{"bits":6,"name": 0x27,"type":2}]}
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x27,"type":2}]}
 ....
 
 Description::
-Subtract the 32-bit values in rs2 from rd, and store the result in rd.
-The rd and rs2 register indexes should be used as rd+8 and rs2+8 (registers x8-x15).
-C.SUBW expands into `subw rd, rd, rs2`.
+Subtract the 32-bit values in xs2 from xd, and store the result in xd.
+The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+C.SUBW expands into `subw xd, xd, xs2`.
 
 
 Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[4:2]
-|rd |$encoding[9:7]
+|xs2 |$encoding[4:2]
+|xd |$encoding[9:7]
 |===
 
 Included in::
@@ -5086,21 +5086,21 @@ Exclusive Or
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "rs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "rd","type":4},{"bits":6,"name": 0x23,"type":2}]}
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x23,"type":2}]}
 ....
 
 Description::
-Exclusive or rd with rs2, and store the result in rd
-The rd and rs2 register indexes should be used as rd+8 and rs2+8 (registers x8-x15).
-C.XOR expands into `xor rd, rd, rs2`.
+Exclusive or xd with xs2, and store the result in xd
+The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+C.XOR expands into `xor xd, xd, xs2`.
 
 
 Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[4:2]
-|rd |$encoding[9:7]
+|xs2 |$encoding[4:2]
+|xd |$encoding[9:7]
 |===
 
 Included in::
@@ -9578,7 +9578,7 @@ Half-precision floating-point load
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": "imm","type":4}]}
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
 ....
 
 Description::
@@ -9594,7 +9594,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |$encoding[31:20]
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |fd |$encoding[11:7]
 |===
 
@@ -9652,12 +9652,12 @@ Included in::
 == fli.h
 
 Synopsis::
-No synopsis available
+Floating-point Load Immediate Half-precision
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xf41,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "imm","type":4},{"bits":12,"name": 0xf41,"type":2}]}
 ....
 
 Description::
@@ -9668,8 +9668,8 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|imm |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12056,12 +12056,12 @@ Included in::
 == froundnx.s
 
 Synopsis::
-No synopsis available
+Floating-point Round Single-precision to Integer with Inexact
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0x405,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x405,"type":2}]}
 ....
 
 Description::
@@ -12072,7 +12072,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
 |fd |$encoding[11:7]
 |===
@@ -12557,16 +12557,16 @@ Half-precision floating-point store
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
 ....
 
 Description::
 The xref:insts:fsh.adoc#udb:doc:inst:fsh[fsh] instruction stores a half-precision floating-point value
-from register _rd_ to memory at address _rs1_ + _imm_.
+from register _xd_ to memory at address _xs1_ + _imm_.
 
 xref:insts:fsh.adoc#udb:doc:inst:fsh[fsh] does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
 
-xref:insts:fsh.adoc#udb:doc:inst:fsh[fsh] ignores all but the lower 16 bits in _rs2_.
+xref:insts:fsh.adoc#udb:doc:inst:fsh[fsh] ignores all but the lower 16 bits in _fs2_.
 
 xref:insts:fsh.adoc#udb:doc:inst:fsh[fsh] is only guaranteed to execute atomically if the effective address is naturally aligned.
 
@@ -12576,7 +12576,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |{$encoding[31:25], $encoding[11:7]}
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |fs2 |$encoding[24:20]
 |===
 
@@ -15936,20 +15936,20 @@ Store doubleword from even/odd register pair
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x23,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2 != {1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31}","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
+{"reg":[{"bits":7,"name": 0x23,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2 != {1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31}","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
 ....
 
 Description::
-Stores a 64-bit value from registers rs2 and rs2+1. The effective address is obtained by adding
-register rs1 to the sign-extended 12-bit offset.
+Stores a 64-bit value from registers xs2 and xs2+1. The effective address is obtained by adding
+register xs1 to the sign-extended 12-bit offset.
 
 
 Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
-|rs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xs2 |$encoding[24:20]
 |imm |{$encoding[31:25], $encoding[11:7]}
 |===
 
@@ -18245,12 +18245,12 @@ Included in::
 == ssrdp
 
 Synopsis::
-No synopsis available
+Read ssp into a Register
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "rd != 0","type":4},{"bits":20,"name": 0xcdc04,"type":2}]}
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd != 0","type":4},{"bits":20,"name": 0xcdc04,"type":2}]}
 ....
 
 Description::
@@ -18261,7 +18261,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::


### PR DESCRIPTION
- `rd` to `xd`
- `rs1` to `xs1`
- `rs2` to `xs2`

Fix a few cases where a `$` appeared before the register name.

Add a few missing "long_names".