### PR TITLE
Add spec to FP Computational and Conversion Instructions

### DIFF
--- a/arch/inst/D/fadd.d.yaml
+++ b/arch/inst/D/fadd.d.yaml
@@ -4,12 +4,12 @@ $schema: inst_schema.json#
 kind: instruction
 name: fadd.d
 long_name: Floating-point Add Double-precision
-description: |
-  -id: inst-fadd.d-behaviour
-  -normative: false
-  -text: |
-    `fadd.d` is analogous to `fadd.s` and performs double-precision floating-point addition between
-    `xs1` and `xs2` and writes the final result to `xd`.
+description:
+  - id: inst-fadd.d-behaviour
+    normative: false
+    text: |
+      `fadd.d` is analogous to `fadd.s` and performs double-precision floating-point addition between
+      `xs1` and `xs2` and writes the final result to `xd`.
 definedBy: D
 assembly: xd, xs1, xs2, rm
 encoding:

--- a/arch/inst/D/fcvt.d.l.yaml
+++ b/arch/inst/D/fcvt.d.l.yaml
@@ -4,12 +4,12 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.d.l
 long_name: Floating-point Convert Long to Double-precision
-description: |
-  -id: inst-fcvt.d.l-behaviour
-  -normative: false
-  -text: |
-     `fcvt.d.l` converts a 64-bit signed integer, in integer register `xs1` into a double-precision
-     floating-point number in floating-point register `fd`.
+description:
+  - id: inst-fcvt.d.l-behaviour
+    normative: false
+    text: |
+      `fcvt.d.l` converts a 64-bit signed integer, in integer register `xs1` into a double-precision
+      floating-point number in floating-point register `fd`.
 definedBy: D
 assembly: xd, xs1, rm
 encoding:

--- a/arch/inst/D/fcvt.d.lu.yaml
+++ b/arch/inst/D/fcvt.d.lu.yaml
@@ -4,12 +4,12 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.d.lu
 long_name: Floating-point Convert Unsigned Long to Double-precision
-description: |
-  -id: inst-fcvt.d.lu-behaviour
-  -normative: false
-  -text: |
-     `fcvt.d.lu` converts to or from a 64-bit unsigned integer, `xs1` into a double-precision
-     floating-point number in floating-point register `fd`.
+description:
+  - id: inst-fcvt.d.lu-behaviour
+    normative: false
+    text: |
+      `fcvt.d.lu` converts to or from a 64-bit unsigned integer, `xs1` into a double-precision
+      floating-point number in floating-point register `fd`.
 definedBy: D
 assembly: xd, xs1, rm
 encoding:

--- a/arch/inst/D/fcvt.d.s.yaml
+++ b/arch/inst/D/fcvt.d.s.yaml
@@ -4,14 +4,14 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.d.s
 long_name: Floating-point Convert Single-precision to Double-precision
-description: |
-  -id: inst-fcvt.d.s-behaviour
-  -normative: false
-  -text: |
-    The single-precision to double-precision conversion instruction, `fcvt.d.s` is encoded in the OP-FP
-    major opcode space and both the source and destination are floating-point registers. The `xs2` field
-    encodes the datatype of the source, and the `fmt` field encodes the datatype of the destination.
-    `fcvt.d.s` will never round.
+description:
+  - id: inst-fcvt.d.s-behaviour
+    normative: false
+    text: |
+      The single-precision to double-precision conversion instruction, `fcvt.d.s` is encoded in the OP-FP
+      major opcode space and both the source and destination are floating-point registers. The `xs2` field
+      encodes the datatype of the source, and the `fmt` field encodes the datatype of the destination.
+      `fcvt.d.s` will never round.
 definedBy: D
 assembly: xd, xs1, rm
 encoding:

--- a/arch/inst/D/fcvt.d.w.yaml
+++ b/arch/inst/D/fcvt.d.w.yaml
@@ -4,13 +4,13 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.d.w
 long_name: Floating-point Convert Word to Double-precision
-description: |
-  -id: inst-fcvt.d.w-behaviour
-  -normative: false
-  -text: |
-    `fcvt.d.w` converts a 32-bit signed integer, in integer register `xs1` into a double-precision
-    floating-point number in floating-point register `fd`.
-    Note `fcvt.d.w` always produces an exact result and is unaffected by rounding mode.
+description:
+  - id: inst-fcvt.d.w-behaviour
+    normative: false
+    text: |
+      `fcvt.d.w` converts a 32-bit signed integer, in integer register `xs1` into a double-precision
+      floating-point number in floating-point register `fd`.
+      Note `fcvt.d.w` always produces an exact result and is unaffected by rounding mode.
 definedBy: D
 assembly: xd, xs1, rm
 encoding:

--- a/arch/inst/D/fcvt.d.wu.yaml
+++ b/arch/inst/D/fcvt.d.wu.yaml
@@ -4,13 +4,13 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.d.wu
 long_name: Floating-point Convert Unsigned Word to Double-precision
-description: |
-  -id: inst-fcvt.d.wu-behaviour
-  -normative: false
-  -text: |
-    `fcvt.d.wu` converts a 32-bit unsigned integer in integer register `fs1` into a double-precision
-    floating-point number in floating-point register `fd`.
-    Note `fcvt.d.wu` always produces an exact result and is unaffected by rounding mode.
+description:
+  - id: inst-fcvt.d.wu-behaviour
+    normative: false
+    text: |
+      `fcvt.d.wu` converts a 32-bit unsigned integer in integer register `fs1` into a double-precision
+      floating-point number in floating-point register `fd`.
+      Note `fcvt.d.wu` always produces an exact result and is unaffected by rounding mode.
 definedBy: D
 assembly: xd, xs1, rm
 encoding:

--- a/arch/inst/D/fcvt.l.d.yaml
+++ b/arch/inst/D/fcvt.l.d.yaml
@@ -4,12 +4,12 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.l.d
 long_name: Floating-point Convert Double-precision to Long
-description: |
-  -id: inst-fcvt.l.d-behaviour
-  -normative: false
-  -text: |
-    `fcvt.l.d` converts a double-precision floating-point number in floating-point register `fs1`
-    to a signed 64-bit integer, in integer register `xd`.
+description:
+  - id: inst-fcvt.l.d-behaviour
+    normative: false
+    text: |
+      `fcvt.l.d` converts a double-precision floating-point number in floating-point register `fs1`
+      to a signed 64-bit integer, in integer register `xd`.
 definedBy: D
 assembly: xd, xs1, rm
 encoding:

--- a/arch/inst/D/fcvt.lu.d.yaml
+++ b/arch/inst/D/fcvt.lu.d.yaml
@@ -4,12 +4,12 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.lu.d
 long_name: Floating-point Convert Double-precision to Unsigned Long
-description: |
-  -id: inst-fcvt.lu.d-behaviour
-  -normative: false
-  -text: |
-    `fcvt.lu.d` converts a double-precision floating-point number in floating-point register `xs1`
-    to an unsigned 64-bit integer, in integer register `xd`.
+description:
+  - id: inst-fcvt.lu.d-behaviour
+    normative: false
+    text: |
+      `fcvt.lu.d` converts a double-precision floating-point number in floating-point register `xs1`
+      to an unsigned 64-bit integer, in integer register `xd`.
 definedBy: D
 assembly: xd, xs1, rm
 encoding:

--- a/arch/inst/D/fcvt.s.d.yaml
+++ b/arch/inst/D/fcvt.s.d.yaml
@@ -4,14 +4,14 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.s.d
 long_name: Floating-point Convert Double-precision to Single-precision
-description: |
-  -id: inst-fcvt.s.d-behaviour
-  -normative: false
-  -text: |
-    `fcvt.s.d` converts a double-precision floating-point number to a single-precision floating-point number.
-     This is encoded in the OP-FP major opcode space and both the source and destination are floating-point
-     registers. The `rs2` field encodes the datatype of the source, and the `fmt` field encodes the datatype
-     of the destination. `fcvt.s.d` rounds according to the RM field
+description:
+  - id: inst-fcvt.s.d-behaviour
+    normative: false
+    text: |
+      `fcvt.s.d` converts a double-precision floating-point number to a single-precision floating-point number.
+       This is encoded in the OP-FP major opcode space and both the source and destination are floating-point
+       registers. The `rs2` field encodes the datatype of the source, and the `fmt` field encodes the datatype
+       of the destination. `fcvt.s.d` rounds according to the RM field
 definedBy: D
 assembly: xd, xs1, rm
 encoding:

--- a/arch/inst/D/fcvt.w.d.yaml
+++ b/arch/inst/D/fcvt.w.d.yaml
@@ -4,12 +4,12 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.w.d
 long_name: Floating-point Convert Double-precision to Word
-description: |
-  -id: inst-fcvt.w.d-behaviour
-  -normative: false
-  -text: |
-    `fcvt.w.d` converts a double-precision floating-point number in floating-point register `xs1` to a
-    signed 32-bit integer, in integer register `xd`.
+description:
+  - id: inst-fcvt.w.d-behaviour
+    normative: false
+    text: |
+      `fcvt.w.d` converts a double-precision floating-point number in floating-point register `xs1` to a
+      signed 32-bit integer, in integer register `xd`.
 definedBy: D
 assembly: xd, xs1, rm
 encoding:

--- a/arch/inst/D/fcvt.wu.d.yaml
+++ b/arch/inst/D/fcvt.wu.d.yaml
@@ -4,12 +4,12 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.wu.d
 long_name: Floating-point Convert Double-precision to Unsigned Word
-description: |
-  -id: inst-fcvt.wu.d-behaviour
-  -normative: false
-  -text: |
-    `fcvt.wu.d` converts a double-precision floating-point number in floating-point register `xs1` to an
-    unsigned 32-bit integer, in integer register `fd`.
+description:
+  - id: inst-fcvt.wu.d-behaviour
+    normative: false
+    text: |
+      `fcvt.wu.d` converts a double-precision floating-point number in floating-point register `xs1` to an
+      unsigned 32-bit integer, in integer register `fd`.
 definedBy: D
 assembly: xd, xs1, rm
 encoding:

--- a/arch/inst/D/fcvtmod.w.d.yaml
+++ b/arch/inst/D/fcvtmod.w.d.yaml
@@ -4,19 +4,19 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvtmod.w.d
 long_name: Floating-point Convert Double-precision to Word with Modulo
-description: |
-  -id: inst-fcvtmod.w.d-behaviour
-  -normative: false
-  -text: |
-    `fcvtmod.w.d` always rounds towards zero. Bits 31:0 are taken from the rounded, unbounded two's
-    complement result, then sign-extended to XLEN bits and written to integer register `xd`.±∞ and
-    NaN are converted to zero.
+description:
+  - id: inst-fcvtmod.w.d-behaviour
+    normative: false
+    text: |
+      `fcvtmod.w.d` always rounds towards zero. Bits 31:0 are taken from the rounded, unbounded two's
+      complement result, then sign-extended to XLEN bits and written to integer register `xd`.±∞ and
+      NaN are converted to zero.
 
-    Floating-point exception flags are raised the same as they would be for FCVT.W.D with the same input
-    operand.
+      Floating-point exception flags are raised the same as they would be for FCVT.W.D with the same input
+      operand.
 
-    This instruction is only provided if the D extension is implemented. It is encoded like FCVT.W.D, but
-    with the `xs2` field set to 8 and the `rm` field set to 1 (RTZ). Other `rm` values are reserved.
+      This instruction is only provided if the D extension is implemented. It is encoded like FCVT.W.D, but
+      with the `xs2` field set to 8 and the `rm` field set to 1 (RTZ). Other `rm` values are reserved.
 definedBy:
   allOf: [D, Zfa]
 assembly: xd, xs1

--- a/arch/inst/F/fcvt.l.s.yaml
+++ b/arch/inst/F/fcvt.l.s.yaml
@@ -4,12 +4,12 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.l.s
 long_name: Floating-point Convert Single-precision to Long
-description: |
-  -id: inst-fcvt.l.s-behaviour
-  -normative: false
-  -text: |
-    `fcvt.l.s` converts a floating-point number in floating-point register `fs1` to a signed
-    64-bit integer, in integer register `xd`.
+description:
+  - id: inst-fcvt.l.s-behaviour
+    normative: false
+    text: |
+      `fcvt.l.s` converts a floating-point number in floating-point register `fs1` to a signed
+      64-bit integer, in integer register `xd`.
 definedBy: F
 base: 64
 assembly: xd, fs1, rm

--- a/arch/inst/F/fcvt.lu.s.yaml
+++ b/arch/inst/F/fcvt.lu.s.yaml
@@ -4,12 +4,12 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.lu.s
 long_name: Floating-point Convert Single-precision to Unsigned Long
-description: |
-  -id: inst-fcvt.lu.s-behaviour
-  -normative: false
-  -text: |
-    `fcvt.l.s` converts a floating-point number in floating-point register `fs1` to a unsigned
-    64-bit integer, in integer register `xd`.
+description:
+  - id: inst-fcvt.lu.s-behaviour
+    normative: false
+    text: |
+      `fcvt.l.s` converts a floating-point number in floating-point register `fs1` to a unsigned
+      64-bit integer, in integer register `xd`.
 definedBy: F
 base: 64
 assembly: xd, fs1, rm

--- a/arch/inst/F/fcvt.s.l.yaml
+++ b/arch/inst/F/fcvt.s.l.yaml
@@ -4,12 +4,12 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.s.l
 long_name: Floating-point Convert Long to Single-precision
-description: |
-  -id: inst-fcvt.s.l-behaviour
-  -normative: false
-  -text: |
-    `fcvt.s.l` converts a 64-bit signed integer in integer register `rs1` into a floating-point
-    number in floating-point register `rd`.
+description:
+  - id: inst-fcvt.s.l-behaviour
+    normative: false
+    text: |
+      `fcvt.s.l` converts a 64-bit signed integer in integer register `rs1` into a floating-point
+      number in floating-point register `rd`.
 definedBy: F
 base: 64
 assembly: fd, xs1, rm

--- a/arch/inst/F/fcvt.s.lu.yaml
+++ b/arch/inst/F/fcvt.s.lu.yaml
@@ -4,11 +4,11 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.s.lu
 long_name: Floating-point Convert Unsigned Long to Single-precision
-description: |
-  -id: inst-fcvt.s.lu-behaviour
-  -normative: false
-  -text: |
-    `fcvt.s.lu` converts a 64-bit unsigned integer into a single-precision floating-point number.
+description:
+  - id: inst-fcvt.s.lu-behaviour
+    normative: false
+    text: |
+      `fcvt.s.lu` converts a 64-bit unsigned integer into a single-precision floating-point number.
 definedBy: F
 base: 64
 assembly: fd, xs1, rm

--- a/arch/inst/Q/fadd.q.yaml
+++ b/arch/inst/Q/fadd.q.yaml
@@ -4,12 +4,12 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fadd.q
 long_name: Floating-point Add Quad-precision
-description: |
-  -id: inst-fadd.q-behaviour
-  -normative: false
-  -text: |
-    `fadd.q` is analogous to `fadd.d` and performs double-precision floating-point addition between
-    `qs1` and `qs2` and writes the final result to `qd`.
+description:
+  - id: inst-fadd.q-behaviour
+    normative: false
+    text: |
+      `fadd.q` is analogous to `fadd.d` and performs double-precision floating-point addition between
+      `qs1` and `qs2` and writes the final result to `qd`.
 definedBy: Q
 assembly: qd, qs1, qs2, rm
 encoding:

--- a/arch/inst/Q/fcvt.d.q.yaml
+++ b/arch/inst/Q/fcvt.d.q.yaml
@@ -4,11 +4,11 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.d.q
 long_name: Floating-point Convert Quad-precision to Double-precision
-description: |
-  -id: inst-fcvt.d.q-behaviour
-  -normative: false
-  -text: |
-    `fcvt.d.q` converts a quad-precision floating-point number to a double-precision floating-point number.
+description:
+  - id: inst-fcvt.d.q-behaviour
+    normative: false
+    text: |
+      `fcvt.d.q` converts a quad-precision floating-point number to a double-precision floating-point number.
 definedBy: Q
 assembly: xd, qs1, rm
 encoding:

--- a/arch/inst/Q/fcvt.h.q.yaml
+++ b/arch/inst/Q/fcvt.h.q.yaml
@@ -4,11 +4,11 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.h.q
 long_name: Floating-point Convert Quad-precision to Half-precision
-description: |
-  -id: inst-fcvt.h.q-behaviour
-  -normative: false
-  -text: |
-    `fcvt.h.q` converts a Quad-precision Floating-point number to a Half-precision Floating-point number.
+description:
+  - id: inst-fcvt.h.q-behaviour
+    normative: false
+    text: |
+      `fcvt.h.q` converts a Quad-precision Floating-point number to a Half-precision Floating-point number.
 definedBy:
   allOf: [Q, Zfh]
 assembly: xd, qs1, rm

--- a/arch/inst/Q/fcvt.l.q.yaml
+++ b/arch/inst/Q/fcvt.l.q.yaml
@@ -4,11 +4,11 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.l.q
 long_name: Floating-point Convert Quad-precision to Long
-description: |
-  -id: inst-fcvt.l.q-behaviour
-  -normative: false
-  -text: |
-    `fcvt.l.q` converts a quad-precision floating-point number to a signed 64-bit integer.
+description:
+  - id: inst-fcvt.l.q-behaviour
+    normative: false
+    text: |
+      `fcvt.l.q` converts a quad-precision floating-point number to a signed 64-bit integer.
 definedBy: Q
 base: 64
 assembly: xd, qs1, rm

--- a/arch/inst/Q/fcvt.lu.q.yaml
+++ b/arch/inst/Q/fcvt.lu.q.yaml
@@ -4,11 +4,11 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.lu.q
 long_name: Floating-point Convert Quad-precision to Unsigned Long
-description: |
-  -id: inst-fcvt.lu.q-behaviour
-  -normative: false
-  -text: |
-    `fcvt.lu.q` converts a quad-precision floating-point number to an unsigned 64-bit integer.
+description:
+  - id: inst-fcvt.lu.q-behaviour
+    normative: false
+    text: |
+      `fcvt.lu.q` converts a quad-precision floating-point number to an unsigned 64-bit integer.
 definedBy: Q
 base: 64
 assembly: qd, hs1, rm

--- a/arch/inst/Q/fcvt.q.d.yaml
+++ b/arch/inst/Q/fcvt.q.d.yaml
@@ -4,11 +4,11 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.q.d
 long_name: Floating-point Convert Double-precision to Quad-precision
-description: |
-  -id: inst-fcvt.q.d-behaviour
-  -normative: false
-  -text: |
-    `fcvt.d.q` converts a double-precision floating-point number to a quad-precision floating-point number.
+description:
+  - id: inst-fcvt.q.d-behaviour
+    normative: false
+    text: |
+      `fcvt.d.q` converts a double-precision floating-point number to a quad-precision floating-point number.
 definedBy: Q
 assembly: dd, fs1, rm
 encoding:

--- a/arch/inst/Q/fcvt.q.h.yaml
+++ b/arch/inst/Q/fcvt.q.h.yaml
@@ -4,11 +4,11 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.q.h
 long_name: Floating-point Convert Half-precision to Quad-precision
-description: |
-  -id: inst-fcvt.q.h-behaviour
-  -normative: false
-  -text: |
-    `fcvt.q.h` converts a half-precision floating-point number to a quad-precision floating-point number.
+description:
+  - id: inst-fcvt.q.h-behaviour
+    normative: false
+    text: |
+      `fcvt.q.h` converts a half-precision floating-point number to a quad-precision floating-point number.
 definedBy:
   allOf: [Q, Zfh]
 assembly: hd, qs1, rm

--- a/arch/inst/Q/fcvt.q.l.yaml
+++ b/arch/inst/Q/fcvt.q.l.yaml
@@ -4,11 +4,11 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.q.l
 long_name: Floating-point Convert Long to Quad-precision
-description: |
-  -id: inst-fcvt.q.l-behaviour
-  -normative: false
-  -text: |
-    `fcvt.q.l` converts a 64-bit signed integer, into a quad-precision floating-point number.
+description:
+  - id: inst-fcvt.q.l-behaviour
+    normative: false
+    text: |
+      `fcvt.q.l` converts a 64-bit signed integer, into a quad-precision floating-point number.
 definedBy: Q
 base: 64
 assembly: qd, xs1, rm

--- a/arch/inst/Q/fcvt.q.lu.yaml
+++ b/arch/inst/Q/fcvt.q.lu.yaml
@@ -4,11 +4,11 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.q.lu
 long_name: Floating-point Convert Unsigned Long to Quad-precision
-description: |
-  -id: inst-fcvt.q.lu-behaviour
-  -normative: false
-  -text: |
-    `fcvt.q.lu` converts a 64-bit unsigned integer, into a quad-precision floating-point number.
+description:
+  - id: inst-fcvt.q.lu-behaviour
+    normative: false
+    text: |
+      `fcvt.q.lu` converts a 64-bit unsigned integer, into a quad-precision floating-point number.
 definedBy: Q
 base: 64
 assembly: qd, xs1, rm

--- a/arch/inst/Q/fcvt.q.s.yaml
+++ b/arch/inst/Q/fcvt.q.s.yaml
@@ -4,11 +4,11 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.q.s
 long_name: Floating-point Convert Single-precision to Quad-precision
-description: |
-  -id: inst-fcvt.q.s-behaviour
-  -normative: false
-  -text: |
-    `fcvt.q.s` converts a single-precision floating-point number to a quad-precision floating-point number.
+description:
+  - id: inst-fcvt.q.s-behaviour
+    normative: false
+    text: |
+      `fcvt.q.s` converts a single-precision floating-point number to a quad-precision floating-point number.
 definedBy: Q
 assembly: qd, fs1, rm
 encoding:

--- a/arch/inst/Q/fcvt.q.w.yaml
+++ b/arch/inst/Q/fcvt.q.w.yaml
@@ -4,11 +4,11 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.q.w
 long_name: Floating-point Convert Word to Quad-precision
-description: |
-  -id: inst-fcvt.q.w-behaviour
-  -normative: false
-  -text: |
-    `fcvt.q.w` converts a 32-bit signed integer into a quad-precision floating-point number.
+description:
+  - id: inst-fcvt.q.w-behaviour
+    normative: false
+    text: |
+      `fcvt.q.w` converts a 32-bit signed integer into a quad-precision floating-point number.
 definedBy: Q
 assembly: fd, xs1, rm
 encoding:

--- a/arch/inst/Q/fcvt.q.wu.yaml
+++ b/arch/inst/Q/fcvt.q.wu.yaml
@@ -4,11 +4,11 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.q.wu
 long_name: Floating-point Convert Unsigned Word to Quad-precision
-description: |
-  -id: inst-fcvt.q.wu-behaviour
-  -normative: false
-  -text: |
-    `fcvt.q.wu` converts a 32-bit unsigned integer into a quad-precision floating-point number.
+description:
+  - id: inst-fcvt.q.wu-behaviour
+    normative: false
+    text: |
+      `fcvt.q.wu` converts a 32-bit unsigned integer into a quad-precision floating-point number.
 definedBy: Q
 assembly: qd, xs1, rm
 encoding:

--- a/arch/inst/Q/fcvt.s.q.yaml
+++ b/arch/inst/Q/fcvt.s.q.yaml
@@ -4,11 +4,11 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.s.q
 long_name: Floating-point Convert Quad-precision to Single-precision
-description: |
-  -id: inst-fcvt.s.q-behaviour
-  -normative: false
-  -text: |
-    `fcvt.s.q` converts a quad-precision floating-point number to a single-precision floating-point number.
+description:
+  - id: inst-fcvt.s.q-behaviour
+    normative: false
+    text: |
+      `fcvt.s.q` converts a quad-precision floating-point number to a single-precision floating-point number.
 definedBy: Q
 assembly: fd, qs1, rm
 encoding:

--- a/arch/inst/Q/fcvt.w.q.yaml
+++ b/arch/inst/Q/fcvt.w.q.yaml
@@ -4,11 +4,11 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.w.q
 long_name: Floating-point Convert Quad-precision to Word
-description: |
-  -id: inst-fcvt.w.q-behaviour
-  -normative: false
-  -text: |
-    `fcvt.w.q` converts a quad-precision floating-point number to a 32-bit signed integer.
+description:
+  - id: inst-fcvt.w.q-behaviour
+    normative: false
+    text: |
+      `fcvt.w.q` converts a quad-precision floating-point number to a 32-bit signed integer.
 definedBy: Q
 assembly: xd, qs1, rm
 encoding:

--- a/arch/inst/Q/fcvt.wu.q.yaml
+++ b/arch/inst/Q/fcvt.wu.q.yaml
@@ -4,11 +4,11 @@ $schema: "inst_schema.json#"
 kind: instruction
 name: fcvt.wu.q
 long_name: Floating-point Convert Unsigned Quad-precision to Word
-description: |
-  -id: inst-fcvt.wu.q-behaviour
-  -normative: false
-  -text: |
-    `fcvt.wu.q` converts a quad-precision floating-point number to a 32-bit unsigned integer.
+description:
+  - id: inst-fcvt.wu.q-behaviour
+    normative: false
+    text: |
+      `fcvt.wu.q` converts a quad-precision floating-point number to a 32-bit unsigned integer.
 definedBy: Q
 assembly: xd, xs1, rm
 encoding:

--- a/arch/inst/Zfh/fcvt.h.d.yaml
+++ b/arch/inst/Zfh/fcvt.h.d.yaml
@@ -4,11 +4,11 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.h.d
 long_name: Floating-point Convert Double-precision to Half-precision
-description: |
-  -id: inst-fcvt.h.d-behaviour
-  -normative: false
-  -text: |
-    `fcvt.h.d` converts a Double-precision Floating-point number to a Half-precision floating-point number.
+description:
+  - id: inst-fcvt.h.d-behaviour
+    normative: false
+    text: |
+      `fcvt.h.d` converts a Double-precision Floating-point number to a Half-precision floating-point number.
 definedBy:
   allOf: [D, Zfh]
 assembly: fd, fs1, frm

--- a/arch/inst/Zfh/fcvt.h.l.yaml
+++ b/arch/inst/Zfh/fcvt.h.l.yaml
@@ -4,11 +4,11 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.h.l
 long_name: Floating-point Convert Long to Half-precision
-description: |
-  -id: inst-fcvt.h.l-behaviour
-  -normative: false
-  -text: |
-    `fcvt.h.l` converts a 64-bit signed integer to a half-precision floating-point number.
+description:
+  - id: inst-fcvt.h.l-behaviour
+    normative: false
+    text: |
+      `fcvt.h.l` converts a 64-bit signed integer to a half-precision floating-point number.
 definedBy: Zfh
 assembly: xd, xs1, frm
 encoding:

--- a/arch/inst/Zfh/fcvt.h.lu.yaml
+++ b/arch/inst/Zfh/fcvt.h.lu.yaml
@@ -4,11 +4,11 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.h.lu
 long_name: Floating-point Convert Unsigned Long to Half-precision
-description: |
-  -id: inst-fcvt.h.lu-behaviour
-  -normative: false
-  -text: |
-    `fcvt.h.lu` converts a 64-bit unsigned integer to a half-precision floating-point number.
+description:
+  - id: inst-fcvt.h.lu-behaviour
+    normative: false
+    text: |
+      `fcvt.h.lu` converts a 64-bit unsigned integer to a half-precision floating-point number.
 definedBy: Zfh
 assembly: xd, xs1, frm
 encoding:

--- a/arch/inst/Zfh/fcvt.h.w.yaml
+++ b/arch/inst/Zfh/fcvt.h.w.yaml
@@ -4,11 +4,11 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.h.w
 long_name: Floating-point Convert Word to Half-precision
-description: |
-  -id: inst-fcvt.h.w-behaviour
-  -normative: false
-  -text: |
-    `fcvt.h.w` converts a 32-bit signed integer to a half-precision floating-point number.
+description:
+  - id: inst-fcvt.h.w-behaviour
+    normative: false
+    text: |
+      `fcvt.h.w` converts a 32-bit signed integer to a half-precision floating-point number.
 definedBy: Zfh
 assembly: xd, xs1, frm
 encoding:

--- a/arch/inst/Zfh/fcvt.h.wu.yaml
+++ b/arch/inst/Zfh/fcvt.h.wu.yaml
@@ -4,11 +4,11 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.h.wu
 long_name: Floating-point Convert Unsigned Word to Half-precision
-description: |
-  -id: inst-fcvt.h.wu-behaviour
-  -normative: false
-  -text: |
-    `fcvt.h.wu` converts a 32-bit unsigned integer to a half-precision floating-point number.
+description:
+  - id: inst-fcvt.h.wu-behaviour
+    normative: false
+    text: |
+      `fcvt.h.wu` converts a 32-bit unsigned integer to a half-precision floating-point number.
 definedBy: Zfh
 assembly: xd, xs1, frm
 encoding:

--- a/arch/inst/Zfh/fcvt.l.h.yaml
+++ b/arch/inst/Zfh/fcvt.l.h.yaml
@@ -4,11 +4,11 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.l.h
 long_name: Floating-point Convert Half-precision to Long
-description: |
-  -id: inst-fcvt.l.h-behaviour
-  -normative: false
-  -text: |
-    `fcvt.l.h` converts a half-precision floating-point number to a signed 64-bit integer.
+description:
+  - id: inst-fcvt.l.h-behaviour
+    normative: false
+    text: |
+      `fcvt.l.h` converts a half-precision floating-point number to a signed 64-bit integer.
 definedBy: Zfh
 assembly: fd, fs1, frm
 encoding:

--- a/arch/inst/Zfh/fcvt.lu.h.yaml
+++ b/arch/inst/Zfh/fcvt.lu.h.yaml
@@ -4,11 +4,11 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.lu.h
 long_name: Floating-point Convert Half-precision to Unsigned Long
-description: |
-  -id: inst-fcvt.lu.h-behaviour
-  -normative: false
-  -text: |
-    `fcvt.lu.h` converts a half-precision floating-point number to an unsigned 64-bit integer.
+description:
+  - id: inst-fcvt.lu.h-behaviour
+    normative: false
+    text: |
+      `fcvt.lu.h` converts a half-precision floating-point number to an unsigned 64-bit integer.
 definedBy: Zfh
 assembly: fd, fs1, frm
 encoding:

--- a/arch/inst/Zfh/fcvt.w.h.yaml
+++ b/arch/inst/Zfh/fcvt.w.h.yaml
@@ -4,11 +4,11 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.w.h
 long_name: Floating-point Convert Half-precision to Word
-description: |
-  -id: inst-fcvt.w.h-behaviour
-  -normative: false
-  -text: |
-    `fcvt.w.h` converts a half-precision floating-point number to a signed 32-bit integer.
+description:
+  - id: inst-fcvt.w.h-behaviour
+    normative: false
+    text: |
+      `fcvt.w.h` converts a half-precision floating-point number to a signed 32-bit integer.
 definedBy: Zfh
 assembly: fd, fs1, frm
 encoding:

--- a/arch/inst/Zfh/fcvt.wu.h.yaml
+++ b/arch/inst/Zfh/fcvt.wu.h.yaml
@@ -4,11 +4,11 @@ $schema: inst_schema.json#
 kind: instruction
 name: fcvt.wu.h
 long_name: Floating-point Convert Half-precision to Word
-description: |
-  -id: inst-fcvt.wu.h-behaviour
-  -normative: false
-  -text: |
-    `fcvt.wu.h` converts a half-precision floating-point number to an unsigned 32-bit integer.
+description:
+  - id: inst-fcvt.wu.h-behaviour
+    normative: false
+    text: |
+      `fcvt.wu.h` converts a half-precision floating-point number to an unsigned 32-bit integer.
 definedBy: Zfh
 assembly: fd, fs1, frm
 encoding:

--- a/backends/instructions_appendix/all_instructions.golden.adoc
+++ b/backends/instructions_appendix/all_instructions.golden.adoc
@@ -6695,11 +6695,8 @@ Encoding::
 ....
 
 Description::
--id: inst-fadd.d-behaviour
--normative: false
--text: |
-  xref:insts:fadd_d.adoc#udb:doc:inst:fadd_d[fadd.d] is analogous to xref:insts:fadd_s.adoc#udb:doc:inst:fadd_s[fadd.s] and performs double-precision floating-point addition between
-  `xs1` and `xs2` and writes the final result to `xd`.
+xref:insts:fadd_d.adoc#udb:doc:inst:fadd_d[fadd.d] is analogous to xref:insts:fadd_s.adoc#udb:doc:inst:fadd_s[fadd.s] and performs double-precision floating-point addition between
+`xs1` and `xs2` and writes the final result to `xd`.
 
 
 Decode Variables::
@@ -6771,11 +6768,8 @@ Encoding::
 ....
 
 Description::
--id: inst-fadd.q-behaviour
--normative: false
--text: |
-  xref:insts:fadd_q.adoc#udb:doc:inst:fadd_q[fadd.q] is analogous to xref:insts:fadd_d.adoc#udb:doc:inst:fadd_d[fadd.d] and performs double-precision floating-point addition between
-  `qs1` and `qs2` and writes the final result to `qd`.
+xref:insts:fadd_q.adoc#udb:doc:inst:fadd_q[fadd.q] is analogous to xref:insts:fadd_d.adoc#udb:doc:inst:fadd_d[fadd.d] and performs double-precision floating-point addition between
+`qs1` and `qs2` and writes the final result to `qd`.
 
 
 Decode Variables::
@@ -7080,11 +7074,8 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.d.l-behaviour
--normative: false
--text: |
-   xref:insts:fcvt_d_l.adoc#udb:doc:inst:fcvt_d_l[fcvt.d.l] converts a 64-bit signed integer, in integer register `xs1` into a double-precision
-   floating-point number in floating-point register `fd`.
+xref:insts:fcvt_d_l.adoc#udb:doc:inst:fcvt_d_l[fcvt.d.l] converts a 64-bit signed integer, in integer register `xs1` into a double-precision
+floating-point number in floating-point register `fd`.
 
 
 Decode Variables::
@@ -7119,11 +7110,8 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.d.lu-behaviour
--normative: false
--text: |
-   xref:insts:fcvt_d_lu.adoc#udb:doc:inst:fcvt_d_lu[fcvt.d.lu] converts to or from a 64-bit unsigned integer, `xs1` into a double-precision
-   floating-point number in floating-point register `fd`.
+xref:insts:fcvt_d_lu.adoc#udb:doc:inst:fcvt_d_lu[fcvt.d.lu] converts to or from a 64-bit unsigned integer, `xs1` into a double-precision
+floating-point number in floating-point register `fd`.
 
 
 Decode Variables::
@@ -7158,10 +7146,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.d.q-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_d_q.adoc#udb:doc:inst:fcvt_d_q[fcvt.d.q] converts a quad-precision floating-point number to a double-precision floating-point number.
+xref:insts:fcvt_d_q.adoc#udb:doc:inst:fcvt_d_q[fcvt.d.q] converts a quad-precision floating-point number to a double-precision floating-point number.
 
 
 Decode Variables::
@@ -7196,13 +7181,10 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.d.s-behaviour
--normative: false
--text: |
-  The single-precision to double-precision conversion instruction, xref:insts:fcvt_d_s.adoc#udb:doc:inst:fcvt_d_s[fcvt.d.s] is encoded in the OP-FP
-  major opcode space and both the source and destination are floating-point registers. The `xs2` field
-  encodes the datatype of the source, and the `fmt` field encodes the datatype of the destination.
-  xref:insts:fcvt_d_s.adoc#udb:doc:inst:fcvt_d_s[fcvt.d.s] will never round.
+The single-precision to double-precision conversion instruction, xref:insts:fcvt_d_s.adoc#udb:doc:inst:fcvt_d_s[fcvt.d.s] is encoded in the OP-FP
+major opcode space and both the source and destination are floating-point registers. The `xs2` field
+encodes the datatype of the source, and the `fmt` field encodes the datatype of the destination.
+xref:insts:fcvt_d_s.adoc#udb:doc:inst:fcvt_d_s[fcvt.d.s] will never round.
 
 
 Decode Variables::
@@ -7237,12 +7219,9 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.d.w-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_d_w.adoc#udb:doc:inst:fcvt_d_w[fcvt.d.w] converts a 32-bit signed integer, in integer register `xs1` into a double-precision
-  floating-point number in floating-point register `fd`.
-  Note xref:insts:fcvt_d_w.adoc#udb:doc:inst:fcvt_d_w[fcvt.d.w] always produces an exact result and is unaffected by rounding mode.
+xref:insts:fcvt_d_w.adoc#udb:doc:inst:fcvt_d_w[fcvt.d.w] converts a 32-bit signed integer, in integer register `xs1` into a double-precision
+floating-point number in floating-point register `fd`.
+Note xref:insts:fcvt_d_w.adoc#udb:doc:inst:fcvt_d_w[fcvt.d.w] always produces an exact result and is unaffected by rounding mode.
 
 
 Decode Variables::
@@ -7277,12 +7256,9 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.d.wu-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_d_wu.adoc#udb:doc:inst:fcvt_d_wu[fcvt.d.wu] converts a 32-bit unsigned integer in integer register `fs1` into a double-precision
-  floating-point number in floating-point register `fd`.
-  Note xref:insts:fcvt_d_wu.adoc#udb:doc:inst:fcvt_d_wu[fcvt.d.wu] always produces an exact result and is unaffected by rounding mode.
+xref:insts:fcvt_d_wu.adoc#udb:doc:inst:fcvt_d_wu[fcvt.d.wu] converts a 32-bit unsigned integer in integer register `fs1` into a double-precision
+floating-point number in floating-point register `fd`.
+Note xref:insts:fcvt_d_wu.adoc#udb:doc:inst:fcvt_d_wu[fcvt.d.wu] always produces an exact result and is unaffected by rounding mode.
 
 
 Decode Variables::
@@ -7317,10 +7293,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.h.d-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_h_d.adoc#udb:doc:inst:fcvt_h_d[fcvt.h.d] converts a Double-precision Floating-point number to a Half-precision floating-point number.
+xref:insts:fcvt_h_d.adoc#udb:doc:inst:fcvt_h_d[fcvt.h.d] converts a Double-precision Floating-point number to a Half-precision floating-point number.
 
 
 Decode Variables::
@@ -7357,10 +7330,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.h.l-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_h_l.adoc#udb:doc:inst:fcvt_h_l[fcvt.h.l] converts a 64-bit signed integer to a half-precision floating-point number.
+xref:insts:fcvt_h_l.adoc#udb:doc:inst:fcvt_h_l[fcvt.h.l] converts a 64-bit signed integer to a half-precision floating-point number.
 
 
 Decode Variables::
@@ -7395,10 +7365,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.h.lu-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_h_lu.adoc#udb:doc:inst:fcvt_h_lu[fcvt.h.lu] converts a 64-bit unsigned integer to a half-precision floating-point number.
+xref:insts:fcvt_h_lu.adoc#udb:doc:inst:fcvt_h_lu[fcvt.h.lu] converts a 64-bit unsigned integer to a half-precision floating-point number.
 
 
 Decode Variables::
@@ -7433,10 +7400,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.h.q-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_h_q.adoc#udb:doc:inst:fcvt_h_q[fcvt.h.q] converts a Quad-precision Floating-point number to a Half-precision Floating-point number.
+xref:insts:fcvt_h_q.adoc#udb:doc:inst:fcvt_h_q[fcvt.h.q] converts a Quad-precision Floating-point number to a Half-precision Floating-point number.
 
 
 Decode Variables::
@@ -7516,10 +7480,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.h.w-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_h_w.adoc#udb:doc:inst:fcvt_h_w[fcvt.h.w] converts a 32-bit signed integer to a half-precision floating-point number.
+xref:insts:fcvt_h_w.adoc#udb:doc:inst:fcvt_h_w[fcvt.h.w] converts a 32-bit signed integer to a half-precision floating-point number.
 
 
 Decode Variables::
@@ -7554,10 +7515,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.h.wu-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_h_wu.adoc#udb:doc:inst:fcvt_h_wu[fcvt.h.wu] converts a 32-bit unsigned integer to a half-precision floating-point number.
+xref:insts:fcvt_h_wu.adoc#udb:doc:inst:fcvt_h_wu[fcvt.h.wu] converts a 32-bit unsigned integer to a half-precision floating-point number.
 
 
 Decode Variables::
@@ -7592,11 +7550,8 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.l.d-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_l_d.adoc#udb:doc:inst:fcvt_l_d[fcvt.l.d] converts a double-precision floating-point number in floating-point register `fs1`
-  to a signed 64-bit integer, in integer register `xd`.
+xref:insts:fcvt_l_d.adoc#udb:doc:inst:fcvt_l_d[fcvt.l.d] converts a double-precision floating-point number in floating-point register `fs1`
+to a signed 64-bit integer, in integer register `xd`.
 
 
 Decode Variables::
@@ -7631,10 +7586,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.l.h-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_l_h.adoc#udb:doc:inst:fcvt_l_h[fcvt.l.h] converts a half-precision floating-point number to a signed 64-bit integer.
+xref:insts:fcvt_l_h.adoc#udb:doc:inst:fcvt_l_h[fcvt.l.h] converts a half-precision floating-point number to a signed 64-bit integer.
 
 
 Decode Variables::
@@ -7669,10 +7621,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.l.q-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_l_q.adoc#udb:doc:inst:fcvt_l_q[fcvt.l.q] converts a quad-precision floating-point number to a signed 64-bit integer.
+xref:insts:fcvt_l_q.adoc#udb:doc:inst:fcvt_l_q[fcvt.l.q] converts a quad-precision floating-point number to a signed 64-bit integer.
 
 
 Decode Variables::
@@ -7707,11 +7656,8 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.l.s-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_l_s.adoc#udb:doc:inst:fcvt_l_s[fcvt.l.s] converts a floating-point number in floating-point register `fs1` to a signed
-  64-bit integer, in integer register `xd`.
+xref:insts:fcvt_l_s.adoc#udb:doc:inst:fcvt_l_s[fcvt.l.s] converts a floating-point number in floating-point register `fs1` to a signed
+64-bit integer, in integer register `xd`.
 
 
 Decode Variables::
@@ -7746,11 +7692,8 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.lu.d-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_lu_d.adoc#udb:doc:inst:fcvt_lu_d[fcvt.lu.d] converts a double-precision floating-point number in floating-point register `xs1`
-  to an unsigned 64-bit integer, in integer register `xd`.
+xref:insts:fcvt_lu_d.adoc#udb:doc:inst:fcvt_lu_d[fcvt.lu.d] converts a double-precision floating-point number in floating-point register `xs1`
+to an unsigned 64-bit integer, in integer register `xd`.
 
 
 Decode Variables::
@@ -7785,10 +7728,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.lu.h-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_lu_h.adoc#udb:doc:inst:fcvt_lu_h[fcvt.lu.h] converts a half-precision floating-point number to an unsigned 64-bit integer.
+xref:insts:fcvt_lu_h.adoc#udb:doc:inst:fcvt_lu_h[fcvt.lu.h] converts a half-precision floating-point number to an unsigned 64-bit integer.
 
 
 Decode Variables::
@@ -7823,10 +7763,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.lu.q-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_lu_q.adoc#udb:doc:inst:fcvt_lu_q[fcvt.lu.q] converts a quad-precision floating-point number to an unsigned 64-bit integer.
+xref:insts:fcvt_lu_q.adoc#udb:doc:inst:fcvt_lu_q[fcvt.lu.q] converts a quad-precision floating-point number to an unsigned 64-bit integer.
 
 
 Decode Variables::
@@ -7861,11 +7798,8 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.lu.s-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_l_s.adoc#udb:doc:inst:fcvt_l_s[fcvt.l.s] converts a floating-point number in floating-point register `fs1` to a unsigned
-  64-bit integer, in integer register `xd`.
+xref:insts:fcvt_l_s.adoc#udb:doc:inst:fcvt_l_s[fcvt.l.s] converts a floating-point number in floating-point register `fs1` to a unsigned
+64-bit integer, in integer register `xd`.
 
 
 Decode Variables::
@@ -7900,10 +7834,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.q.d-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_d_q.adoc#udb:doc:inst:fcvt_d_q[fcvt.d.q] converts a double-precision floating-point number to a quad-precision floating-point number.
+xref:insts:fcvt_d_q.adoc#udb:doc:inst:fcvt_d_q[fcvt.d.q] converts a double-precision floating-point number to a quad-precision floating-point number.
 
 
 Decode Variables::
@@ -7938,10 +7869,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.q.h-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_q_h.adoc#udb:doc:inst:fcvt_q_h[fcvt.q.h] converts a half-precision floating-point number to a quad-precision floating-point number.
+xref:insts:fcvt_q_h.adoc#udb:doc:inst:fcvt_q_h[fcvt.q.h] converts a half-precision floating-point number to a quad-precision floating-point number.
 
 
 Decode Variables::
@@ -7978,10 +7906,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.q.l-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_q_l.adoc#udb:doc:inst:fcvt_q_l[fcvt.q.l] converts a 64-bit signed integer, into a quad-precision floating-point number.
+xref:insts:fcvt_q_l.adoc#udb:doc:inst:fcvt_q_l[fcvt.q.l] converts a 64-bit signed integer, into a quad-precision floating-point number.
 
 
 Decode Variables::
@@ -8016,10 +7941,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.q.lu-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_q_lu.adoc#udb:doc:inst:fcvt_q_lu[fcvt.q.lu] converts a 64-bit unsigned integer, into a quad-precision floating-point number.
+xref:insts:fcvt_q_lu.adoc#udb:doc:inst:fcvt_q_lu[fcvt.q.lu] converts a 64-bit unsigned integer, into a quad-precision floating-point number.
 
 
 Decode Variables::
@@ -8054,10 +7976,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.q.s-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_q_s.adoc#udb:doc:inst:fcvt_q_s[fcvt.q.s] converts a single-precision floating-point number to a quad-precision floating-point number.
+xref:insts:fcvt_q_s.adoc#udb:doc:inst:fcvt_q_s[fcvt.q.s] converts a single-precision floating-point number to a quad-precision floating-point number.
 
 
 Decode Variables::
@@ -8092,10 +8011,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.q.w-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_q_w.adoc#udb:doc:inst:fcvt_q_w[fcvt.q.w] converts a 32-bit signed integer into a quad-precision floating-point number.
+xref:insts:fcvt_q_w.adoc#udb:doc:inst:fcvt_q_w[fcvt.q.w] converts a 32-bit signed integer into a quad-precision floating-point number.
 
 
 Decode Variables::
@@ -8130,10 +8046,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.q.wu-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_q_wu.adoc#udb:doc:inst:fcvt_q_wu[fcvt.q.wu] converts a 32-bit unsigned integer into a quad-precision floating-point number.
+xref:insts:fcvt_q_wu.adoc#udb:doc:inst:fcvt_q_wu[fcvt.q.wu] converts a 32-bit unsigned integer into a quad-precision floating-point number.
 
 
 Decode Variables::
@@ -8203,13 +8116,10 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.s.d-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_s_d.adoc#udb:doc:inst:fcvt_s_d[fcvt.s.d] converts a double-precision floating-point number to a single-precision floating-point number.
-   This is encoded in the OP-FP major opcode space and both the source and destination are floating-point
-   registers. The `rs2` field encodes the datatype of the source, and the `fmt` field encodes the datatype
-   of the destination. xref:insts:fcvt_s_d.adoc#udb:doc:inst:fcvt_s_d[fcvt.s.d] rounds according to the RM field
+xref:insts:fcvt_s_d.adoc#udb:doc:inst:fcvt_s_d[fcvt.s.d] converts a double-precision floating-point number to a single-precision floating-point number.
+ This is encoded in the OP-FP major opcode space and both the source and destination are floating-point
+ registers. The `rs2` field encodes the datatype of the source, and the `fmt` field encodes the datatype
+ of the destination. xref:insts:fcvt_s_d.adoc#udb:doc:inst:fcvt_s_d[fcvt.s.d] rounds according to the RM field
 
 
 Decode Variables::
@@ -8284,11 +8194,8 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.s.l-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_s_l.adoc#udb:doc:inst:fcvt_s_l[fcvt.s.l] converts a 64-bit signed integer in integer register `rs1` into a floating-point
-  number in floating-point register `rd`.
+xref:insts:fcvt_s_l.adoc#udb:doc:inst:fcvt_s_l[fcvt.s.l] converts a 64-bit signed integer in integer register `rs1` into a floating-point
+number in floating-point register `rd`.
 
 
 Decode Variables::
@@ -8323,10 +8230,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.s.lu-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_s_lu.adoc#udb:doc:inst:fcvt_s_lu[fcvt.s.lu] converts a 64-bit unsigned integer into a single-precision floating-point number.
+xref:insts:fcvt_s_lu.adoc#udb:doc:inst:fcvt_s_lu[fcvt.s.lu] converts a 64-bit unsigned integer into a single-precision floating-point number.
 
 
 Decode Variables::
@@ -8361,10 +8265,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.s.q-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_s_q.adoc#udb:doc:inst:fcvt_s_q[fcvt.s.q] converts a quad-precision floating-point number to a single-precision floating-point number.
+xref:insts:fcvt_s_q.adoc#udb:doc:inst:fcvt_s_q[fcvt.s.q] converts a quad-precision floating-point number to a single-precision floating-point number.
 
 
 Decode Variables::
@@ -8487,11 +8388,8 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.w.d-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_w_d.adoc#udb:doc:inst:fcvt_w_d[fcvt.w.d] converts a double-precision floating-point number in floating-point register `xs1` to a
-  signed 32-bit integer, in integer register `xd`.
+xref:insts:fcvt_w_d.adoc#udb:doc:inst:fcvt_w_d[fcvt.w.d] converts a double-precision floating-point number in floating-point register `xs1` to a
+signed 32-bit integer, in integer register `xd`.
 
 
 Decode Variables::
@@ -8526,10 +8424,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.w.h-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_w_h.adoc#udb:doc:inst:fcvt_w_h[fcvt.w.h] converts a half-precision floating-point number to a signed 32-bit integer.
+xref:insts:fcvt_w_h.adoc#udb:doc:inst:fcvt_w_h[fcvt.w.h] converts a half-precision floating-point number to a signed 32-bit integer.
 
 
 Decode Variables::
@@ -8564,10 +8459,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.w.q-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_w_q.adoc#udb:doc:inst:fcvt_w_q[fcvt.w.q] converts a quad-precision floating-point number to a 32-bit signed integer.
+xref:insts:fcvt_w_q.adoc#udb:doc:inst:fcvt_w_q[fcvt.w.q] converts a quad-precision floating-point number to a 32-bit signed integer.
 
 
 Decode Variables::
@@ -8665,11 +8557,8 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.wu.d-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_wu_d.adoc#udb:doc:inst:fcvt_wu_d[fcvt.wu.d] converts a double-precision floating-point number in floating-point register `xs1` to an
-  unsigned 32-bit integer, in integer register `fd`.
+xref:insts:fcvt_wu_d.adoc#udb:doc:inst:fcvt_wu_d[fcvt.wu.d] converts a double-precision floating-point number in floating-point register `xs1` to an
+unsigned 32-bit integer, in integer register `fd`.
 
 
 Decode Variables::
@@ -8704,10 +8593,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.wu.h-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_wu_h.adoc#udb:doc:inst:fcvt_wu_h[fcvt.wu.h] converts a half-precision floating-point number to an unsigned 32-bit integer.
+xref:insts:fcvt_wu_h.adoc#udb:doc:inst:fcvt_wu_h[fcvt.wu.h] converts a half-precision floating-point number to an unsigned 32-bit integer.
 
 
 Decode Variables::
@@ -8742,10 +8628,7 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvt.wu.q-behaviour
--normative: false
--text: |
-  xref:insts:fcvt_wu_q.adoc#udb:doc:inst:fcvt_wu_q[fcvt.wu.q] converts a quad-precision floating-point number to a 32-bit unsigned integer.
+xref:insts:fcvt_wu_q.adoc#udb:doc:inst:fcvt_wu_q[fcvt.wu.q] converts a quad-precision floating-point number to a 32-bit unsigned integer.
 
 
 Decode Variables::
@@ -8842,18 +8725,15 @@ Encoding::
 ....
 
 Description::
--id: inst-fcvtmod.w.d-behaviour
--normative: false
--text: |
-  xref:insts:fcvtmod_w_d.adoc#udb:doc:inst:fcvtmod_w_d[fcvtmod.w.d] always rounds towards zero. Bits 31:0 are taken from the rounded, unbounded two's
-  complement result, then sign-extended to XLEN bits and written to integer register `xd`.±∞ and
-  NaN are converted to zero.
+xref:insts:fcvtmod_w_d.adoc#udb:doc:inst:fcvtmod_w_d[fcvtmod.w.d] always rounds towards zero. Bits 31:0 are taken from the rounded, unbounded two's
+complement result, then sign-extended to XLEN bits and written to integer register `xd`.±∞ and
+NaN are converted to zero.
 
-  Floating-point exception flags are raised the same as they would be for FCVT.W.D with the same input
-  operand.
+Floating-point exception flags are raised the same as they would be for FCVT.W.D with the same input
+operand.
 
-  This instruction is only provided if the D extension is implemented. It is encoded like FCVT.W.D, but
-  with the `xs2` field set to 8 and the `rm` field set to 1 (RTZ). Other `rm` values are reserved.
+This instruction is only provided if the D extension is implemented. It is encoded like FCVT.W.D, but
+with the `xs2` field set to 8 and the `rm` field set to 1 (RTZ). Other `rm` values are reserved.
 
 
 Decode Variables::


### PR DESCRIPTION
This PR adds missing long_name and description to some FP Computational and remaining FP Conversion Instructions.