### PR TITLE
fix(data): floating-point loads/stores several issues

### DIFF
--- a/arch/inst/D/fld.yaml
+++ b/arch/inst/D/fld.yaml
@@ -3,19 +3,19 @@
 $schema: inst_schema.json#
 kind: instruction
 name: fld
-long_name: No synopsis available
+long_name: Load Double-precision Floating-Point
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, imm
+assembly: fd, xs1, imm
 encoding:
   match: -----------------011-----0000111
   variables:
     - name: imm
       location: 31-20
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fsd.yaml
+++ b/arch/inst/D/fsd.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xs1, xs2, imm
+assembly: fs2, imm(xs1)
 encoding:
   match: -----------------011-----0100111
   variables:
     - name: imm
       location: 31-25|11-7
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
 access:
   s: always

--- a/arch/inst/F/flw.yaml
+++ b/arch/inst/F/flw.yaml
@@ -5,7 +5,7 @@ kind: instruction
 name: flw
 long_name: Single-precision floating-point load
 description: |
-  The `flw` instruction loads a single-precision floating-point value from memory at address _rs1_ + _imm_ into floating-point register _fd_.
+  The `flw` instruction loads a single-precision floating-point value from memory at address _xs1_ + _imm_ into floating-point register _fd_.
 
   `flw` does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
 
@@ -16,7 +16,7 @@ encoding:
   variables:
     - name: imm
       location: 31-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: fd
       location: 11-7
@@ -29,7 +29,7 @@ data_independent_timing: true
 operation(): |
   check_f_ok($encoding);
 
-  XReg virtual_address = X[rs1] + $signed(imm);
+  XReg virtual_address = X[xs1] + $signed(imm);
 
   Bits<32> sp_value = read_memory<32>(virtual_address, $encoding);
 

--- a/arch/inst/F/fsw.yaml
+++ b/arch/inst/F/fsw.yaml
@@ -5,7 +5,7 @@ kind: instruction
 name: fsw
 long_name: Single-precision floating-point store
 description: |
-  The `fsw` instruction stores a single-precision floating-point value in _fs2_ to memory at address _rs1_ + _imm_.
+  The `fsw` instruction stores a single-precision floating-point value in _fs2_ to memory at address _xs1_ + _imm_.
 
   `fsw` does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
 
@@ -18,7 +18,7 @@ encoding:
       location: 31-25|11-7
     - name: fs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
 access:
   s: always
@@ -29,7 +29,7 @@ data_independent_timing: true
 operation(): |
   check_f_ok($encoding);
 
-  XReg virtual_address = X[rs1] + $signed(imm);
+  XReg virtual_address = X[xs1] + $signed(imm);
 
   write_memory<32>(virtual_address, f[fs2][31:0], $encoding);
 

--- a/arch/inst/Q/flq.yaml
+++ b/arch/inst/Q/flq.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: imm
       location: 31-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: qd
       location: 11-7

--- a/arch/inst/Q/fsq.yaml
+++ b/arch/inst/Q/fsq.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: xs1, qs2, imm
+assembly: qs2, imm(xs1)
 encoding:
   match: -----------------100-----0100111
   variables:
@@ -15,7 +15,7 @@ encoding:
       location: 31-25|11-7
     - name: qs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
 access:
   s: always

--- a/arch/inst/Zfh/flh.yaml
+++ b/arch/inst/Zfh/flh.yaml
@@ -5,7 +5,7 @@ kind: instruction
 name: flh
 long_name: Half-precision floating-point load
 description: |
-  The `flh` instruction loads a single-precision floating-point value from memory at address _rs1_ + _imm_ into floating-point register _rd_.
+  The `flh` instruction loads a single-precision floating-point value from memory at address _xs1_ + _imm_ into floating-point register _rd_.
 
   `flh` does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
 
@@ -13,13 +13,13 @@ description: |
 
 definedBy:
   anyOf: [Zfh, Zfhmin, Zhinx]
-assembly: xd, imm12($rs1)
+assembly: xd, imm12(xs1)
 encoding:
   match: -----------------001-----0000111
   variables:
     - name: imm
       location: 31-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: fd
       location: 11-7
@@ -31,7 +31,7 @@ access:
 operation(): |
   check_f_ok($encoding);
 
-  XReg virtual_address = X[rs1] + $signed(imm);
+  XReg virtual_address = X[xs1] + $signed(imm);
 
   Bits<16> hp_value = read_memory<16>(virtual_address, $encoding);
 

--- a/backends/instructions_appendix/all_instructions.golden.adoc
+++ b/backends/instructions_appendix/all_instructions.golden.adoc
@@ -9247,12 +9247,12 @@ Included in::
 == fld
 
 Synopsis::
-No synopsis available
+Load Double-precision Floating-Point
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": "imm","type":4}]}
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
 ....
 
 Description::
@@ -9264,8 +9264,8 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |$encoding[31:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -9578,11 +9578,11 @@ Half-precision floating-point load
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": "imm","type":4}]}
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
 ....
 
 Description::
-The xref:insts:flh.adoc#udb:doc:inst:flh[flh] instruction loads a single-precision floating-point value from memory at address _rs1_ + _imm_ into floating-point register _rd_.
+The xref:insts:flh.adoc#udb:doc:inst:flh[flh] instruction loads a single-precision floating-point value from memory at address _xs1_ + _imm_ into floating-point register _rd_.
 
 xref:insts:flh.adoc#udb:doc:inst:flh[flh] does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
 
@@ -9594,7 +9594,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |$encoding[31:20]
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |fd |$encoding[11:7]
 |===
 
@@ -9763,7 +9763,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": "imm","type":4}]}
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
 ....
 
 Description::
@@ -9775,7 +9775,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |$encoding[31:20]
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |qd |$encoding[11:7]
 |===
 
@@ -10087,11 +10087,11 @@ Single-precision floating-point load
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": "imm","type":4}]}
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
 ....
 
 Description::
-The xref:insts:flw.adoc#udb:doc:inst:flw[flw] instruction loads a single-precision floating-point value from memory at address _rs1_ + _imm_ into floating-point register _fd_.
+The xref:insts:flw.adoc#udb:doc:inst:flw[flw] instruction loads a single-precision floating-point value from memory at address _xs1_ + _imm_ into floating-point register _fd_.
 
 xref:insts:flw.adoc#udb:doc:inst:flw[flw] does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
 
@@ -10101,7 +10101,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |$encoding[31:20]
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |fd |$encoding[11:7]
 |===
 
@@ -12096,7 +12096,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
 ....
 
 Description::
@@ -12108,8 +12108,8 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |{$encoding[31:25], $encoding[11:7]}
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
 |===
 
 Included in::
@@ -12603,7 +12603,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
 ....
 
 Description::
@@ -12616,7 +12616,7 @@ Decode Variables::
 |Variable Name |Location
 |imm |{$encoding[31:25], $encoding[11:7]}
 |qs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |===
 
 Included in::
@@ -12923,11 +12923,11 @@ Single-precision floating-point store
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
 ....
 
 Description::
-The xref:insts:fsw.adoc#udb:doc:inst:fsw[fsw] instruction stores a single-precision floating-point value in _fs2_ to memory at address _rs1_ + _imm_.
+The xref:insts:fsw.adoc#udb:doc:inst:fsw[fsw] instruction stores a single-precision floating-point value in _fs2_ to memory at address _xs1_ + _imm_.
 
 xref:insts:fsw.adoc#udb:doc:inst:fsw[fsw] does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
 
@@ -12938,7 +12938,7 @@ Decode Variables::
 |Variable Name |Location
 |imm |{$encoding[31:25], $encoding[11:7]}
 |fs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |===
 
 Included in::


### PR DESCRIPTION
- make sure the loads load to a float register
- make sure the stores store from a float register
- update the corresponding field names, description, IDL
- make sure the assembly syntax are correct
- add a few missing "long_name"
- remove an extraneous `$`