### PR TITLE
fix(encodings): fix V extension encodings mismatch with assembly

### DIFF
--- a/arch/inst/V/vaadd.vx.yaml
+++ b/arch/inst/V/vaadd.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vaaddu.vx.yaml
+++ b/arch/inst/V/vaaddu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vadc.vim.yaml
+++ b/arch/inst/V/vadc.vim.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vadc.vxm.yaml
+++ b/arch/inst/V/vadc.vxm.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vadd.vi.yaml
+++ b/arch/inst/V/vadd.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vadd.vx.yaml
+++ b/arch/inst/V/vadd.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vand.vi.yaml
+++ b/arch/inst/V/vand.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vand.vx.yaml
+++ b/arch/inst/V/vand.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vasub.vx.yaml
+++ b/arch/inst/V/vasub.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vasubu.vx.yaml
+++ b/arch/inst/V/vasubu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vcpop.m.yaml
+++ b/arch/inst/V/vcpop.m.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rd
+    - name: vd
       location: 11-7
 access:
   s: always

--- a/arch/inst/V/vdiv.vx.yaml
+++ b/arch/inst/V/vdiv.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vdivu.vx.yaml
+++ b/arch/inst/V/vdivu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfadd.vf.yaml
+++ b/arch/inst/V/vfadd.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfdiv.vf.yaml
+++ b/arch/inst/V/vfdiv.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfirst.m.yaml
+++ b/arch/inst/V/vfirst.m.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rd
+    - name: vd
       location: 11-7
 access:
   s: always

--- a/arch/inst/V/vfmacc.vf.yaml
+++ b/arch/inst/V/vfmacc.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfmadd.vf.yaml
+++ b/arch/inst/V/vfmadd.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfmax.vf.yaml
+++ b/arch/inst/V/vfmax.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfmerge.vfm.yaml
+++ b/arch/inst/V/vfmerge.vfm.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfmin.vf.yaml
+++ b/arch/inst/V/vfmin.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfmsac.vf.yaml
+++ b/arch/inst/V/vfmsac.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfmsub.vf.yaml
+++ b/arch/inst/V/vfmsub.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfmul.vf.yaml
+++ b/arch/inst/V/vfmul.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfmv.f.s.yaml
+++ b/arch/inst/V/vfmv.f.s.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/V/vfmv.s.f.yaml
+++ b/arch/inst/V/vfmv.s.f.yaml
@@ -11,7 +11,7 @@ assembly: vd, fs1
 encoding:
   match: 010000100000-----101-----1010111
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfmv.v.f.yaml
+++ b/arch/inst/V/vfmv.v.f.yaml
@@ -11,7 +11,7 @@ assembly: vd, fs1
 encoding:
   match: 010111100000-----101-----1010111
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfnmacc.vf.yaml
+++ b/arch/inst/V/vfnmacc.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfnmadd.vf.yaml
+++ b/arch/inst/V/vfnmadd.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfnmsac.vf.yaml
+++ b/arch/inst/V/vfnmsac.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfnmsub.vf.yaml
+++ b/arch/inst/V/vfnmsub.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfrdiv.vf.yaml
+++ b/arch/inst/V/vfrdiv.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfrsub.vf.yaml
+++ b/arch/inst/V/vfrsub.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfsgnj.vf.yaml
+++ b/arch/inst/V/vfsgnj.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfsgnjn.vf.yaml
+++ b/arch/inst/V/vfsgnjn.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfsgnjx.vf.yaml
+++ b/arch/inst/V/vfsgnjx.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfslide1down.vf.yaml
+++ b/arch/inst/V/vfslide1down.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfslide1up.vf.yaml
+++ b/arch/inst/V/vfslide1up.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfsub.vf.yaml
+++ b/arch/inst/V/vfsub.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfwadd.vf.yaml
+++ b/arch/inst/V/vfwadd.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfwadd.wf.yaml
+++ b/arch/inst/V/vfwadd.wf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfwmacc.vf.yaml
+++ b/arch/inst/V/vfwmacc.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfwmsac.vf.yaml
+++ b/arch/inst/V/vfwmsac.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfwmul.vf.yaml
+++ b/arch/inst/V/vfwmul.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfwnmacc.vf.yaml
+++ b/arch/inst/V/vfwnmacc.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfwnmsac.vf.yaml
+++ b/arch/inst/V/vfwnmsac.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfwsub.vf.yaml
+++ b/arch/inst/V/vfwsub.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vfwsub.wf.yaml
+++ b/arch/inst/V/vfwsub.wf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl1re16.v.yaml
+++ b/arch/inst/V/vl1re16.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 000000101000-----101-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl1re32.v.yaml
+++ b/arch/inst/V/vl1re32.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 000000101000-----110-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl1re64.v.yaml
+++ b/arch/inst/V/vl1re64.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 000000101000-----111-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl1re8.v.yaml
+++ b/arch/inst/V/vl1re8.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 000000101000-----000-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl2re16.v.yaml
+++ b/arch/inst/V/vl2re16.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 001000101000-----101-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl2re32.v.yaml
+++ b/arch/inst/V/vl2re32.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 001000101000-----110-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl2re64.v.yaml
+++ b/arch/inst/V/vl2re64.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 001000101000-----111-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl2re8.v.yaml
+++ b/arch/inst/V/vl2re8.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 001000101000-----000-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl4re16.v.yaml
+++ b/arch/inst/V/vl4re16.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 011000101000-----101-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl4re32.v.yaml
+++ b/arch/inst/V/vl4re32.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 011000101000-----110-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl4re64.v.yaml
+++ b/arch/inst/V/vl4re64.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 011000101000-----111-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl4re8.v.yaml
+++ b/arch/inst/V/vl4re8.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 011000101000-----000-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl8re16.v.yaml
+++ b/arch/inst/V/vl8re16.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 111000101000-----101-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl8re32.v.yaml
+++ b/arch/inst/V/vl8re32.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 111000101000-----110-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl8re64.v.yaml
+++ b/arch/inst/V/vl8re64.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 111000101000-----111-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vl8re8.v.yaml
+++ b/arch/inst/V/vl8re8.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 111000101000-----000-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vle16.v.yaml
+++ b/arch/inst/V/vle16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vle16ff.v.yaml
+++ b/arch/inst/V/vle16ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vle32.v.yaml
+++ b/arch/inst/V/vle32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vle32ff.v.yaml
+++ b/arch/inst/V/vle32ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vle64.v.yaml
+++ b/arch/inst/V/vle64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vle64ff.v.yaml
+++ b/arch/inst/V/vle64ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vle8.v.yaml
+++ b/arch/inst/V/vle8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vle8ff.v.yaml
+++ b/arch/inst/V/vle8ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlm.v.yaml
+++ b/arch/inst/V/vlm.v.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 000000101011-----000-----0000111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxei16.v.yaml
+++ b/arch/inst/V/vloxei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxei32.v.yaml
+++ b/arch/inst/V/vloxei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxei64.v.yaml
+++ b/arch/inst/V/vloxei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxei8.v.yaml
+++ b/arch/inst/V/vloxei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg2ei16.v.yaml
+++ b/arch/inst/V/vloxseg2ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg2ei32.v.yaml
+++ b/arch/inst/V/vloxseg2ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg2ei64.v.yaml
+++ b/arch/inst/V/vloxseg2ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg2ei8.v.yaml
+++ b/arch/inst/V/vloxseg2ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg3ei16.v.yaml
+++ b/arch/inst/V/vloxseg3ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg3ei32.v.yaml
+++ b/arch/inst/V/vloxseg3ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg3ei64.v.yaml
+++ b/arch/inst/V/vloxseg3ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg3ei8.v.yaml
+++ b/arch/inst/V/vloxseg3ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg4ei16.v.yaml
+++ b/arch/inst/V/vloxseg4ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg4ei32.v.yaml
+++ b/arch/inst/V/vloxseg4ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg4ei64.v.yaml
+++ b/arch/inst/V/vloxseg4ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg4ei8.v.yaml
+++ b/arch/inst/V/vloxseg4ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg5ei16.v.yaml
+++ b/arch/inst/V/vloxseg5ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg5ei32.v.yaml
+++ b/arch/inst/V/vloxseg5ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg5ei64.v.yaml
+++ b/arch/inst/V/vloxseg5ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg5ei8.v.yaml
+++ b/arch/inst/V/vloxseg5ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg6ei16.v.yaml
+++ b/arch/inst/V/vloxseg6ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg6ei32.v.yaml
+++ b/arch/inst/V/vloxseg6ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg6ei64.v.yaml
+++ b/arch/inst/V/vloxseg6ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg6ei8.v.yaml
+++ b/arch/inst/V/vloxseg6ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg7ei16.v.yaml
+++ b/arch/inst/V/vloxseg7ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg7ei32.v.yaml
+++ b/arch/inst/V/vloxseg7ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg7ei64.v.yaml
+++ b/arch/inst/V/vloxseg7ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg7ei8.v.yaml
+++ b/arch/inst/V/vloxseg7ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg8ei16.v.yaml
+++ b/arch/inst/V/vloxseg8ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg8ei32.v.yaml
+++ b/arch/inst/V/vloxseg8ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg8ei64.v.yaml
+++ b/arch/inst/V/vloxseg8ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vloxseg8ei8.v.yaml
+++ b/arch/inst/V/vloxseg8ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlse16.v.yaml
+++ b/arch/inst/V/vlse16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlse32.v.yaml
+++ b/arch/inst/V/vlse32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlse64.v.yaml
+++ b/arch/inst/V/vlse64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlse8.v.yaml
+++ b/arch/inst/V/vlse8.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg2e16.v.yaml
+++ b/arch/inst/V/vlseg2e16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg2e16ff.v.yaml
+++ b/arch/inst/V/vlseg2e16ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg2e32.v.yaml
+++ b/arch/inst/V/vlseg2e32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg2e32ff.v.yaml
+++ b/arch/inst/V/vlseg2e32ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg2e64.v.yaml
+++ b/arch/inst/V/vlseg2e64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg2e64ff.v.yaml
+++ b/arch/inst/V/vlseg2e64ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg2e8.v.yaml
+++ b/arch/inst/V/vlseg2e8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg2e8ff.v.yaml
+++ b/arch/inst/V/vlseg2e8ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg3e16.v.yaml
+++ b/arch/inst/V/vlseg3e16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg3e16ff.v.yaml
+++ b/arch/inst/V/vlseg3e16ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg3e32.v.yaml
+++ b/arch/inst/V/vlseg3e32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg3e32ff.v.yaml
+++ b/arch/inst/V/vlseg3e32ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg3e64.v.yaml
+++ b/arch/inst/V/vlseg3e64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg3e64ff.v.yaml
+++ b/arch/inst/V/vlseg3e64ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg3e8.v.yaml
+++ b/arch/inst/V/vlseg3e8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg3e8ff.v.yaml
+++ b/arch/inst/V/vlseg3e8ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg4e16.v.yaml
+++ b/arch/inst/V/vlseg4e16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg4e16ff.v.yaml
+++ b/arch/inst/V/vlseg4e16ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg4e32.v.yaml
+++ b/arch/inst/V/vlseg4e32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg4e32ff.v.yaml
+++ b/arch/inst/V/vlseg4e32ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg4e64.v.yaml
+++ b/arch/inst/V/vlseg4e64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg4e64ff.v.yaml
+++ b/arch/inst/V/vlseg4e64ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg4e8.v.yaml
+++ b/arch/inst/V/vlseg4e8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg4e8ff.v.yaml
+++ b/arch/inst/V/vlseg4e8ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg5e16.v.yaml
+++ b/arch/inst/V/vlseg5e16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg5e16ff.v.yaml
+++ b/arch/inst/V/vlseg5e16ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg5e32.v.yaml
+++ b/arch/inst/V/vlseg5e32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg5e32ff.v.yaml
+++ b/arch/inst/V/vlseg5e32ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg5e64.v.yaml
+++ b/arch/inst/V/vlseg5e64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg5e64ff.v.yaml
+++ b/arch/inst/V/vlseg5e64ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg5e8.v.yaml
+++ b/arch/inst/V/vlseg5e8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg5e8ff.v.yaml
+++ b/arch/inst/V/vlseg5e8ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg6e16.v.yaml
+++ b/arch/inst/V/vlseg6e16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg6e16ff.v.yaml
+++ b/arch/inst/V/vlseg6e16ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg6e32.v.yaml
+++ b/arch/inst/V/vlseg6e32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg6e32ff.v.yaml
+++ b/arch/inst/V/vlseg6e32ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg6e64.v.yaml
+++ b/arch/inst/V/vlseg6e64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg6e64ff.v.yaml
+++ b/arch/inst/V/vlseg6e64ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg6e8.v.yaml
+++ b/arch/inst/V/vlseg6e8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg6e8ff.v.yaml
+++ b/arch/inst/V/vlseg6e8ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg7e16.v.yaml
+++ b/arch/inst/V/vlseg7e16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg7e16ff.v.yaml
+++ b/arch/inst/V/vlseg7e16ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg7e32.v.yaml
+++ b/arch/inst/V/vlseg7e32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg7e32ff.v.yaml
+++ b/arch/inst/V/vlseg7e32ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg7e64.v.yaml
+++ b/arch/inst/V/vlseg7e64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg7e64ff.v.yaml
+++ b/arch/inst/V/vlseg7e64ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg7e8.v.yaml
+++ b/arch/inst/V/vlseg7e8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg7e8ff.v.yaml
+++ b/arch/inst/V/vlseg7e8ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg8e16.v.yaml
+++ b/arch/inst/V/vlseg8e16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg8e16ff.v.yaml
+++ b/arch/inst/V/vlseg8e16ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg8e32.v.yaml
+++ b/arch/inst/V/vlseg8e32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg8e32ff.v.yaml
+++ b/arch/inst/V/vlseg8e32ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg8e64.v.yaml
+++ b/arch/inst/V/vlseg8e64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg8e64ff.v.yaml
+++ b/arch/inst/V/vlseg8e64ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg8e8.v.yaml
+++ b/arch/inst/V/vlseg8e8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlseg8e8ff.v.yaml
+++ b/arch/inst/V/vlseg8e8ff.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg2e16.v.yaml
+++ b/arch/inst/V/vlsseg2e16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg2e32.v.yaml
+++ b/arch/inst/V/vlsseg2e32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg2e64.v.yaml
+++ b/arch/inst/V/vlsseg2e64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg2e8.v.yaml
+++ b/arch/inst/V/vlsseg2e8.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg3e16.v.yaml
+++ b/arch/inst/V/vlsseg3e16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg3e32.v.yaml
+++ b/arch/inst/V/vlsseg3e32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg3e64.v.yaml
+++ b/arch/inst/V/vlsseg3e64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg3e8.v.yaml
+++ b/arch/inst/V/vlsseg3e8.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg4e16.v.yaml
+++ b/arch/inst/V/vlsseg4e16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg4e32.v.yaml
+++ b/arch/inst/V/vlsseg4e32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg4e64.v.yaml
+++ b/arch/inst/V/vlsseg4e64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg4e8.v.yaml
+++ b/arch/inst/V/vlsseg4e8.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg5e16.v.yaml
+++ b/arch/inst/V/vlsseg5e16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg5e32.v.yaml
+++ b/arch/inst/V/vlsseg5e32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg5e64.v.yaml
+++ b/arch/inst/V/vlsseg5e64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg5e8.v.yaml
+++ b/arch/inst/V/vlsseg5e8.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg6e16.v.yaml
+++ b/arch/inst/V/vlsseg6e16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg6e32.v.yaml
+++ b/arch/inst/V/vlsseg6e32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg6e64.v.yaml
+++ b/arch/inst/V/vlsseg6e64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg7e16.v.yaml
+++ b/arch/inst/V/vlsseg7e16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg7e32.v.yaml
+++ b/arch/inst/V/vlsseg7e32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg7e64.v.yaml
+++ b/arch/inst/V/vlsseg7e64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg7e8.v.yaml
+++ b/arch/inst/V/vlsseg7e8.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg8e16.v.yaml
+++ b/arch/inst/V/vlsseg8e16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg8e32.v.yaml
+++ b/arch/inst/V/vlsseg8e32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg8e64.v.yaml
+++ b/arch/inst/V/vlsseg8e64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vlsseg8e8.v.yaml
+++ b/arch/inst/V/vlsseg8e8.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxei16.v.yaml
+++ b/arch/inst/V/vluxei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxei32.v.yaml
+++ b/arch/inst/V/vluxei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxei64.v.yaml
+++ b/arch/inst/V/vluxei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxei8.v.yaml
+++ b/arch/inst/V/vluxei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg2ei16.v.yaml
+++ b/arch/inst/V/vluxseg2ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg2ei32.v.yaml
+++ b/arch/inst/V/vluxseg2ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg2ei64.v.yaml
+++ b/arch/inst/V/vluxseg2ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg2ei8.v.yaml
+++ b/arch/inst/V/vluxseg2ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg3ei16.v.yaml
+++ b/arch/inst/V/vluxseg3ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg3ei32.v.yaml
+++ b/arch/inst/V/vluxseg3ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg3ei64.v.yaml
+++ b/arch/inst/V/vluxseg3ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg3ei8.v.yaml
+++ b/arch/inst/V/vluxseg3ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg4ei16.v.yaml
+++ b/arch/inst/V/vluxseg4ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg4ei32.v.yaml
+++ b/arch/inst/V/vluxseg4ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg4ei64.v.yaml
+++ b/arch/inst/V/vluxseg4ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg4ei8.v.yaml
+++ b/arch/inst/V/vluxseg4ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg5ei16.v.yaml
+++ b/arch/inst/V/vluxseg5ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg5ei32.v.yaml
+++ b/arch/inst/V/vluxseg5ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg5ei64.v.yaml
+++ b/arch/inst/V/vluxseg5ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg5ei8.v.yaml
+++ b/arch/inst/V/vluxseg5ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg6ei16.v.yaml
+++ b/arch/inst/V/vluxseg6ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg6ei32.v.yaml
+++ b/arch/inst/V/vluxseg6ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg6ei64.v.yaml
+++ b/arch/inst/V/vluxseg6ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg6ei8.v.yaml
+++ b/arch/inst/V/vluxseg6ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg7ei16.v.yaml
+++ b/arch/inst/V/vluxseg7ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg7ei32.v.yaml
+++ b/arch/inst/V/vluxseg7ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg7ei64.v.yaml
+++ b/arch/inst/V/vluxseg7ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg7ei8.v.yaml
+++ b/arch/inst/V/vluxseg7ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg8ei16.v.yaml
+++ b/arch/inst/V/vluxseg8ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg8ei32.v.yaml
+++ b/arch/inst/V/vluxseg8ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg8ei64.v.yaml
+++ b/arch/inst/V/vluxseg8ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vluxseg8ei8.v.yaml
+++ b/arch/inst/V/vluxseg8ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmacc.vx.yaml
+++ b/arch/inst/V/vmacc.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmadc.vi.yaml
+++ b/arch/inst/V/vmadc.vi.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmadc.vim.yaml
+++ b/arch/inst/V/vmadc.vim.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmadc.vx.yaml
+++ b/arch/inst/V/vmadc.vx.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmadc.vxm.yaml
+++ b/arch/inst/V/vmadc.vxm.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmadd.vx.yaml
+++ b/arch/inst/V/vmadd.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmax.vx.yaml
+++ b/arch/inst/V/vmax.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmaxu.vx.yaml
+++ b/arch/inst/V/vmaxu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmerge.vim.yaml
+++ b/arch/inst/V/vmerge.vim.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmerge.vxm.yaml
+++ b/arch/inst/V/vmerge.vxm.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmfeq.vf.yaml
+++ b/arch/inst/V/vmfeq.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmfge.vf.yaml
+++ b/arch/inst/V/vmfge.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmfgt.vf.yaml
+++ b/arch/inst/V/vmfgt.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmfle.vf.yaml
+++ b/arch/inst/V/vmfle.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmflt.vf.yaml
+++ b/arch/inst/V/vmflt.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmfne.vf.yaml
+++ b/arch/inst/V/vmfne.vf.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmin.vx.yaml
+++ b/arch/inst/V/vmin.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vminu.vx.yaml
+++ b/arch/inst/V/vminu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmsbc.vx.yaml
+++ b/arch/inst/V/vmsbc.vx.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmsbc.vxm.yaml
+++ b/arch/inst/V/vmsbc.vxm.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmseq.vi.yaml
+++ b/arch/inst/V/vmseq.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmseq.vx.yaml
+++ b/arch/inst/V/vmseq.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmsgt.vi.yaml
+++ b/arch/inst/V/vmsgt.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmsgt.vx.yaml
+++ b/arch/inst/V/vmsgt.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmsgtu.vi.yaml
+++ b/arch/inst/V/vmsgtu.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmsgtu.vx.yaml
+++ b/arch/inst/V/vmsgtu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmsle.vi.yaml
+++ b/arch/inst/V/vmsle.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmsle.vx.yaml
+++ b/arch/inst/V/vmsle.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmsleu.vi.yaml
+++ b/arch/inst/V/vmsleu.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmsleu.vx.yaml
+++ b/arch/inst/V/vmsleu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmslt.vx.yaml
+++ b/arch/inst/V/vmslt.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmsltu.vx.yaml
+++ b/arch/inst/V/vmsltu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmsne.vi.yaml
+++ b/arch/inst/V/vmsne.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmsne.vx.yaml
+++ b/arch/inst/V/vmsne.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmul.vx.yaml
+++ b/arch/inst/V/vmul.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmulh.vx.yaml
+++ b/arch/inst/V/vmulh.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmulhsu.vx.yaml
+++ b/arch/inst/V/vmulhsu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmulhu.vx.yaml
+++ b/arch/inst/V/vmulhu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmv.s.x.yaml
+++ b/arch/inst/V/vmv.s.x.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 010000100000-----110-----1010111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmv.v.i.yaml
+++ b/arch/inst/V/vmv.v.i.yaml
@@ -11,7 +11,7 @@ assembly: vd, imm
 encoding:
   match: 010111100000-----011-----1010111
   variables:
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmv.v.x.yaml
+++ b/arch/inst/V/vmv.v.x.yaml
@@ -11,7 +11,7 @@ assembly: vd, xs1
 encoding:
   match: 010111100000-----100-----1010111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vmv.x.s.yaml
+++ b/arch/inst/V/vmv.x.s.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: rd
+    - name: vd
       location: 11-7
 access:
   s: always

--- a/arch/inst/V/vnclip.wi.yaml
+++ b/arch/inst/V/vnclip.wi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vnclip.wx.yaml
+++ b/arch/inst/V/vnclip.wx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vnclipu.wi.yaml
+++ b/arch/inst/V/vnclipu.wi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vnclipu.wx.yaml
+++ b/arch/inst/V/vnclipu.wx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vnmsac.vx.yaml
+++ b/arch/inst/V/vnmsac.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vnmsub.vx.yaml
+++ b/arch/inst/V/vnmsub.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vnsra.wi.yaml
+++ b/arch/inst/V/vnsra.wi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vnsra.wx.yaml
+++ b/arch/inst/V/vnsra.wx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vnsrl.wi.yaml
+++ b/arch/inst/V/vnsrl.wi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vnsrl.wx.yaml
+++ b/arch/inst/V/vnsrl.wx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vor.vi.yaml
+++ b/arch/inst/V/vor.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vor.vx.yaml
+++ b/arch/inst/V/vor.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vrem.vx.yaml
+++ b/arch/inst/V/vrem.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vremu.vx.yaml
+++ b/arch/inst/V/vremu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vrgather.vi.yaml
+++ b/arch/inst/V/vrgather.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vrgather.vx.yaml
+++ b/arch/inst/V/vrgather.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vrsub.vi.yaml
+++ b/arch/inst/V/vrsub.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vrsub.vx.yaml
+++ b/arch/inst/V/vrsub.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vs1r.v.yaml
+++ b/arch/inst/V/vs1r.v.yaml
@@ -11,7 +11,7 @@ assembly: vs3, xs1
 encoding:
   match: 000000101000-----000-----0100111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vs2r.v.yaml
+++ b/arch/inst/V/vs2r.v.yaml
@@ -11,7 +11,7 @@ assembly: vs3, xs1
 encoding:
   match: 001000101000-----000-----0100111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vs4r.v.yaml
+++ b/arch/inst/V/vs4r.v.yaml
@@ -11,7 +11,7 @@ assembly: vs3, xs1
 encoding:
   match: 011000101000-----000-----0100111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vs8r.v.yaml
+++ b/arch/inst/V/vs8r.v.yaml
@@ -11,7 +11,7 @@ assembly: vs3, xs1
 encoding:
   match: 111000101000-----000-----0100111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsadd.vi.yaml
+++ b/arch/inst/V/vsadd.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vsadd.vx.yaml
+++ b/arch/inst/V/vsadd.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vsaddu.vi.yaml
+++ b/arch/inst/V/vsaddu.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vsaddu.vx.yaml
+++ b/arch/inst/V/vsaddu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vsbc.vxm.yaml
+++ b/arch/inst/V/vsbc.vxm.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vse16.v.yaml
+++ b/arch/inst/V/vse16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vse32.v.yaml
+++ b/arch/inst/V/vse32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vse64.v.yaml
+++ b/arch/inst/V/vse64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vse8.v.yaml
+++ b/arch/inst/V/vse8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsetivli.yaml
+++ b/arch/inst/V/vsetivli.yaml
@@ -11,11 +11,11 @@ assembly: xd, uimm, vtypei
 encoding:
   match: 11---------------111-----1010111
   variables:
-    - name: zimm10
+    - name: vtypei
       location: 29-20
     - name: uimm
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/V/vsetvl.yaml
+++ b/arch/inst/V/vsetvl.yaml
@@ -11,11 +11,11 @@ assembly: xd, xs1, xs2
 encoding:
   match: 1000000----------111-----1010111
   variables:
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/V/vsetvli.yaml
+++ b/arch/inst/V/vsetvli.yaml
@@ -11,11 +11,11 @@ assembly: xd, xs1, vtypei
 encoding:
   match: 0----------------111-----1010111
   variables:
-    - name: zimm11
+    - name: xs1
       location: 30-20
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/V/vslide1down.vx.yaml
+++ b/arch/inst/V/vslide1down.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vslide1up.vx.yaml
+++ b/arch/inst/V/vslide1up.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vslidedown.vi.yaml
+++ b/arch/inst/V/vslidedown.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vslidedown.vx.yaml
+++ b/arch/inst/V/vslidedown.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vslideup.vi.yaml
+++ b/arch/inst/V/vslideup.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vslideup.vx.yaml
+++ b/arch/inst/V/vslideup.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vsll.vi.yaml
+++ b/arch/inst/V/vsll.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vsll.vx.yaml
+++ b/arch/inst/V/vsll.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vsm.v.yaml
+++ b/arch/inst/V/vsm.v.yaml
@@ -11,7 +11,7 @@ assembly: vs3, xs1
 encoding:
   match: 000000101011-----000-----0100111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsmul.vx.yaml
+++ b/arch/inst/V/vsmul.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vsoxei16.v.yaml
+++ b/arch/inst/V/vsoxei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxei32.v.yaml
+++ b/arch/inst/V/vsoxei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxei64.v.yaml
+++ b/arch/inst/V/vsoxei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxei8.v.yaml
+++ b/arch/inst/V/vsoxei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg2ei16.v.yaml
+++ b/arch/inst/V/vsoxseg2ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg2ei32.v.yaml
+++ b/arch/inst/V/vsoxseg2ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg2ei64.v.yaml
+++ b/arch/inst/V/vsoxseg2ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg2ei8.v.yaml
+++ b/arch/inst/V/vsoxseg2ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg3ei16.v.yaml
+++ b/arch/inst/V/vsoxseg3ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg3ei32.v.yaml
+++ b/arch/inst/V/vsoxseg3ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg3ei64.v.yaml
+++ b/arch/inst/V/vsoxseg3ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg3ei8.v.yaml
+++ b/arch/inst/V/vsoxseg3ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg4ei16.v.yaml
+++ b/arch/inst/V/vsoxseg4ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg4ei32.v.yaml
+++ b/arch/inst/V/vsoxseg4ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg4ei64.v.yaml
+++ b/arch/inst/V/vsoxseg4ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg4ei8.v.yaml
+++ b/arch/inst/V/vsoxseg4ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg5ei16.v.yaml
+++ b/arch/inst/V/vsoxseg5ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg5ei32.v.yaml
+++ b/arch/inst/V/vsoxseg5ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg5ei64.v.yaml
+++ b/arch/inst/V/vsoxseg5ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg5ei8.v.yaml
+++ b/arch/inst/V/vsoxseg5ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg6ei16.v.yaml
+++ b/arch/inst/V/vsoxseg6ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg6ei32.v.yaml
+++ b/arch/inst/V/vsoxseg6ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg6ei64.v.yaml
+++ b/arch/inst/V/vsoxseg6ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg6ei8.v.yaml
+++ b/arch/inst/V/vsoxseg6ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg7ei16.v.yaml
+++ b/arch/inst/V/vsoxseg7ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg7ei32.v.yaml
+++ b/arch/inst/V/vsoxseg7ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg7ei64.v.yaml
+++ b/arch/inst/V/vsoxseg7ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg7ei8.v.yaml
+++ b/arch/inst/V/vsoxseg7ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg8ei16.v.yaml
+++ b/arch/inst/V/vsoxseg8ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg8ei32.v.yaml
+++ b/arch/inst/V/vsoxseg8ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg8ei64.v.yaml
+++ b/arch/inst/V/vsoxseg8ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsoxseg8ei8.v.yaml
+++ b/arch/inst/V/vsoxseg8ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsra.vi.yaml
+++ b/arch/inst/V/vsra.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vsra.vx.yaml
+++ b/arch/inst/V/vsra.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vsrl.vi.yaml
+++ b/arch/inst/V/vsrl.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vsrl.vx.yaml
+++ b/arch/inst/V/vsrl.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vsse16.v.yaml
+++ b/arch/inst/V/vsse16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsse32.v.yaml
+++ b/arch/inst/V/vsse32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsse64.v.yaml
+++ b/arch/inst/V/vsse64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsse8.v.yaml
+++ b/arch/inst/V/vsse8.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg2e16.v.yaml
+++ b/arch/inst/V/vsseg2e16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg2e32.v.yaml
+++ b/arch/inst/V/vsseg2e32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg2e64.v.yaml
+++ b/arch/inst/V/vsseg2e64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg2e8.v.yaml
+++ b/arch/inst/V/vsseg2e8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg3e16.v.yaml
+++ b/arch/inst/V/vsseg3e16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg3e32.v.yaml
+++ b/arch/inst/V/vsseg3e32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg3e64.v.yaml
+++ b/arch/inst/V/vsseg3e64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg3e8.v.yaml
+++ b/arch/inst/V/vsseg3e8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg4e16.v.yaml
+++ b/arch/inst/V/vsseg4e16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg4e32.v.yaml
+++ b/arch/inst/V/vsseg4e32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg4e64.v.yaml
+++ b/arch/inst/V/vsseg4e64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg4e8.v.yaml
+++ b/arch/inst/V/vsseg4e8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg5e16.v.yaml
+++ b/arch/inst/V/vsseg5e16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg5e32.v.yaml
+++ b/arch/inst/V/vsseg5e32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg5e64.v.yaml
+++ b/arch/inst/V/vsseg5e64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg5e8.v.yaml
+++ b/arch/inst/V/vsseg5e8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg6e16.v.yaml
+++ b/arch/inst/V/vsseg6e16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg6e32.v.yaml
+++ b/arch/inst/V/vsseg6e32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg6e64.v.yaml
+++ b/arch/inst/V/vsseg6e64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg6e8.v.yaml
+++ b/arch/inst/V/vsseg6e8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg7e16.v.yaml
+++ b/arch/inst/V/vsseg7e16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg7e32.v.yaml
+++ b/arch/inst/V/vsseg7e32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg7e64.v.yaml
+++ b/arch/inst/V/vsseg7e64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg7e8.v.yaml
+++ b/arch/inst/V/vsseg7e8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg8e16.v.yaml
+++ b/arch/inst/V/vsseg8e16.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg8e32.v.yaml
+++ b/arch/inst/V/vsseg8e32.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg8e64.v.yaml
+++ b/arch/inst/V/vsseg8e64.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsseg8e8.v.yaml
+++ b/arch/inst/V/vsseg8e8.v.yaml
@@ -13,7 +13,7 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssra.vi.yaml
+++ b/arch/inst/V/vssra.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vssra.vx.yaml
+++ b/arch/inst/V/vssra.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vssrl.vi.yaml
+++ b/arch/inst/V/vssrl.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vssrl.vx.yaml
+++ b/arch/inst/V/vssrl.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vssseg2e16.v.yaml
+++ b/arch/inst/V/vssseg2e16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg2e32.v.yaml
+++ b/arch/inst/V/vssseg2e32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg2e64.v.yaml
+++ b/arch/inst/V/vssseg2e64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg2e8.v.yaml
+++ b/arch/inst/V/vssseg2e8.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg3e16.v.yaml
+++ b/arch/inst/V/vssseg3e16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg3e32.v.yaml
+++ b/arch/inst/V/vssseg3e32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg3e64.v.yaml
+++ b/arch/inst/V/vssseg3e64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg3e8.v.yaml
+++ b/arch/inst/V/vssseg3e8.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg4e16.v.yaml
+++ b/arch/inst/V/vssseg4e16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg4e32.v.yaml
+++ b/arch/inst/V/vssseg4e32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg4e64.v.yaml
+++ b/arch/inst/V/vssseg4e64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg4e8.v.yaml
+++ b/arch/inst/V/vssseg4e8.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg5e16.v.yaml
+++ b/arch/inst/V/vssseg5e16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg5e32.v.yaml
+++ b/arch/inst/V/vssseg5e32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg5e64.v.yaml
+++ b/arch/inst/V/vssseg5e64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg5e8.v.yaml
+++ b/arch/inst/V/vssseg5e8.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg6e16.v.yaml
+++ b/arch/inst/V/vssseg6e16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg6e32.v.yaml
+++ b/arch/inst/V/vssseg6e32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg6e64.v.yaml
+++ b/arch/inst/V/vssseg6e64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg6e8.v.yaml
+++ b/arch/inst/V/vssseg6e8.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg7e16.v.yaml
+++ b/arch/inst/V/vssseg7e16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg7e32.v.yaml
+++ b/arch/inst/V/vssseg7e32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg7e64.v.yaml
+++ b/arch/inst/V/vssseg7e64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg7e8.v.yaml
+++ b/arch/inst/V/vssseg7e8.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg8e16.v.yaml
+++ b/arch/inst/V/vssseg8e16.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg8e32.v.yaml
+++ b/arch/inst/V/vssseg8e32.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg8e64.v.yaml
+++ b/arch/inst/V/vssseg8e64.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssseg8e8.v.yaml
+++ b/arch/inst/V/vssseg8e8.v.yaml
@@ -13,9 +13,9 @@ encoding:
   variables:
     - name: vm
       location: 25-25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vssub.vx.yaml
+++ b/arch/inst/V/vssub.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vssubu.vx.yaml
+++ b/arch/inst/V/vssubu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vsub.vx.yaml
+++ b/arch/inst/V/vsub.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vsuxei16.v.yaml
+++ b/arch/inst/V/vsuxei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxei32.v.yaml
+++ b/arch/inst/V/vsuxei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxei64.v.yaml
+++ b/arch/inst/V/vsuxei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxei8.v.yaml
+++ b/arch/inst/V/vsuxei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg2ei16.v.yaml
+++ b/arch/inst/V/vsuxseg2ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg2ei32.v.yaml
+++ b/arch/inst/V/vsuxseg2ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg2ei64.v.yaml
+++ b/arch/inst/V/vsuxseg2ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg2ei8.v.yaml
+++ b/arch/inst/V/vsuxseg2ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg3ei16.v.yaml
+++ b/arch/inst/V/vsuxseg3ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg3ei32.v.yaml
+++ b/arch/inst/V/vsuxseg3ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg3ei64.v.yaml
+++ b/arch/inst/V/vsuxseg3ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg3ei8.v.yaml
+++ b/arch/inst/V/vsuxseg3ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg4ei16.v.yaml
+++ b/arch/inst/V/vsuxseg4ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg4ei32.v.yaml
+++ b/arch/inst/V/vsuxseg4ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg4ei64.v.yaml
+++ b/arch/inst/V/vsuxseg4ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg4ei8.v.yaml
+++ b/arch/inst/V/vsuxseg4ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg5ei16.v.yaml
+++ b/arch/inst/V/vsuxseg5ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg5ei32.v.yaml
+++ b/arch/inst/V/vsuxseg5ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg5ei64.v.yaml
+++ b/arch/inst/V/vsuxseg5ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg5ei8.v.yaml
+++ b/arch/inst/V/vsuxseg5ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg6ei16.v.yaml
+++ b/arch/inst/V/vsuxseg6ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg6ei32.v.yaml
+++ b/arch/inst/V/vsuxseg6ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg6ei64.v.yaml
+++ b/arch/inst/V/vsuxseg6ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg6ei8.v.yaml
+++ b/arch/inst/V/vsuxseg6ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg7ei16.v.yaml
+++ b/arch/inst/V/vsuxseg7ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg7ei32.v.yaml
+++ b/arch/inst/V/vsuxseg7ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg7ei64.v.yaml
+++ b/arch/inst/V/vsuxseg7ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg7ei8.v.yaml
+++ b/arch/inst/V/vsuxseg7ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg8ei16.v.yaml
+++ b/arch/inst/V/vsuxseg8ei16.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg8ei32.v.yaml
+++ b/arch/inst/V/vsuxseg8ei32.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg8ei64.v.yaml
+++ b/arch/inst/V/vsuxseg8ei64.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vsuxseg8ei8.v.yaml
+++ b/arch/inst/V/vsuxseg8ei8.v.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vs3
       location: 11-7

--- a/arch/inst/V/vwadd.vx.yaml
+++ b/arch/inst/V/vwadd.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vwadd.wx.yaml
+++ b/arch/inst/V/vwadd.wx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vwaddu.vx.yaml
+++ b/arch/inst/V/vwaddu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vwaddu.wx.yaml
+++ b/arch/inst/V/vwaddu.wx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vwmacc.vx.yaml
+++ b/arch/inst/V/vwmacc.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vwmaccsu.vx.yaml
+++ b/arch/inst/V/vwmaccsu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vwmaccu.vx.yaml
+++ b/arch/inst/V/vwmaccu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vwmaccus.vx.yaml
+++ b/arch/inst/V/vwmaccus.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vwmul.vx.yaml
+++ b/arch/inst/V/vwmul.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vwmulsu.vx.yaml
+++ b/arch/inst/V/vwmulsu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vwmulu.vx.yaml
+++ b/arch/inst/V/vwmulu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vwsub.vx.yaml
+++ b/arch/inst/V/vwsub.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vwsub.wx.yaml
+++ b/arch/inst/V/vwsub.wx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vwsubu.vx.yaml
+++ b/arch/inst/V/vwsubu.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vwsubu.wx.yaml
+++ b/arch/inst/V/vwsubu.wx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vxor.vi.yaml
+++ b/arch/inst/V/vxor.vi.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: simm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/arch/inst/V/vxor.vx.yaml
+++ b/arch/inst/V/vxor.vx.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: vd
       location: 11-7


### PR DESCRIPTION
Fixes #705. I believe the main problem @dbrash comment in https://github.com/riscv-software-src/riscv-unified-db/issues/705#issuecomment-2891042479 was that encodings and assembly were not matching, since I had fixed assembly but not encodings. This PR should fix that.