### PR TITLE
fix(data): correct assembly in a few places

### DIFF
--- a/arch/inst/C/c.nop.yaml
+++ b/arch/inst/C/c.nop.yaml
@@ -10,7 +10,7 @@ definedBy:
   anyOf:
     - C
     - Zca
-assembly: imm
+assembly: ""
 encoding:
   match: "0000000000000001"
 access:

--- a/arch/inst/Zicsr/csrrs.yaml
+++ b/arch/inst/Zicsr/csrrs.yaml
@@ -14,7 +14,7 @@ description: |
   corresponding bit to be set in the CSR, if that CSR bit is writable.
   Other bits in the CSR are not explicitly written.
 definedBy: Zicsr
-assembly: xd, imm, xs1
+assembly: xd, csr, xs1
 encoding:
   match: -----------------010-----1110011
   variables:

--- a/arch/inst/Zicsr/csrrw.yaml
+++ b/arch/inst/Zicsr/csrrw.yaml
@@ -13,7 +13,7 @@ description: |
   If `xd=x0`, then the instruction shall not read the CSR and shall not
   cause any of the side effects that might occur on a CSR read.
 definedBy: Zicsr
-assembly: xd, csr, imm
+assembly: xd, csr, xs1
 encoding:
   match: -----------------001-----1110011
   variables:

--- a/arch/inst/Zicsr/csrrw.yaml
+++ b/arch/inst/Zicsr/csrrw.yaml
@@ -13,7 +13,7 @@ description: |
   If `xd=x0`, then the instruction shall not read the CSR and shall not
   cause any of the side effects that might occur on a CSR read.
 definedBy: Zicsr
-assembly: xd, imm, xs1
+assembly: xd, csr, imm
 encoding:
   match: -----------------001-----1110011
   variables:

--- a/arch/inst/Zicsr/csrrwi.yaml
+++ b/arch/inst/Zicsr/csrrwi.yaml
@@ -13,7 +13,7 @@ description: |
   If `xd=x0`, then the instruction shall not read the CSR and shall not
   cause any of the side effects that might occur on a CSR read.
 definedBy: Zicsr
-assembly: xd, imm, xs1
+assembly: xd, csr, imm
 encoding:
   match: -----------------101-----1110011
   variables:


### PR DESCRIPTION
- `c.nop` has no operands
- For CSR instructions, `imm` should be `csr` to better match Sail
- Correct operand order and names