### PR TITLE
fix(data): correct f* assembly operand names and more

### DIFF
--- a/arch/inst/D/fadd.d.yaml
+++ b/arch/inst/D/fadd.d.yaml
@@ -7,17 +7,17 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2, rm
+assembly: fd, fs1, fs2, rm
 encoding:
   match: 0000001------------------1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fclass.d.yaml
+++ b/arch/inst/D/fclass.d.yaml
@@ -7,13 +7,13 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1
+assembly: xd, fs1
 encoding:
   match: 111000100000-----001-----1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fcvt.d.l.yaml
+++ b/arch/inst/D/fcvt.d.l.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, rm
+assembly: fd, xs1, rm
 encoding:
   match: 110100100010-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fcvt.d.lu.yaml
+++ b/arch/inst/D/fcvt.d.lu.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, rm
+assembly: fd, xs1, rm
 encoding:
   match: 110100100011-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fcvt.d.s.yaml
+++ b/arch/inst/D/fcvt.d.s.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010000100000-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fcvt.d.w.yaml
+++ b/arch/inst/D/fcvt.d.w.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, rm
+assembly: fd, xs1, rm
 encoding:
   match: 110100100000-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fcvt.d.wu.yaml
+++ b/arch/inst/D/fcvt.d.wu.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, rm
+assembly: fd, xs1, rm
 encoding:
   match: 110100100001-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fcvt.l.d.yaml
+++ b/arch/inst/D/fcvt.l.d.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, rm
+assembly: xd, fs1, rm
 encoding:
   match: 110000100010-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fcvt.lu.d.yaml
+++ b/arch/inst/D/fcvt.lu.d.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, rm
+assembly: xd, fs1, rm
 encoding:
   match: 110000100011-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fcvt.s.d.yaml
+++ b/arch/inst/D/fcvt.s.d.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010000000001-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fcvt.w.d.yaml
+++ b/arch/inst/D/fcvt.w.d.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, rm
+assembly: xd, fs1, rm
 encoding:
   match: 110000100000-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fcvt.wu.d.yaml
+++ b/arch/inst/D/fcvt.wu.d.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, rm
+assembly: xd, fs1, rm
 encoding:
   match: 110000100001-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fcvtmod.w.d.yaml
+++ b/arch/inst/D/fcvtmod.w.d.yaml
@@ -8,13 +8,16 @@ description: |
   No description available.
 definedBy:
   allOf: [D, Zfa]
-assembly: xd, xs1
+assembly: xd, fs1, rm
 encoding:
-  match: 110000101000-----001-----1010011
+  match: 110000101000-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: rm
+      location: 14-12
+      not: [0, 2, 3, 4, 5, 6, 7]
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fdiv.d.yaml
+++ b/arch/inst/D/fdiv.d.yaml
@@ -7,17 +7,17 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2, rm
+assembly: fd, fs1, fs2, rm
 encoding:
   match: 0001101------------------1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/feq.d.yaml
+++ b/arch/inst/D/feq.d.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2
+assembly: xd, fs1, fs2
 encoding:
   match: 1010001----------010-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fld.yaml
+++ b/arch/inst/D/fld.yaml
@@ -7,7 +7,7 @@ long_name: Load Double-precision Floating-Point
 description: |
   No description available.
 definedBy: D
-assembly: fd, xs1, imm
+assembly: fd, imm(xs1)
 encoding:
   match: -----------------011-----0000111
   variables:

--- a/arch/inst/D/fle.d.yaml
+++ b/arch/inst/D/fle.d.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2
+assembly: xd, fs1, fs2
 encoding:
   match: 1010001----------000-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fleq.d.yaml
+++ b/arch/inst/D/fleq.d.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [D, Zfa]
-assembly: xd, xs1, xs2
+assembly: xd, fs1, fs2
 encoding:
   match: 1010001----------100-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fli.d.yaml
+++ b/arch/inst/D/fli.d.yaml
@@ -8,13 +8,13 @@ description: |
   No description available.
 definedBy:
   allOf: [D, Zfa]
-assembly: xd, xs1
+assembly: fd, xs1
 encoding:
   match: 111100100001-----000-----1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/flt.d.yaml
+++ b/arch/inst/D/flt.d.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2
+assembly: xd, fs1, fs2
 encoding:
   match: 1010001----------001-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fltq.d.yaml
+++ b/arch/inst/D/fltq.d.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [D, Zfa]
-assembly: xd, xs1, xs2
+assembly: xd, fs1, fs2
 encoding:
   match: 1010001----------101-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fmadd.d.yaml
+++ b/arch/inst/D/fmadd.d.yaml
@@ -7,19 +7,19 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2, xs3, rm
+assembly: fd, fs1, fs2, fs3, rm
 encoding:
   match: -----01------------------1000011
   variables:
-    - name: rs3
+    - name: fs3
       location: 31-27
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fmax.d.yaml
+++ b/arch/inst/D/fmax.d.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010101----------001-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fmaxm.d.yaml
+++ b/arch/inst/D/fmaxm.d.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [D, Zfa]
-assembly: xd, xs1, xs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010101----------011-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fmin.d.yaml
+++ b/arch/inst/D/fmin.d.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010101----------000-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fminm.d.yaml
+++ b/arch/inst/D/fminm.d.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [D, Zfa]
-assembly: xd, xs1, xs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010101----------010-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fmsub.d.yaml
+++ b/arch/inst/D/fmsub.d.yaml
@@ -7,19 +7,19 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2, xs3, rm
+assembly: fd, fs1, fs2, fs3, rm
 encoding:
   match: -----01------------------1000111
   variables:
-    - name: rs3
+    - name: fs3
       location: 31-27
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fmul.d.yaml
+++ b/arch/inst/D/fmul.d.yaml
@@ -7,17 +7,17 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2, rm
+assembly: fd, fs1, fs2, rm
 encoding:
   match: 0001001------------------1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fmv.d.x.yaml
+++ b/arch/inst/D/fmv.d.x.yaml
@@ -7,13 +7,13 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1
+assembly: fd, xs1
 encoding:
   match: 111100100000-----000-----1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fmv.x.d.yaml
+++ b/arch/inst/D/fmv.x.d.yaml
@@ -7,13 +7,13 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1
+assembly: xd, fs1
 encoding:
   match: 111000100000-----000-----1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fmvh.x.d.yaml
+++ b/arch/inst/D/fmvh.x.d.yaml
@@ -8,13 +8,13 @@ description: |
   No description available.
 definedBy:
   allOf: [D, Zfa]
-assembly: xd, xs1
+assembly: xd, fs1
 encoding:
   match: 111000100001-----000-----1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fmvp.d.x.yaml
+++ b/arch/inst/D/fmvp.d.x.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [D, Zfa]
-assembly: xd, xs1, xs2
+assembly: fd, xs1, xs2
 encoding:
   match: 1011001----------000-----1010011
   variables:
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fnmadd.d.yaml
+++ b/arch/inst/D/fnmadd.d.yaml
@@ -7,19 +7,19 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2, xs3, rm
+assembly: fd, fs1, fs2, fs3, rm
 encoding:
   match: -----01------------------1001111
   variables:
-    - name: rs3
+    - name: fs3
       location: 31-27
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fnmsub.d.yaml
+++ b/arch/inst/D/fnmsub.d.yaml
@@ -7,19 +7,19 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2, xs3, rm
+assembly: fd, fs1, fs2, fs3, rm
 encoding:
   match: -----01------------------1001011
   variables:
-    - name: rs3
+    - name: fs3
       location: 31-27
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fround.d.yaml
+++ b/arch/inst/D/fround.d.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [D, Zfa]
-assembly: xd, xs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010000100100-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/froundnx.d.yaml
+++ b/arch/inst/D/froundnx.d.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [D, Zfa]
-assembly: xd, xs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010000100101-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fsgnj.d.yaml
+++ b/arch/inst/D/fsgnj.d.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010001----------000-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fsgnjn.d.yaml
+++ b/arch/inst/D/fsgnjn.d.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010001----------001-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fsgnjx.d.yaml
+++ b/arch/inst/D/fsgnjx.d.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010001----------010-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fsqrt.d.yaml
+++ b/arch/inst/D/fsqrt.d.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010110100000-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/D/fsub.d.yaml
+++ b/arch/inst/D/fsub.d.yaml
@@ -7,17 +7,17 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: D
-assembly: xd, xs1, xs2, rm
+assembly: fd, fs1, fs2, rm
 encoding:
   match: 0000101------------------1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/F/fclass.s.yaml
+++ b/arch/inst/F/fclass.s.yaml
@@ -6,29 +6,29 @@ name: fclass.s
 long_name: Single-precision floating-point classify
 description: |
   The `fclass.s` instruction examines the value in floating-point register
-  _fs1_ and writes to integer register _rd_ a 10-bit mask that indicates
+  _fs1_ and writes to integer register _xd_ a 10-bit mask that indicates
   the class of the floating-point number.
   The format of the mask is described in the table below.
-  The corresponding bit in _rd_ will be set if the property is true and
+  The corresponding bit in _xd_ will be set if the property is true and
   clear otherwise.
-  All other bits in _rd_ are cleared.
-  Note that exactly one bit in rd will be set.
+  All other bits in _xd_ are cleared.
+  Note that exactly one bit in xd will be set.
   `fclass.s` does not set the floating-point exception flags.
 
   .Format of result of `fclass` instruction.
   [%autowidth,float="center",align="center",cols="^,<",options="header",]
   |===
-  |_rd_ bit |Meaning
-  |0 |_rs1_ is latexmath:[$-\infty$].
-  |1 |_rs1_ is a negative normal number.
-  |2 |_rs1_ is a negative subnormal number.
-  |3 |_rs1_ is latexmath:[$-0$].
-  |4 |_rs1_ is latexmath:[$+0$].
-  |5 |_rs1_ is a positive subnormal number.
-  |6 |_rs1_ is a positive normal number.
-  |7 |_rs1_ is latexmath:[$+\infty$].
-  |8 |_rs1_ is a signaling NaN.
-  |9 |_rs1_ is a quiet NaN.
+  |_xd_ bit |Meaning
+  |0 |_fs1_ is latexmath:[$-\infty$].
+  |1 |_fs1_ is a negative normal number.
+  |2 |_fs1_ is a negative subnormal number.
+  |3 |_fs1_ is latexmath:[$-0$].
+  |4 |_fs1_ is latexmath:[$+0$].
+  |5 |_fs1_ is a positive subnormal number.
+  |6 |_fs1_ is a positive normal number.
+  |7 |_fs1_ is latexmath:[$+\infty$].
+  |8 |_fs1_ is a signaling NaN.
+  |9 |_fs1_ is a quiet NaN.
   |===
 
 definedBy: F
@@ -38,7 +38,7 @@ encoding:
   variables:
     - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always
@@ -52,26 +52,26 @@ operation(): |
   Bits<32> sp_value = f[fs1][31:0];
 
   if (is_sp_neg_inf?(sp_value)) {
-    X[rd] = 1 << 0;
+    X[xd] = 1 << 0;
   } else if (is_sp_neg_norm?(sp_value)) {
-    X[rd] = 1 `<< 1;
+    X[xd] = 1 `<< 1;
   } else if (is_sp_neg_subnorm?(sp_value)) {
-    X[rd] = 1 `<< 2;
+    X[xd] = 1 `<< 2;
   } else if (is_sp_neg_zero?(sp_value)) {
-    X[rd] = 1 `<< 3;
+    X[xd] = 1 `<< 3;
   } else if (is_sp_pos_zero?(sp_value)) {
-    X[rd] = 1 `<< 4;
+    X[xd] = 1 `<< 4;
   } else if (is_sp_pos_subnorm?(sp_value)) {
-    X[rd] = 1 `<< 5;
+    X[xd] = 1 `<< 5;
   } else if (is_sp_pos_norm?(sp_value)) {
-    X[rd] = 1 `<< 6;
+    X[xd] = 1 `<< 6;
   } else if (is_sp_pos_inf?(sp_value)) {
-    X[rd] = 1 `<< 7;
+    X[xd] = 1 `<< 7;
   } else if (is_sp_signaling_nan?(sp_value)) {
-    X[rd] = 1 `<< 8;
+    X[xd] = 1 `<< 8;
   } else {
     assert(is_sp_quiet_nan?(sp_value), "Unexpected SP value");
-    X[rd] = 1 `<< 9;
+    X[xd] = 1 `<< 9;
   }
 
 # SPDX-SnippetBegin

--- a/arch/inst/F/fcvt.l.s.yaml
+++ b/arch/inst/F/fcvt.l.s.yaml
@@ -16,7 +16,7 @@ encoding:
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/F/fcvt.lu.s.yaml
+++ b/arch/inst/F/fcvt.lu.s.yaml
@@ -16,7 +16,7 @@ encoding:
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/F/fcvt.s.l.yaml
+++ b/arch/inst/F/fcvt.s.l.yaml
@@ -12,7 +12,7 @@ assembly: fd, xs1, rm
 encoding:
   match: 110100000010-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12

--- a/arch/inst/F/fcvt.s.lu.yaml
+++ b/arch/inst/F/fcvt.s.lu.yaml
@@ -12,7 +12,7 @@ assembly: fd, xs1, rm
 encoding:
   match: 110100000011-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12

--- a/arch/inst/F/fcvt.s.w.yaml
+++ b/arch/inst/F/fcvt.s.w.yaml
@@ -5,22 +5,22 @@ kind: instruction
 name: fcvt.s.w
 long_name: Convert signed 32-bit integer to single-precision float
 description: |
-  Converts a 32-bit signed integer in integer register _rs1_ into a floating-point number in
+  Converts a 32-bit signed integer in integer register _xs1_ into a floating-point number in
   floating-point register _fd_.
 
   All floating-point to integer and integer to floating-point conversion instructions round
   according to the _rm_ field.
   A floating-point register can be initialized to floating-point positive zero using
-  `fcvt.s.w rd, x0`, which will never set any exception flags.
+  `fcvt.s.w fd, x0`, which will never set any exception flags.
 
   All floating-point conversion instructions set the Inexact exception flag if the rounded
   result differs from the operand value and the Invalid exception flag is not set.
 definedBy: F
-assembly: fd, xs1
+assembly: fd, xs1, rm
 encoding:
   match: 110100000000-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12
@@ -35,7 +35,7 @@ data_independent_timing: false
 operation(): |
   check_f_ok($encoding);
   RoundingMode rounding_mode = rm_to_mode(rm, $encoding);
-  X[fd] = i32_to_f32(X[rs1], rounding_mode);
+  X[fd] = i32_to_f32(X[xs1], rounding_mode);
   mark_f_state_dirty();
 
 # SPDX-SnippetBegin

--- a/arch/inst/F/fcvt.s.wu.yaml
+++ b/arch/inst/F/fcvt.s.wu.yaml
@@ -5,7 +5,7 @@ kind: instruction
 name: fcvt.s.wu
 long_name: Convert unsigned 32-bit integer to single-precision float
 description: |
-  Converts a 32-bit unsigned integer in integer register _rs1_ into a floating-point number in
+  Converts a 32-bit unsigned integer in integer register _xs1_ into a floating-point number in
   floating-point register _fd_.
 
   All floating-point to integer and integer to floating-point conversion instructions round
@@ -20,7 +20,7 @@ assembly: fd, xs1, rm
 encoding:
   match: 110100000001-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12
@@ -35,7 +35,7 @@ data_independent_timing: true
 operation(): |
   check_f_ok($encoding);
   RoundingMode rounding_mode = rm_to_mode(rm, $encoding);
-  X[fd] = ui32_to_f32(X[rs1], rounding_mode);
+  X[fd] = ui32_to_f32(X[xs1], rounding_mode);
   mark_f_state_dirty();
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/arch/inst/F/fcvt.w.s.yaml
+++ b/arch/inst/F/fcvt.w.s.yaml
@@ -36,7 +36,7 @@ description: |
   result differs from the operand value and the Invalid exception flag is not set.
 
 definedBy: F
-assembly: xd, fs1
+assembly: xd, fs1, rm
 encoding:
   match: 110000000000-------------1010011
   variables:

--- a/arch/inst/F/feq.s.yaml
+++ b/arch/inst/F/feq.s.yaml
@@ -5,7 +5,7 @@ kind: instruction
 name: feq.s
 long_name: Single-precision floating-point equal
 description: |
-  Writes 1 to _rd_ if _fs1_ and _fs2_ are equal, and 0 otherwise.
+  Writes 1 to _xd_ if _fs1_ and _fs2_ are equal, and 0 otherwise.
 
   If either operand is NaN, the result is 0 (not equal). If either operand is a signaling NaN, the invalid flag is set.
 
@@ -20,7 +20,7 @@ encoding:
       location: 24-20
     - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always
@@ -38,9 +38,9 @@ operation(): |
     if (is_sp_signaling_nan?(sp_value_a) || is_sp_signaling_nan?(sp_value_b)) {
       set_fp_flag(FpFlag::NV);
     }
-    X[rd] = 0;
+    X[xd] = 0;
   } else {
-    X[rd] = (
+    X[xd] = (
       (sp_value_a == sp_value_b)
       || ((sp_value_a | sp_value_b)[30:0] == 0) # pos 0 is equal to neg zero
     ) ? 1 : 0;

--- a/arch/inst/F/fle.s.yaml
+++ b/arch/inst/F/fle.s.yaml
@@ -5,7 +5,7 @@ kind: instruction
 name: fle.s
 long_name: Single-precision floating-point less than or equal
 description: |
-  Writes 1 to _rd_ if _fs1_ is less than or equal to _fs2_, and 0 otherwise.
+  Writes 1 to _xd_ if _fs1_ is less than or equal to _fs2_, and 0 otherwise.
 
   If either operand is NaN, the result is 0 (not equal).
   If either operand is a NaN (signaling or quiet), the invalid flag is set.
@@ -21,7 +21,7 @@ encoding:
       location: 24-20
     - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always
@@ -39,9 +39,9 @@ operation(): |
     if (is_sp_signaling_nan?(sp_value_a) || is_sp_signaling_nan?(sp_value_b)) {
       set_fp_flag(FpFlag::NV);
     }
-    X[rd] = 0;
+    X[xd] = 0;
   } else {
-    X[rd] = (
+    X[xd] = (
       (sp_value_a == sp_value_b)
       || ((sp_value_a | sp_value_b)[30:0] == 0) # pos 0 is equal to neg zero
     ) ? 1 : 0;

--- a/arch/inst/F/fleq.s.yaml
+++ b/arch/inst/F/fleq.s.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 24-20
     - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/F/fli.s.yaml
+++ b/arch/inst/F/fli.s.yaml
@@ -7,11 +7,11 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfa
-assembly: fd, fs1
+assembly: fd, xs1
 encoding:
   match: 111100000001-----000-----1010011
   variables:
-    - name: fs1
+    - name: xs1
       location: 19-15
     - name: fd
       location: 11-7

--- a/arch/inst/F/flt.s.yaml
+++ b/arch/inst/F/flt.s.yaml
@@ -5,7 +5,7 @@ kind: instruction
 name: flt.s
 long_name: Single-precision floating-point less than
 description: |
-  Writes 1 to _rd_ if _fs1_ is less than _fs2_, and 0 otherwise.
+  Writes 1 to _xd_ if _fs1_ is less than _fs2_, and 0 otherwise.
 
   If either operand is NaN, the result is 0 (not equal).
   If either operand is a NaN (signaling or quiet), the invalid flag is set.
@@ -19,7 +19,7 @@ encoding:
       location: 24-20
     - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always
@@ -35,7 +35,7 @@ operation(): |
 
   if (is_sp_nan?(sp_value_a) || is_sp_nan?(sp_value_b)) {
     set_fp_flag(FpFlag::NV);
-    X[rd] = 0;
+    X[xd] = 0;
   } else {
     Boolean sign_a = sp_value_a[31] == 1;
     Boolean sign_b = sp_value_b[31] == 1;
@@ -44,7 +44,7 @@ operation(): |
       (sign_a != sign_b)
         ? (sign_a && ((sp_value_a[30:0] | sp_value_b[30:0]) != 0)) # opposite sign, a is negative. a is less than b as long as both are not zero
         : ((sp_value_a != sp_value_b) && (sign_a != (sp_value_a < sp_value_b)));
-    X[rd] = a_lt_b ? 1 : 0;
+    X[xd] = a_lt_b ? 1 : 0;
   }
 
 # SPDX-SnippetBegin

--- a/arch/inst/F/fltq.s.yaml
+++ b/arch/inst/F/fltq.s.yaml
@@ -15,7 +15,7 @@ encoding:
       location: 24-20
     - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/F/flw.yaml
+++ b/arch/inst/F/flw.yaml
@@ -10,7 +10,7 @@ description: |
   `flw` does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
 
 definedBy: F
-assembly: fd, xs1, imm
+assembly: fd, imm(xs1)
 encoding:
   match: -----------------010-----0000111
   variables:

--- a/arch/inst/F/fmaxm.s.yaml
+++ b/arch/inst/F/fmaxm.s.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfa
-assembly: xd, xs1, xs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010100----------011-----1010011
   variables:

--- a/arch/inst/F/fmin.s.yaml
+++ b/arch/inst/F/fmin.s.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: F
-assembly: xd, xs1, xs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010100----------000-----1010011
   variables:

--- a/arch/inst/F/fmv.w.x.yaml
+++ b/arch/inst/F/fmv.w.x.yaml
@@ -6,7 +6,7 @@ name: fmv.w.x
 long_name: Single-precision floating-point move from integer
 description: |
   Moves the single-precision value encoded in IEEE 754-2008 standard encoding
-  from the lower 32 bits of integer register `rs1` to the floating-point
+  from the lower 32 bits of integer register `xs1` to the floating-point
   register `fd`. The bits are not modified in the transfer, and in particular,
   the payloads of non-canonical NaNs are preserved.
 definedBy: F
@@ -14,7 +14,7 @@ assembly: fd, xs1
 encoding:
   match: 111100000000-----000-----1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: fd
       location: 11-7
@@ -27,7 +27,7 @@ data_independent_timing: true
 operation(): |
   check_f_ok($encoding);
 
-  Bits<32> sp_value = X[rs1][31:0];
+  Bits<32> sp_value = X[xs1][31:0];
 
   if (implemented?(ExtensionName::D)) {
     f[fd] = nan_box<32, 64>(sp_value);

--- a/arch/inst/F/fmv.x.w.yaml
+++ b/arch/inst/F/fmv.x.w.yaml
@@ -6,7 +6,7 @@ name: fmv.x.w
 long_name: Move single-precision value from floating-point to integer register
 description: |
   Moves the single-precision value in floating-point register rs1 represented in IEEE 754-2008
-  encoding to the lower 32 bits of integer register rd.
+  encoding to the lower 32 bits of integer register xd.
   The bits are not modified in the transfer, and in particular, the payloads of non-canonical
   NaNs are preserved.
   For RV64, the higher 32 bits of the destination register are filled with copies of the
@@ -18,7 +18,7 @@ encoding:
   variables:
     - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always
@@ -29,7 +29,7 @@ data_independent_timing: true
 operation(): |
   check_f_ok($encoding);
 
-  X[rd] = sext(f[fs1][31:0], 32);
+  X[xd] = sext(f[fs1][31:0], 32);
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/arch/inst/F/fnmsub.s.yaml
+++ b/arch/inst/F/fnmsub.s.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: F
-assembly: xd, xs1, xs2, xs3, rm
+assembly: fd, fs1, fs2, fs3, rm
 encoding:
   match: -----00------------------1001011
   variables:

--- a/arch/inst/F/fround.s.yaml
+++ b/arch/inst/F/fround.s.yaml
@@ -7,11 +7,11 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfa
-assembly: fd, xs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010000000100-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12

--- a/arch/inst/F/froundnx.s.yaml
+++ b/arch/inst/F/froundnx.s.yaml
@@ -7,11 +7,11 @@ long_name: Floating-point Round Single-precision to Integer with Inexact
 description: |
   No description available.
 definedBy: Zfa
-assembly: fd, xs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010000000101-------------1010011
   variables:
-    - name: xs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12

--- a/arch/inst/F/fsw.yaml
+++ b/arch/inst/F/fsw.yaml
@@ -10,7 +10,7 @@ description: |
   `fsw` does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
 
 definedBy: F
-assembly: fs2, xs1, imm
+assembly: fs2, imm(xs1)
 encoding:
   match: -----------------010-----0100111
   variables:

--- a/arch/inst/I/fence.tso.yaml
+++ b/arch/inst/I/fence.tso.yaml
@@ -12,7 +12,7 @@ description: |
   in its predecessor set before all store operations in its successor set. This leaves non-AMO store
   operations in the 'fence.tso's predecessor set unordered with non-AMO loads in its successor set.
 
-  The `rs1` and `rd` fields are unused and ignored.
+  The `xs1` and `xd` fields are unused and ignored.
 
   In modes other than M-mode, `fence.tso` is further affected by `menvcfg.FIOM`,
   `senvcfg.FIOM`<% if ext?(:H) %>, and/or `henvcfg.FIOM`<% end %>.
@@ -22,9 +22,9 @@ assembly: ""
 encoding:
   match: 100000110011-----000-----0001111
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/I/fence.yaml
+++ b/arch/inst/I/fence.yaml
@@ -121,7 +121,7 @@ description: |
   <%- end -%>
 
 definedBy: I
-assembly: "TODO"
+assembly: pred, succ
 encoding:
   match: -----------------000-----0001111
   variables:

--- a/arch/inst/Q/fadd.q.yaml
+++ b/arch/inst/Q/fadd.q.yaml
@@ -7,17 +7,17 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, qs1, qs2, rm
+assembly: fd, fs1, fs2, rm
 encoding:
   match: 0000011------------------1010011
   variables:
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fclass.q.yaml
+++ b/arch/inst/Q/fclass.q.yaml
@@ -7,13 +7,13 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: xd, qs1
+assembly: xd, fs1
 encoding:
   match: 111001100000-----001-----1010011
   variables:
-    - name: qs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fcvt.d.q.yaml
+++ b/arch/inst/Q/fcvt.d.q.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: xd, qs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010000100011-------------1010011
   variables:
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fcvt.h.q.yaml
+++ b/arch/inst/Q/fcvt.h.q.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [Q, Zfh]
-assembly: xd, qs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010001000011-------------1010011
   variables:
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fcvt.l.q.yaml
+++ b/arch/inst/Q/fcvt.l.q.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy: Q
 base: 64
-assembly: xd, qs1, rm
+assembly: xd, fs1, rm
 encoding:
   match: 110001100010-------------1010011
   variables:
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fcvt.lu.q.yaml
+++ b/arch/inst/Q/fcvt.lu.q.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy: Q
 base: 64
-assembly: qd, hs1, rm
+assembly: xd, fs1, rm
 encoding:
   match: 110001100011-------------1010011
   variables:
-    - name: hs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fcvt.q.d.yaml
+++ b/arch/inst/Q/fcvt.q.d.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: dd, fs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010001100001-------------1010011
   variables:
@@ -15,7 +15,7 @@ encoding:
       location: 19-15
     - name: rm
       location: 14-12
-    - name: dd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fcvt.q.h.yaml
+++ b/arch/inst/Q/fcvt.q.h.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [Q, Zfh]
-assembly: hd, qs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010001100010-------------1010011
   variables:
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: hd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fcvt.q.l.yaml
+++ b/arch/inst/Q/fcvt.q.l.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy: Q
 base: 64
-assembly: qd, xs1, rm
+assembly: fd, xs1, rm
 encoding:
   match: 110101100010-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fcvt.q.lu.yaml
+++ b/arch/inst/Q/fcvt.q.lu.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy: Q
 base: 64
-assembly: qd, xs1, rm
+assembly: fd, xs1, rm
 encoding:
   match: 110101100011-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fcvt.q.s.yaml
+++ b/arch/inst/Q/fcvt.q.s.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, fs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010001100000-------------1010011
   variables:
@@ -15,7 +15,7 @@ encoding:
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fcvt.q.w.yaml
+++ b/arch/inst/Q/fcvt.q.w.yaml
@@ -11,7 +11,7 @@ assembly: fd, xs1, rm
 encoding:
   match: 110101100000-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12

--- a/arch/inst/Q/fcvt.q.wu.yaml
+++ b/arch/inst/Q/fcvt.q.wu.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, xs1, rm
+assembly: fd, xs1, rm
 encoding:
   match: 110101100001-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fcvt.s.q.yaml
+++ b/arch/inst/Q/fcvt.s.q.yaml
@@ -7,11 +7,11 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: fd, qs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010000000011-------------1010011
   variables:
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12

--- a/arch/inst/Q/fcvt.w.q.yaml
+++ b/arch/inst/Q/fcvt.w.q.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: xd, qs1, rm
+assembly: xd, fs1, rm
 encoding:
   match: 110001100000-------------1010011
   variables:
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fcvt.wu.q.yaml
+++ b/arch/inst/Q/fcvt.wu.q.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: xd, xs1, rm
+assembly: xd, fs1, rm
 encoding:
   match: 110001100001-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fdiv.q.yaml
+++ b/arch/inst/Q/fdiv.q.yaml
@@ -7,17 +7,17 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, qs1, qs2, rm
+assembly: fd, fs1, fs2, rm
 encoding:
   match: 0001111------------------1010011
   variables:
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/feq.q.yaml
+++ b/arch/inst/Q/feq.q.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: xd, qs1, qs2
+assembly: xd, fs1, fs2
 encoding:
   match: 1010011----------010-----1010011
   variables:
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fle.q.yaml
+++ b/arch/inst/Q/fle.q.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: xd, qs1, qs2
+assembly: xd, fs1, fs2
 encoding:
   match: 1010011----------000-----1010011
   variables:
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fleq.q.yaml
+++ b/arch/inst/Q/fleq.q.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [Q, Zfa]
-assembly: xd, qs1, qs2
+assembly: xd, fs1, fs2
 encoding:
   match: 1010011----------100-----1010011
   variables:
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fli.q.yaml
+++ b/arch/inst/Q/fli.q.yaml
@@ -8,11 +8,11 @@ description: |
   No description available.
 definedBy:
   allOf: [Q, Zfa]
-assembly: fd, qs1
+assembly: fd, xs1
 encoding:
   match: 111101100001-----000-----1010011
   variables:
-    - name: qs1
+    - name: xs1
       location: 19-15
     - name: fd
       location: 11-7

--- a/arch/inst/Q/flq.yaml
+++ b/arch/inst/Q/flq.yaml
@@ -7,7 +7,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, xs1, imm
+assembly: fd, xs1, imm
 encoding:
   match: -----------------100-----0000111
   variables:
@@ -15,7 +15,7 @@ encoding:
       location: 31-20
     - name: xs1
       location: 19-15
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/flt.q.yaml
+++ b/arch/inst/Q/flt.q.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: xd, qs1, qs2
+assembly: xd, fs1, fs2
 encoding:
   match: 1010011----------001-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fltq.q.yaml
+++ b/arch/inst/Q/fltq.q.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [Q, Zfa]
-assembly: qd, qs1, qs2
+assembly: fd, fs1, fs2
 encoding:
   match: 1010011----------101-----1010011
   variables:
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fmadd.q.yaml
+++ b/arch/inst/Q/fmadd.q.yaml
@@ -7,19 +7,19 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, qs1, qs2, qs3, rm
+assembly: fd, fs1, fs2, fs3, rm
 encoding:
   match: -----11------------------1000011
   variables:
-    - name: qs3
+    - name: fs3
       location: 31-27
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fmax.q.yaml
+++ b/arch/inst/Q/fmax.q.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, qs1, qs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010111----------001-----1010011
   variables:
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fmaxm.q.yaml
+++ b/arch/inst/Q/fmaxm.q.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [Q, Zfa]
-assembly: qd, qs1, qs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010111----------011-----1010011
   variables:
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fmin.q.yaml
+++ b/arch/inst/Q/fmin.q.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: xd, xs1, xs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010111----------000-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fminm.q.yaml
+++ b/arch/inst/Q/fminm.q.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [Q, Zfa]
-assembly: qd, qs1, qs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010111----------010-----1010011
   variables:
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fmsub.q.yaml
+++ b/arch/inst/Q/fmsub.q.yaml
@@ -7,19 +7,19 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, qs1, qs2, qs3, rm
+assembly: fd, fs1, fs2, fs3, rm
 encoding:
   match: -----11------------------1000111
   variables:
-    - name: qs3
+    - name: fs3
       location: 31-27
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fmul.q.yaml
+++ b/arch/inst/Q/fmul.q.yaml
@@ -7,17 +7,17 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, qs1, qs2, rm
+assembly: fd, fs1, fs2, rm
 encoding:
   match: 0001011------------------1010011
   variables:
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fmvh.x.q.yaml
+++ b/arch/inst/Q/fmvh.x.q.yaml
@@ -9,13 +9,13 @@ description: |
 definedBy:
   allOf: [Q, Zfa]
 base: 64
-assembly: xd, qs1
+assembly: xd, fs1
 encoding:
   match: 111001100001-----000-----1010011
   variables:
-    - name: qs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fmvp.q.x.yaml
+++ b/arch/inst/Q/fmvp.q.x.yaml
@@ -9,15 +9,15 @@ description: |
 definedBy:
   allOf: [Q, Zfa]
 base: 64
-assembly: qd, xs1, xs2
+assembly: fd, xs1, xs2
 encoding:
   match: 1011011----------000-----1010011
   variables:
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fnmadd.q.yaml
+++ b/arch/inst/Q/fnmadd.q.yaml
@@ -7,19 +7,19 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, qs1, qs2, qs3, rm
+assembly: fd, fs1, fs2, fs3, rm
 encoding:
   match: -----11------------------1001111
   variables:
-    - name: qs3
+    - name: fs3
       location: 31-27
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fnmsub.q.yaml
+++ b/arch/inst/Q/fnmsub.q.yaml
@@ -7,19 +7,19 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, qs1, qs2, qs3, rm
+assembly: fd, fs1, fs2, fs3, rm
 encoding:
   match: -----11------------------1001011
   variables:
-    - name: qs3
+    - name: fs3
       location: 31-27
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fround.q.yaml
+++ b/arch/inst/Q/fround.q.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [Q, Zfa]
-assembly: qd, qs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010001100100-------------1010011
   variables:
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/froundnx.q.yaml
+++ b/arch/inst/Q/froundnx.q.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [Q, Zfa]
-assembly: qd, qs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010001100101-------------1010011
   variables:
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fsgnj.q.yaml
+++ b/arch/inst/Q/fsgnj.q.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, qs1, qs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010011----------000-----1010011
   variables:
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fsgnjn.q.yaml
+++ b/arch/inst/Q/fsgnjn.q.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, qs1, qs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010011----------001-----1010011
   variables:
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fsgnjx.q.yaml
+++ b/arch/inst/Q/fsgnjx.q.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, qs1, qs2
+assembly: fd, fs1, fs2
 encoding:
   match: 0010011----------010-----1010011
   variables:
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fsq.yaml
+++ b/arch/inst/Q/fsq.yaml
@@ -7,13 +7,13 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qs2, imm(xs1)
+assembly: fs2, imm(xs1)
 encoding:
   match: -----------------100-----0100111
   variables:
     - name: imm
       location: 31-25|11-7
-    - name: qs2
+    - name: fs2
       location: 24-20
     - name: xs1
       location: 19-15

--- a/arch/inst/Q/fsqrt.q.yaml
+++ b/arch/inst/Q/fsqrt.q.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, qs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010111100000-------------1010011
   variables:
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Q/fsub.q.yaml
+++ b/arch/inst/Q/fsub.q.yaml
@@ -7,17 +7,17 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Q
-assembly: qd, qs1, qs2, rm
+assembly: fd, fs1, fs2, rm
 encoding:
   match: 0000111------------------1010011
   variables:
-    - name: qs2
+    - name: fs2
       location: 24-20
-    - name: qs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: qd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zalasr/lb.aq.yaml
+++ b/arch/inst/Zalasr/lb.aq.yaml
@@ -7,15 +7,13 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zalasr
-assembly: xd, xs1
+assembly: xd, (xs1)
 encoding:
-  match: 001101-00000-----000-----0101111
+  match: 001101000000-----000-----0101111
   variables:
-    - name: rl
-      location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zalasr/ld.aq.yaml
+++ b/arch/inst/Zalasr/ld.aq.yaml
@@ -7,15 +7,13 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zalasr
-assembly: xd, xs1
+assembly: xd, (xs1)
 encoding:
-  match: 001101-00000-----011-----0101111
+  match: 001101000000-----011-----0101111
   variables:
-    - name: rl
-      location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zalasr/lh.aq.yaml
+++ b/arch/inst/Zalasr/lh.aq.yaml
@@ -7,15 +7,13 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zalasr
-assembly: xd, xs1
+assembly: xd, (xs1)
 encoding:
-  match: 001101-00000-----001-----0101111
+  match: 001101000000-----001-----0101111
   variables:
-    - name: rl
-      location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zalasr/lw.aq.yaml
+++ b/arch/inst/Zalasr/lw.aq.yaml
@@ -7,15 +7,13 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zalasr
-assembly: xd, xs1
+assembly: xd, (xs1)
 encoding:
-  match: 001101-00000-----010-----0101111
+  match: 001101000000-----010-----0101111
   variables:
-    - name: rl
-      location: 25-25
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zalasr/sb.rl.yaml
+++ b/arch/inst/Zalasr/sb.rl.yaml
@@ -7,15 +7,13 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zalasr
-assembly: xs2, xs1
+assembly: xs2, (xs1)
 encoding:
-  match: 00111-1----------000000000101111
+  match: 0011101----------000000000101111
   variables:
-    - name: aq
-      location: 26-26
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
 access:
   s: always

--- a/arch/inst/Zalasr/sd.rl.yaml
+++ b/arch/inst/Zalasr/sd.rl.yaml
@@ -7,12 +7,10 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zalasr
-assembly: xs2, xs1
+assembly: xs2, (xs1)
 encoding:
-  match: 00111-1----------011000000101111
+  match: 0011101----------011000000101111
   variables:
-    - name: aq
-      location: 26-26
     - name: rs2
       location: 24-20
     - name: rs1

--- a/arch/inst/Zalasr/sh.rl.yaml
+++ b/arch/inst/Zalasr/sh.rl.yaml
@@ -7,12 +7,10 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zalasr
-assembly: xs2, xs1
+assembly: xs2, (xs1)
 encoding:
-  match: 00111-1----------001000000101111
+  match: 0011101----------001000000101111
   variables:
-    - name: aq
-      location: 26-26
     - name: rs2
       location: 24-20
     - name: rs1

--- a/arch/inst/Zalasr/sw.rl.yaml
+++ b/arch/inst/Zalasr/sw.rl.yaml
@@ -7,12 +7,10 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zalasr
-assembly: xs2, xs1
+assembly: xs2, (xs1)
 encoding:
-  match: 00111-1----------010000000101111
+  match: 0011101----------010000000101111
   variables:
-    - name: aq
-      location: 26-26
     - name: rs2
       location: 24-20
     - name: rs1

--- a/arch/inst/Zalrsc/lr.d.yaml
+++ b/arch/inst/Zalrsc/lr.d.yaml
@@ -5,11 +5,11 @@ kind: instruction
 name: lr.d
 long_name: Load reserved doubleword
 description: |
-  Loads a word from the address in rs1, places the value in rd,
+  Loads a word from the address in xs1, places the value in xd,
   and registers a _reservation set_  -- a set of bytes that subsumes the bytes in the
   addressed word.
 
-  The address in rs1 must be 8-byte aligned.
+  The address in xs1 must be 8-byte aligned.
 
   If the address is not naturally aligned, a `LoadAddressMisaligned` exception or an
   `LoadAccessFault` exception will be generated. The access-fault exception can be generated
@@ -44,17 +44,19 @@ description: |
   with both bits clear, but may result in lower performance.
 definedBy: Zalrsc
 base: 64
-assembly: xd, xs1
+assembly: xd, (xs1)
 encoding:
   match: 00010--00000-----011-----0101111
   variables:
     - name: aq
       location: 26
+      not: 1
     - name: rl
       location: 25
-    - name: rs1
+      not: 1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always
@@ -68,7 +70,7 @@ operation(): |
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg virtual_address = X[rs1];
+  XReg virtual_address = X[xs1];
 
   if (!is_naturally_aligned<64>(virtual_address)) {
     # can raise either LoadAddressMisaligned *or* LoadAccessFault
@@ -88,7 +90,7 @@ operation(): |
     }
   }
 
-  X[rd] = load_reserved<32>(virtual_address, aq, rl, $encoding);
+  X[xd] = load_reserved<32>(virtual_address, aq, rl, $encoding);
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/arch/inst/Zalrsc/lr.w.yaml
+++ b/arch/inst/Zalrsc/lr.w.yaml
@@ -48,14 +48,16 @@ description: |
   LR.rl and SC.aq instructions are not guaranteed to provide any stronger ordering than those
   with both bits clear, but may result in lower performance.
 definedBy: Zalrsc
-assembly: xd, xs1
+assembly: xd, (xs1)
 encoding:
   match: 00010--00000-----010-----0101111
   variables:
     - name: aq
       location: 26
+      not: 1
     - name: rl
       location: 25
+      not: 1
     - name: rs1
       location: 19-15
     - name: rd

--- a/arch/inst/Zalrsc/sc.d.yaml
+++ b/arch/inst/Zalrsc/sc.d.yaml
@@ -5,12 +5,12 @@ kind: instruction
 name: sc.d
 long_name: Store conditional doubleword
 description: |
-  `sc.d` conditionally writes a doubleword in _rs2_ to the address in _rs1_:
+  `sc.d` conditionally writes a doubleword in _xs2_ to the address in _xs1_:
   the `sc.d` succeeds only if the reservation is still valid and the
   reservation set contains the bytes being written. If the `sc.d` succeeds,
-  the instruction writes the doubleword in _rs2_ to memory, and it writes zero to _rd_.
+  the instruction writes the doubleword in _xs2_ to memory, and it writes zero to _xd_.
   If the `sc.d` fails, the instruction does not write to memory, and it writes a
-  nonzero value to _rd_. For the purposes of memory protection, a failed `sc.d`
+  nonzero value to _xd_. For the purposes of memory protection, a failed `sc.d`
   may be treated like a store. Regardless of success or failure, executing an
   `sc.d` instruction invalidates any reservation held by this hart.
 
@@ -18,7 +18,7 @@ description: |
   Other failure codes are reserved at this time.
   Portable software should only assume the failure code will be non-zero.
 
-  The address held in _rs1_ must be naturally aligned to the size of the operand
+  The address held in _xs1_ must be naturally aligned to the size of the operand
   (_i.e._, eight-byte aligned).
   If the address is not naturally aligned, an address-misaligned exception or an
   access-fault exception will be generated.
@@ -100,7 +100,7 @@ description: |
   with both bits clear, but may result in lower performance.
 definedBy: Zalrsc
 base: 64
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00011------------011-----0101111
   variables:
@@ -108,11 +108,11 @@ encoding:
       location: 26
     - name: rl
       location: 25
-    - name: rs2
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always
@@ -126,8 +126,8 @@ operation(): |
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg virtual_address = X[rs1];
-  XReg value = X[rs2];
+  XReg virtual_address = X[xs1];
+  XReg value = X[xs2];
 
   if (!is_naturally_aligned<64>(virtual_address)) {
     # can raise either LoadAddressMisaligned *or* LoadAccessFault
@@ -148,7 +148,7 @@ operation(): |
   }
 
   Boolean success = store_conditional<64>(virtual_address, value, aq, rl, $encoding);
-  X[rd] = success ? 0 : 1;
+  X[xd] = success ? 0 : 1;
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/arch/inst/Zalrsc/sc.w.yaml
+++ b/arch/inst/Zalrsc/sc.w.yaml
@@ -5,26 +5,26 @@ kind: instruction
 name: sc.w
 long_name: Store conditional word
 description: |
-  `sc.w` conditionally writes a word in _rs2_ to the address in _rs1_:
+  `sc.w` conditionally writes a word in _xs2_ to the address in _xs1_:
   the `sc.w` succeeds only if the reservation is still valid and the
   reservation set contains the bytes being written. If the `sc.w` succeeds,
-  the instruction writes the word in _rs2_ to memory, and it writes zero to _rd_.
+  the instruction writes the word in _xs2_ to memory, and it writes zero to _xd_.
   If the `sc.w` fails, the instruction does not write to memory, and it writes a
-  nonzero value to _rd_. For the purposes of memory protection, a failed `sc.w`
+  nonzero value to _xd_. For the purposes of memory protection, a failed `sc.w`
   may be treated like a store. Regardless of success or failure, executing an
   `sc.w` instruction invalidates any reservation held by this hart.
 
   <%- if MXLEN == 64 -%>
   [NOTE]
   If a value other than 0 or 1 is defined as a result for `sc.w`, the value will before
-  sign-extended into _rd_.
+  sign-extended into _xd_.
   <%- end -%>
 
   The failure code with value 1 encodes an unspecified failure.
   Other failure codes are reserved at this time.
   Portable software should only assume the failure code will be non-zero.
 
-  The address held in _rs1_ must be naturally aligned to the size of the operand
+  The address held in _xs1_ must be naturally aligned to the size of the operand
   (_i.e._, eight-byte aligned for doublewords and four-byte aligned for words).
   If the address is not naturally aligned, an address-misaligned exception or an
   access-fault exception will be generated.
@@ -105,19 +105,21 @@ description: |
   LR.rl and SC.aq instructions are not guaranteed to provide any stronger ordering than those
   with both bits clear, but may result in lower performance.
 definedBy: Zalrsc
-assembly: xd, xs2, xs1
+assembly: xd, xs2, (xs1)
 encoding:
   match: 00011------------010-----0101111
   variables:
     - name: aq
       location: 26
+      not: 1
     - name: rl
       location: 25
-    - name: rs2
+      not: 1
+    - name: xs2
       location: 24-20
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always
@@ -131,8 +133,8 @@ operation(): |
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg virtual_address = X[rs1];
-  XReg value = X[rs2];
+  XReg virtual_address = X[xs1];
+  XReg value = X[xs2];
 
   if (!is_naturally_aligned<32>(virtual_address)) {
     # can raise either LoadAddressMisaligned *or* LoadAccessFault
@@ -153,7 +155,7 @@ operation(): |
   }
 
   Boolean success = store_conditional<32>(virtual_address, value, aq, rl, $encoding);
-  X[rd] = success ? 0 : 1;
+  X[xd] = success ? 0 : 1;
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/arch/inst/Zfbfmin/fcvt.bf16.s.yaml
+++ b/arch/inst/Zfbfmin/fcvt.bf16.s.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfbfmin
-assembly: xd, xs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010001001000-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfbfmin/fcvt.s.bf16.yaml
+++ b/arch/inst/Zfbfmin/fcvt.s.bf16.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfbfmin
-assembly: xd, xs1, rm
+assembly: fd, fs1, rm
 encoding:
   match: 010000000110-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fadd.h.yaml
+++ b/arch/inst/Zfh/fadd.h.yaml
@@ -7,17 +7,17 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, fs2, frm
+assembly: fd, fs1, fs2, rm
 encoding:
   match: 0000010------------------1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fclass.h.yaml
+++ b/arch/inst/Zfh/fclass.h.yaml
@@ -7,13 +7,13 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1
+assembly: xd, fs1
 encoding:
   match: 111001000000-----001-----1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fcvt.d.h.yaml
+++ b/arch/inst/Zfh/fcvt.d.h.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [D, Zfh]
-assembly: fd, fs1, frm
+assembly: fd, fs1, rm
 encoding:
   match: 010000100010-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fcvt.h.d.yaml
+++ b/arch/inst/Zfh/fcvt.h.d.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [D, Zfh]
-assembly: fd, fs1, frm
+assembly: fd, fs1, rm
 encoding:
   match: 010001000001-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fcvt.h.l.yaml
+++ b/arch/inst/Zfh/fcvt.h.l.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: xd, xs1, frm
+assembly: fd, xs1, rm
 encoding:
   match: 110101000010-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fcvt.h.lu.yaml
+++ b/arch/inst/Zfh/fcvt.h.lu.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: xd, xs1, frm
+assembly: fd, xs1, rm
 encoding:
   match: 110101000011-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fcvt.h.s.yaml
+++ b/arch/inst/Zfh/fcvt.h.s.yaml
@@ -6,7 +6,7 @@ name: fcvt.h.s
 long_name: Convert half-precision float to a single-precision float
 definedBy:
   allOf: [Zfh, Zfhmin]
-assembly: fd, fs1, frm
+assembly: fd, fs1, rm
 description: |
   Converts a half-precision number in floating-point register _fs1_ into a single-precision floating-point number in
   floating-point register _fd_.

--- a/arch/inst/Zfh/fcvt.h.w.yaml
+++ b/arch/inst/Zfh/fcvt.h.w.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: xd, xs1, frm
+assembly: fd, xs1, rm
 encoding:
   match: 110101000000-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fcvt.h.wu.yaml
+++ b/arch/inst/Zfh/fcvt.h.wu.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: xd, xs1, frm
+assembly: fd, xs1, rm
 encoding:
   match: 110101000001-------------1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fcvt.l.h.yaml
+++ b/arch/inst/Zfh/fcvt.l.h.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, frm
+assembly: xd, fs1, rm
 encoding:
   match: 110001000010-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fcvt.lu.h.yaml
+++ b/arch/inst/Zfh/fcvt.lu.h.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, frm
+assembly: xd, fs1, rm
 encoding:
   match: 110001000011-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fcvt.s.h.yaml
+++ b/arch/inst/Zfh/fcvt.s.h.yaml
@@ -6,7 +6,7 @@ name: fcvt.s.h
 long_name: Convert single-precision float to a half-precision float
 definedBy:
   allOf: [Zfh, Zfhmin]
-assembly: fd, fs1, frm
+assembly: fd, fs1, rm
 description: |
   Converts a single-precision number in floating-point register _fs1_ into a half-precision floating-point number in
   floating-point register _fd_.

--- a/arch/inst/Zfh/fcvt.w.h.yaml
+++ b/arch/inst/Zfh/fcvt.w.h.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, frm
+assembly: xd, fs1, rm
 encoding:
   match: 110001000000-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fcvt.wu.h.yaml
+++ b/arch/inst/Zfh/fcvt.wu.h.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, frm
+assembly: xd, fs1, rm
 encoding:
   match: 110001000001-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fdiv.h.yaml
+++ b/arch/inst/Zfh/fdiv.h.yaml
@@ -7,17 +7,17 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, fs2, frm
+assembly: fd, fs1, fs2, rm
 encoding:
   match: 0001110------------------1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/feq.h.yaml
+++ b/arch/inst/Zfh/feq.h.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, fs2
+assembly: xd, fs1, fs2
 encoding:
   match: 1010010----------010-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fle.h.yaml
+++ b/arch/inst/Zfh/fle.h.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, fs2
+assembly: xd, fs1, fs2
 encoding:
   match: 1010010----------000-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fleq.h.yaml
+++ b/arch/inst/Zfh/fleq.h.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [Zfa, Zfh]
-assembly: fd, fs1, fs2
+assembly: xd, fs1, fs2
 encoding:
   match: 1010010----------100-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/flh.yaml
+++ b/arch/inst/Zfh/flh.yaml
@@ -5,7 +5,7 @@ kind: instruction
 name: flh
 long_name: Half-precision floating-point load
 description: |
-  The `flh` instruction loads a single-precision floating-point value from memory at address _xs1_ + _imm_ into floating-point register _rd_.
+  The `flh` instruction loads a single-precision floating-point value from memory at address _xs1_ + _imm_ into floating-point register _xd_.
 
   `flh` does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
 
@@ -13,7 +13,7 @@ description: |
 
 definedBy:
   anyOf: [Zfh, Zfhmin, Zhinx]
-assembly: xd, imm12(xs1)
+assembly: fd, imm(xs1)
 encoding:
   match: -----------------001-----0000111
   variables:

--- a/arch/inst/Zfh/fli.h.yaml
+++ b/arch/inst/Zfh/fli.h.yaml
@@ -8,11 +8,11 @@ description: |
   No description available.
 definedBy:
   allOf: [Zfa, Zfh]
-assembly: fd, imm
+assembly: fd, xs1
 encoding:
   match: 111101000001-----000-----1010011
   variables:
-    - name: imm
+    - name: xs1
       location: 19-15
     - name: fd
       location: 11-7

--- a/arch/inst/Zfh/flt.h.yaml
+++ b/arch/inst/Zfh/flt.h.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, fs2
+assembly: xd, fs1, fs2
 encoding:
   match: 1010010----------001-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fltq.h.yaml
+++ b/arch/inst/Zfh/fltq.h.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [Zfa, Zfh]
-assembly: fd, fs1, fs2
+assembly: xd, fs1, fs2
 encoding:
   match: 1010010----------101-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fmadd.h.yaml
+++ b/arch/inst/Zfh/fmadd.h.yaml
@@ -7,19 +7,19 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, fs2, fs3, frm
+assembly: fd, fs1, fs2, fs3, rm
 encoding:
   match: -----10------------------1000011
   variables:
-    - name: rs3
+    - name: fs3
       location: 31-27
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fmax.h.yaml
+++ b/arch/inst/Zfh/fmax.h.yaml
@@ -11,11 +11,11 @@ assembly: fd, fs1, fs2
 encoding:
   match: 0010110----------001-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fmaxm.h.yaml
+++ b/arch/inst/Zfh/fmaxm.h.yaml
@@ -12,11 +12,11 @@ assembly: fd, fs1, fs2
 encoding:
   match: 0010110----------011-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fmin.h.yaml
+++ b/arch/inst/Zfh/fmin.h.yaml
@@ -11,11 +11,11 @@ assembly: fd, fs1, fs2
 encoding:
   match: 0010110----------000-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fminm.h.yaml
+++ b/arch/inst/Zfh/fminm.h.yaml
@@ -12,11 +12,11 @@ assembly: fd, fs1, fs2
 encoding:
   match: 0010110----------010-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fmsub.h.yaml
+++ b/arch/inst/Zfh/fmsub.h.yaml
@@ -7,19 +7,19 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, fs2, fs3, frm
+assembly: fd, fs1, fs2, fs3, rm
 encoding:
   match: -----10------------------1000111
   variables:
-    - name: rs3
+    - name: fs3
       location: 31-27
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fmul.h.yaml
+++ b/arch/inst/Zfh/fmul.h.yaml
@@ -7,17 +7,17 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, fs2, frm
+assembly: fd, fs1, fs2, rm
 encoding:
   match: 0001010------------------1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fmv.h.x.yaml
+++ b/arch/inst/Zfh/fmv.h.x.yaml
@@ -6,15 +6,15 @@ name: fmv.h.x
 long_name: Half-precision floating-point move from integer
 description: |
   Moves the half-precision value encoded in IEEE 754-2008 standard encoding
-  from the lower 16 bits of integer register `rs1` to the floating-point
+  from the lower 16 bits of integer register `xs1` to the floating-point
   register `fd`. The bits are not modified in the transfer, and in particular,
   the payloads of non-canonical NaNs are preserved.
 definedBy: F
-assembly: xd, xs1
+assembly: fd, xs1
 encoding:
   match: 111101000000-----000-----1010011
   variables:
-    - name: rs1
+    - name: xs1
       location: 19-15
     - name: fd
       location: 11-7
@@ -26,7 +26,7 @@ access:
 operation(): |
   check_f_ok($encoding);
 
-  Bits<16> hp_value = X[rs1][15:0];
+  Bits<16> hp_value = X[xs1][15:0];
 
   f[fd] = nan_box<16, FLEN>(hp_value);
 

--- a/arch/inst/Zfh/fmv.x.h.yaml
+++ b/arch/inst/Zfh/fmv.x.h.yaml
@@ -6,10 +6,10 @@ name: fmv.x.h
 long_name: Move half-precision value from floating-point to integer register
 definedBy:
   anyOf: [Zfh, Zfhmin, Zhinx]
-assembly: fd, fs1
+assembly: xd, fs1
 description: |
-  Moves the half-precision value in floating-point register rs1 represented in IEEE 754-2008
-  encoding to the lower 16 bits of integer register rd.
+  Moves the half-precision value in floating-point register fs1 represented in IEEE 754-2008
+  encoding to the lower 16 bits of integer register xd.
 
   The bits are not modified in the transfer, and in particular, the payloads of non-canonical
   NaNs are preserved.
@@ -21,7 +21,7 @@ encoding:
   variables:
     - name: fs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always
@@ -31,7 +31,7 @@ access:
 operation(): |
   check_f_ok($encoding);
 
-  X[rd] = sext(f[fs1][15:0], 16);
+  X[xd] = sext(f[fs1][15:0], 16);
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/arch/inst/Zfh/fnmadd.h.yaml
+++ b/arch/inst/Zfh/fnmadd.h.yaml
@@ -7,19 +7,19 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, fs2, fs3, frm
+assembly: fd, fs1, fs2, fs3, rm
 encoding:
   match: -----10------------------1001111
   variables:
-    - name: rs3
+    - name: fs3
       location: 31-27
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fnmsub.h.yaml
+++ b/arch/inst/Zfh/fnmsub.h.yaml
@@ -7,19 +7,19 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, fs2, fs3, frm
+assembly: fd, fs1, fs2, fs3, rm
 encoding:
   match: -----10------------------1001011
   variables:
-    - name: rs3
+    - name: fs3
       location: 31-27
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fround.h.yaml
+++ b/arch/inst/Zfh/fround.h.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [Zfa, Zfh]
-assembly: fd, fs1, frm
+assembly: fd, fs1, rm
 encoding:
   match: 010001000100-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/froundnx.h.yaml
+++ b/arch/inst/Zfh/froundnx.h.yaml
@@ -8,15 +8,15 @@ description: |
   No description available.
 definedBy:
   allOf: [Zfa, Zfh]
-assembly: fd, fs1, frm
+assembly: fd, fs1, rm
 encoding:
   match: 010001000101-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fsgnj.h.yaml
+++ b/arch/inst/Zfh/fsgnj.h.yaml
@@ -11,11 +11,11 @@ assembly: fd, fs1, fs2
 encoding:
   match: 0010010----------000-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fsgnjn.h.yaml
+++ b/arch/inst/Zfh/fsgnjn.h.yaml
@@ -11,11 +11,11 @@ assembly: fd, fs1, fs2
 encoding:
   match: 0010010----------001-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fsgnjx.h.yaml
+++ b/arch/inst/Zfh/fsgnjx.h.yaml
@@ -11,11 +11,11 @@ assembly: fd, fs1, fs2
 encoding:
   match: 0010010----------010-----1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fsh.yaml
+++ b/arch/inst/Zfh/fsh.yaml
@@ -16,7 +16,7 @@ description: |
 
 definedBy:
   anyOf: [Zfh, Zfhmin, Zhinx]
-assembly: fs2, imm12(xs1)
+assembly: fs2, imm(xs1)
 encoding:
   match: -----------------001-----0100111
   variables:

--- a/arch/inst/Zfh/fsqrt.h.yaml
+++ b/arch/inst/Zfh/fsqrt.h.yaml
@@ -7,15 +7,15 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, frm
+assembly: fd, fs1, rm
 encoding:
   match: 010111000000-------------1010011
   variables:
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zfh/fsub.h.yaml
+++ b/arch/inst/Zfh/fsub.h.yaml
@@ -7,17 +7,17 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Zfh
-assembly: fd, fs1, fs2, frm
+assembly: fd, fs1, fs2, rm
 encoding:
   match: 0000110------------------1010011
   variables:
-    - name: rs2
+    - name: fs2
       location: 24-20
-    - name: rs1
+    - name: fs1
       location: 19-15
     - name: rm
       location: 14-12
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always

--- a/arch/inst/Zifencei/fence.i.yaml
+++ b/arch/inst/Zifencei/fence.i.yaml
@@ -17,8 +17,8 @@ description: |
   has to execute a data FENCE before requesting that all remote RISC-V
   harts execute a FENCE.I.
 
-  The unused fields in the FENCE.I instruction, _imm[11:0]_, _rs1_, and
-  _rd_, are reserved for finer-grain fences in future extensions. For
+  The unused fields in the FENCE.I instruction, _imm[11:0]_, _xs1_, and
+  _xd_, are reserved for finer-grain fences in future extensions. For
   forward compatibility, base implementations shall ignore these fields,
   and standard software shall zero these fields.
   (((FENCE.I, finer-grained)))
@@ -39,9 +39,9 @@ encoding:
   variables:
     - name: imm
       location: 31-20
-    - name: rs1
+    - name: xs1
       location: 19-15
-    - name: rd
+    - name: xd
       location: 11-7
 access:
   s: always

--- a/backends/instructions_appendix/all_instructions.golden.adoc
+++ b/backends/instructions_appendix/all_instructions.golden.adoc
@@ -6691,7 +6691,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
 ....
 
 Description::
@@ -6702,10 +6702,10 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -6727,7 +6727,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x2,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x2,"type":2}]}
 ....
 
 Description::
@@ -6738,10 +6738,10 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -6763,7 +6763,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": 0x3,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x3,"type":2}]}
 ....
 
 Description::
@@ -6774,10 +6774,10 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -6836,7 +6836,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xe20,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe20,"type":2}]}
 ....
 
 Description::
@@ -6847,8 +6847,8 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -6870,7 +6870,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xe40,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe40,"type":2}]}
 ....
 
 Description::
@@ -6881,8 +6881,8 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -6904,7 +6904,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "qs1","type":4},{"bits":12,"name": 0xe60,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe60,"type":2}]}
 ....
 
 Description::
@@ -6915,8 +6915,8 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -6938,34 +6938,34 @@ Single-precision floating-point classify
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe00,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe00,"type":2}]}
 ....
 
 Description::
 The xref:insts:fclass_s.adoc#udb:doc:inst:fclass_s[fclass.s] instruction examines the value in floating-point register
-_fs1_ and writes to integer register _rd_ a 10-bit mask that indicates
+_fs1_ and writes to integer register _xd_ a 10-bit mask that indicates
 the class of the floating-point number.
 The format of the mask is described in the table below.
-The corresponding bit in _rd_ will be set if the property is true and
+The corresponding bit in _xd_ will be set if the property is true and
 clear otherwise.
-All other bits in _rd_ are cleared.
-Note that exactly one bit in rd will be set.
+All other bits in _xd_ are cleared.
+Note that exactly one bit in xd will be set.
 xref:insts:fclass_s.adoc#udb:doc:inst:fclass_s[fclass.s] does not set the floating-point exception flags.
 
 .Format of result of `fclass` instruction.
 [%autowidth,float="center",align="center",cols="^,<",options="header",]
 |===
-|_rd_ bit |Meaning
-|0 |_rs1_ is latexmath:[$-\infty$].
-|1 |_rs1_ is a negative normal number.
-|2 |_rs1_ is a negative subnormal number.
-|3 |_rs1_ is latexmath:[$-0$].
-|4 |_rs1_ is latexmath:[$+0$].
-|5 |_rs1_ is a positive subnormal number.
-|6 |_rs1_ is a positive normal number.
-|7 |_rs1_ is latexmath:[$+\infty$].
-|8 |_rs1_ is a signaling NaN.
-|9 |_rs1_ is a quiet NaN.
+|_xd_ bit |Meaning
+|0 |_fs1_ is latexmath:[$-\infty$].
+|1 |_fs1_ is a negative normal number.
+|2 |_fs1_ is a negative subnormal number.
+|3 |_fs1_ is latexmath:[$-0$].
+|4 |_fs1_ is latexmath:[$+0$].
+|5 |_fs1_ is a positive subnormal number.
+|6 |_fs1_ is a positive normal number.
+|7 |_fs1_ is latexmath:[$+\infty$].
+|8 |_fs1_ is a signaling NaN.
+|9 |_fs1_ is a quiet NaN.
 |===
 
 
@@ -6974,7 +6974,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |fs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -6996,7 +6996,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0x448,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x448,"type":2}]}
 ....
 
 Description::
@@ -7007,9 +7007,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7031,7 +7031,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0x422,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x422,"type":2}]}
 ....
 
 Description::
@@ -7042,9 +7042,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7068,7 +7068,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd22,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd22,"type":2}]}
 ....
 
 Description::
@@ -7079,9 +7079,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7103,7 +7103,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd23,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd23,"type":2}]}
 ....
 
 Description::
@@ -7114,9 +7114,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7138,7 +7138,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":12,"name": 0x423,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x423,"type":2}]}
 ....
 
 Description::
@@ -7149,9 +7149,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7173,7 +7173,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0x420,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x420,"type":2}]}
 ....
 
 Description::
@@ -7184,9 +7184,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7208,7 +7208,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd20,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd20,"type":2}]}
 ....
 
 Description::
@@ -7219,9 +7219,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7243,7 +7243,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd21,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd21,"type":2}]}
 ....
 
 Description::
@@ -7254,9 +7254,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7278,7 +7278,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0x441,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x441,"type":2}]}
 ....
 
 Description::
@@ -7289,9 +7289,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7315,7 +7315,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd42,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd42,"type":2}]}
 ....
 
 Description::
@@ -7326,9 +7326,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7350,7 +7350,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd43,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd43,"type":2}]}
 ....
 
 Description::
@@ -7361,9 +7361,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7385,7 +7385,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":12,"name": 0x443,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x443,"type":2}]}
 ....
 
 Description::
@@ -7396,9 +7396,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7465,7 +7465,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd40,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd40,"type":2}]}
 ....
 
 Description::
@@ -7476,9 +7476,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7500,7 +7500,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd41,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd41,"type":2}]}
 ....
 
 Description::
@@ -7511,9 +7511,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7535,7 +7535,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xc22,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc22,"type":2}]}
 ....
 
 Description::
@@ -7546,9 +7546,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -7570,7 +7570,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xc42,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc42,"type":2}]}
 ....
 
 Description::
@@ -7581,9 +7581,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -7605,7 +7605,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":12,"name": 0xc62,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc62,"type":2}]}
 ....
 
 Description::
@@ -7616,9 +7616,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -7640,7 +7640,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc02,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc02,"type":2}]}
 ....
 
 Description::
@@ -7653,7 +7653,7 @@ Decode Variables::
 |Variable Name |Location
 |fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -7675,7 +7675,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xc23,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc23,"type":2}]}
 ....
 
 Description::
@@ -7686,9 +7686,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -7710,7 +7710,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xc43,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc43,"type":2}]}
 ....
 
 Description::
@@ -7721,9 +7721,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -7745,7 +7745,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "hs1","type":4},{"bits":12,"name": 0xc63,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc63,"type":2}]}
 ....
 
 Description::
@@ -7756,9 +7756,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|hs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -7780,7 +7780,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc03,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc03,"type":2}]}
 ....
 
 Description::
@@ -7793,7 +7793,7 @@ Decode Variables::
 |Variable Name |Location
 |fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -7815,7 +7815,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "dd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x461,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x461,"type":2}]}
 ....
 
 Description::
@@ -7828,7 +7828,7 @@ Decode Variables::
 |Variable Name |Location
 |fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|dd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7850,7 +7850,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "hd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":12,"name": 0x462,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x462,"type":2}]}
 ....
 
 Description::
@@ -7861,9 +7861,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|hd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7887,7 +7887,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd62,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd62,"type":2}]}
 ....
 
 Description::
@@ -7898,9 +7898,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7922,7 +7922,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd63,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd63,"type":2}]}
 ....
 
 Description::
@@ -7933,9 +7933,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7957,7 +7957,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x460,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x460,"type":2}]}
 ....
 
 Description::
@@ -7970,7 +7970,7 @@ Decode Variables::
 |Variable Name |Location
 |fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -7992,7 +7992,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd60,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd60,"type":2}]}
 ....
 
 Description::
@@ -8003,7 +8003,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
 |fd |$encoding[11:7]
 |===
@@ -8027,7 +8027,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd61,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd61,"type":2}]}
 ....
 
 Description::
@@ -8038,9 +8038,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -8062,7 +8062,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0x406,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x406,"type":2}]}
 ....
 
 Description::
@@ -8073,9 +8073,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -8097,7 +8097,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0x401,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x401,"type":2}]}
 ....
 
 Description::
@@ -8108,9 +8108,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -8172,7 +8172,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd02,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd02,"type":2}]}
 ....
 
 Description::
@@ -8183,7 +8183,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
 |fd |$encoding[11:7]
 |===
@@ -8207,7 +8207,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd03,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd03,"type":2}]}
 ....
 
 Description::
@@ -8218,7 +8218,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
 |fd |$encoding[11:7]
 |===
@@ -8242,7 +8242,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":12,"name": 0x403,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x403,"type":2}]}
 ....
 
 Description::
@@ -8253,7 +8253,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
 |fd |$encoding[11:7]
 |===
@@ -8277,17 +8277,17 @@ Convert signed 32-bit integer to single-precision float
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd00,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd00,"type":2}]}
 ....
 
 Description::
-Converts a 32-bit signed integer in integer register _rs1_ into a floating-point number in
+Converts a 32-bit signed integer in integer register _xs1_ into a floating-point number in
 floating-point register _fd_.
 
 All floating-point to integer and integer to floating-point conversion instructions round
 according to the _rm_ field.
 A floating-point register can be initialized to floating-point positive zero using
-`fcvt.s.w rd, x0`, which will never set any exception flags.
+`fcvt.s.w fd, x0`, which will never set any exception flags.
 
 All floating-point conversion instructions set the Inexact exception flag if the rounded
 result differs from the operand value and the Invalid exception flag is not set.
@@ -8297,7 +8297,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
 |fd |$encoding[11:7]
 |===
@@ -8321,11 +8321,11 @@ Convert unsigned 32-bit integer to single-precision float
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xd01,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd01,"type":2}]}
 ....
 
 Description::
-Converts a 32-bit unsigned integer in integer register _rs1_ into a floating-point number in
+Converts a 32-bit unsigned integer in integer register _xs1_ into a floating-point number in
 floating-point register _fd_.
 
 All floating-point to integer and integer to floating-point conversion instructions round
@@ -8341,7 +8341,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |rm |$encoding[14:12]
 |fd |$encoding[11:7]
 |===
@@ -8365,7 +8365,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xc20,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc20,"type":2}]}
 ....
 
 Description::
@@ -8376,9 +8376,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -8400,7 +8400,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xc40,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc40,"type":2}]}
 ....
 
 Description::
@@ -8411,9 +8411,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -8435,7 +8435,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":12,"name": 0xc60,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc60,"type":2}]}
 ....
 
 Description::
@@ -8446,9 +8446,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -8533,7 +8533,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xc21,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc21,"type":2}]}
 ....
 
 Description::
@@ -8544,9 +8544,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -8568,7 +8568,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xc41,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc41,"type":2}]}
 ....
 
 Description::
@@ -8579,9 +8579,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -8603,7 +8603,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xc61,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc61,"type":2}]}
 ....
 
 Description::
@@ -8614,9 +8614,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -8700,7 +8700,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xc28,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm != {0,2,3,4,5,6,7}","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc28,"type":2}]}
 ....
 
 Description::
@@ -8711,8 +8711,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -8736,7 +8737,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0xd,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0xd,"type":2}]}
 ....
 
 Description::
@@ -8747,10 +8748,10 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -8772,7 +8773,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0xe,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0xe,"type":2}]}
 ....
 
 Description::
@@ -8783,10 +8784,10 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -8808,7 +8809,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": 0xf,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0xf,"type":2}]}
 ....
 
 Description::
@@ -8819,10 +8820,10 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -9030,7 +9031,7 @@ Instruction fence
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0xf,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": "imm","type":4}]}
+{"reg":[{"bits":7,"name": 0xf,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
 ....
 
 Description::
@@ -9046,8 +9047,8 @@ instruction memory visible to all RISC-V harts, the writing hart also
 has to execute a data FENCE before requesting that all remote RISC-V
 harts execute a FENCE.I.
 
-The unused fields in the FENCE.I instruction, _imm[11:0]_, _rs1_, and
-_rd_, are reserved for finer-grain fences in future extensions. For
+The unused fields in the FENCE.I instruction, _imm[11:0]_, _xs1_, and
+_xd_, are reserved for finer-grain fences in future extensions. For
 forward compatibility, base implementations shall ignore these fields,
 and standard software shall zero these fields.
 (((FENCE.I, finer-grained)))
@@ -9068,8 +9069,8 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |$encoding[31:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9091,7 +9092,7 @@ Memory ordering fence, total store ordering
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0xf,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0x833,"type":2}]}
+{"reg":[{"bits":7,"name": 0xf,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x833,"type":2}]}
 ....
 
 Description::
@@ -9102,7 +9103,7 @@ in its predecessor set before all memory operations in its successor set, and al
 in its predecessor set before all store operations in its successor set. This leaves non-AMO store
 operations in the 'fence.tso's predecessor set unordered with non-AMO loads in its successor set.
 
-The `rs1` and `rd` fields are unused and ignored.
+The `xs1` and `xd` fields are unused and ignored.
 
 In modes other than M-mode, xref:insts:fence_tso.adoc#udb:doc:inst:fence_tso[fence.tso] is further affected by xref:csrs:menvcfg.adoc#udb:doc:csr_field:menvcfg:FIOM[menvcfg.FIOM],
 xref:csrs:senvcfg.adoc#udb:doc:csr_field:senvcfg:FIOM[senvcfg.FIOM]<% if ext?(:H) %>, and/or xref:csrs:henvcfg.adoc#udb:doc:csr_field:henvcfg:FIOM[henvcfg.FIOM]<% end %>.
@@ -9112,8 +9113,8 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9135,7 +9136,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
 ....
 
 Description::
@@ -9146,9 +9147,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9170,7 +9171,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x52,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x52,"type":2}]}
 ....
 
 Description::
@@ -9181,9 +9182,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9205,7 +9206,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
 ....
 
 Description::
@@ -9216,9 +9217,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9240,11 +9241,11 @@ Single-precision floating-point equal
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x50,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x50,"type":2}]}
 ....
 
 Description::
-Writes 1 to _rd_ if _fs1_ and _fs2_ are equal, and 0 otherwise.
+Writes 1 to _xd_ if _fs1_ and _fs2_ are equal, and 0 otherwise.
 
 If either operand is NaN, the result is 0 (not equal). If either operand is a signaling NaN, the invalid flag is set.
 
@@ -9257,7 +9258,7 @@ Decode Variables::
 |Variable Name |Location
 |fs2 |$encoding[24:20]
 |fs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9314,7 +9315,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
 ....
 
 Description::
@@ -9325,9 +9326,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9349,7 +9350,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x52,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x52,"type":2}]}
 ....
 
 Description::
@@ -9360,9 +9361,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9384,7 +9385,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
 ....
 
 Description::
@@ -9395,9 +9396,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9419,11 +9420,11 @@ Single-precision floating-point less than or equal
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x50,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x50,"type":2}]}
 ....
 
 Description::
-Writes 1 to _rd_ if _fs1_ is less than or equal to _fs2_, and 0 otherwise.
+Writes 1 to _xd_ if _fs1_ is less than or equal to _fs2_, and 0 otherwise.
 
 If either operand is NaN, the result is 0 (not equal).
 If either operand is a NaN (signaling or quiet), the invalid flag is set.
@@ -9437,7 +9438,7 @@ Decode Variables::
 |Variable Name |Location
 |fs2 |$encoding[24:20]
 |fs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9459,7 +9460,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
 ....
 
 Description::
@@ -9470,9 +9471,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9496,7 +9497,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x52,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x52,"type":2}]}
 ....
 
 Description::
@@ -9507,9 +9508,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9533,7 +9534,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
 ....
 
 Description::
@@ -9544,9 +9545,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9570,7 +9571,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x50,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x50,"type":2}]}
 ....
 
 Description::
@@ -9583,7 +9584,7 @@ Decode Variables::
 |Variable Name |Location
 |fs2 |$encoding[24:20]
 |fs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9609,7 +9610,7 @@ Encoding::
 ....
 
 Description::
-The xref:insts:flh.adoc#udb:doc:inst:flh[flh] instruction loads a single-precision floating-point value from memory at address _xs1_ + _imm_ into floating-point register _rd_.
+The xref:insts:flh.adoc#udb:doc:inst:flh[flh] instruction loads a single-precision floating-point value from memory at address _xs1_ + _imm_ into floating-point register _xd_.
 
 xref:insts:flh.adoc#udb:doc:inst:flh[flh] does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
 
@@ -9648,7 +9649,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xf21,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xf21,"type":2}]}
 ....
 
 Description::
@@ -9659,8 +9660,8 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -9684,7 +9685,7 @@ Floating-point Load Immediate Half-precision
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "imm","type":4},{"bits":12,"name": 0xf41,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xf41,"type":2}]}
 ....
 
 Description::
@@ -9695,7 +9696,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |fd |$encoding[11:7]
 |===
 
@@ -9720,7 +9721,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "qs1","type":4},{"bits":12,"name": 0xf61,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xf61,"type":2}]}
 ....
 
 Description::
@@ -9731,7 +9732,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |fd |$encoding[11:7]
 |===
 
@@ -9756,7 +9757,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xf01,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xf01,"type":2}]}
 ....
 
 Description::
@@ -9767,7 +9768,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|fs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |fd |$encoding[11:7]
 |===
 
@@ -9790,7 +9791,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
 ....
 
 Description::
@@ -9803,7 +9804,7 @@ Decode Variables::
 |Variable Name |Location
 |imm |$encoding[31:20]
 |xs1 |$encoding[19:15]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -9825,7 +9826,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
 ....
 
 Description::
@@ -9836,9 +9837,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9860,7 +9861,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x52,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x52,"type":2}]}
 ....
 
 Description::
@@ -9871,9 +9872,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9895,7 +9896,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
 ....
 
 Description::
@@ -9906,9 +9907,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9930,11 +9931,11 @@ Single-precision floating-point less than
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x50,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x50,"type":2}]}
 ....
 
 Description::
-Writes 1 to _rd_ if _fs1_ is less than _fs2_, and 0 otherwise.
+Writes 1 to _xd_ if _fs1_ is less than _fs2_, and 0 otherwise.
 
 If either operand is NaN, the result is 0 (not equal).
 If either operand is a NaN (signaling or quiet), the invalid flag is set.
@@ -9946,7 +9947,7 @@ Decode Variables::
 |Variable Name |Location
 |fs2 |$encoding[24:20]
 |fs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -9968,7 +9969,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
 ....
 
 Description::
@@ -9979,9 +9980,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -10005,7 +10006,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x52,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x52,"type":2}]}
 ....
 
 Description::
@@ -10016,9 +10017,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -10042,7 +10043,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
 ....
 
 Description::
@@ -10053,9 +10054,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
-|qd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10079,7 +10080,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x50,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x50,"type":2}]}
 ....
 
 Description::
@@ -10092,7 +10093,7 @@ Decode Variables::
 |Variable Name |Location
 |fs2 |$encoding[24:20]
 |fs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -10151,7 +10152,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x43,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "rs3","type":4}]}
+{"reg":[{"bits":7,"name": 0x43,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "fs3","type":4}]}
 ....
 
 Description::
@@ -10162,11 +10163,11 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs3 |$encoding[31:27]
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10188,7 +10189,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x43,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "rs3","type":4}]}
+{"reg":[{"bits":7,"name": 0x43,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "fs3","type":4}]}
 ....
 
 Description::
@@ -10199,11 +10200,11 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs3 |$encoding[31:27]
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10225,7 +10226,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x43,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":5,"name": "qs3","type":4}]}
+{"reg":[{"bits":7,"name": 0x43,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":5,"name": "fs3","type":4}]}
 ....
 
 Description::
@@ -10236,11 +10237,11 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs3 |$encoding[31:27]
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10299,7 +10300,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x15,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x15,"type":2}]}
 ....
 
 Description::
@@ -10310,9 +10311,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10334,7 +10335,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x16,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x16,"type":2}]}
 ....
 
 Description::
@@ -10345,9 +10346,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10369,7 +10370,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": 0x17,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x17,"type":2}]}
 ....
 
 Description::
@@ -10380,9 +10381,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
-|qd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10439,7 +10440,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x15,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x15,"type":2}]}
 ....
 
 Description::
@@ -10450,9 +10451,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10476,7 +10477,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x16,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x16,"type":2}]}
 ....
 
 Description::
@@ -10487,9 +10488,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10513,7 +10514,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": 0x17,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x17,"type":2}]}
 ....
 
 Description::
@@ -10524,9 +10525,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
-|qd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10585,7 +10586,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x15,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x15,"type":2}]}
 ....
 
 Description::
@@ -10596,9 +10597,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10620,7 +10621,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x16,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x16,"type":2}]}
 ....
 
 Description::
@@ -10631,9 +10632,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10655,7 +10656,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x17,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x17,"type":2}]}
 ....
 
 Description::
@@ -10666,9 +10667,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10725,7 +10726,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x15,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x15,"type":2}]}
 ....
 
 Description::
@@ -10736,9 +10737,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10762,7 +10763,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x16,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x16,"type":2}]}
 ....
 
 Description::
@@ -10773,9 +10774,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10799,7 +10800,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": 0x17,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x17,"type":2}]}
 ....
 
 Description::
@@ -10810,9 +10811,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
-|qd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10871,7 +10872,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x47,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "rs3","type":4}]}
+{"reg":[{"bits":7,"name": 0x47,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "fs3","type":4}]}
 ....
 
 Description::
@@ -10882,11 +10883,11 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs3 |$encoding[31:27]
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10908,7 +10909,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x47,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "rs3","type":4}]}
+{"reg":[{"bits":7,"name": 0x47,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "fs3","type":4}]}
 ....
 
 Description::
@@ -10919,11 +10920,11 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs3 |$encoding[31:27]
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -10945,7 +10946,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x47,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":5,"name": "qs3","type":4}]}
+{"reg":[{"bits":7,"name": 0x47,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":5,"name": "fs3","type":4}]}
 ....
 
 Description::
@@ -10956,11 +10957,11 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs3 |$encoding[31:27]
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11019,7 +11020,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x9,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x9,"type":2}]}
 ....
 
 Description::
@@ -11030,10 +11031,10 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11055,7 +11056,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0xa,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0xa,"type":2}]}
 ....
 
 Description::
@@ -11066,10 +11067,10 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11091,7 +11092,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": 0xb,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0xb,"type":2}]}
 ....
 
 Description::
@@ -11102,10 +11103,10 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11163,7 +11164,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xf20,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xf20,"type":2}]}
 ....
 
 Description::
@@ -11174,8 +11175,8 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11197,12 +11198,12 @@ Half-precision floating-point move from integer
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xf40,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xf40,"type":2}]}
 ....
 
 Description::
 Moves the half-precision value encoded in IEEE 754-2008 standard encoding
-from the lower 16 bits of integer register `rs1` to the floating-point
+from the lower 16 bits of integer register `xs1` to the floating-point
 register `fd`. The bits are not modified in the transfer, and in particular,
 the payloads of non-canonical NaNs are preserved.
 
@@ -11211,7 +11212,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |fd |$encoding[11:7]
 |===
 
@@ -11234,12 +11235,12 @@ Single-precision floating-point move from integer
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xf00,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xf00,"type":2}]}
 ....
 
 Description::
 Moves the single-precision value encoded in IEEE 754-2008 standard encoding
-from the lower 32 bits of integer register `rs1` to the floating-point
+from the lower 32 bits of integer register `xs1` to the floating-point
 register `fd`. The bits are not modified in the transfer, and in particular,
 the payloads of non-canonical NaNs are preserved.
 
@@ -11248,7 +11249,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|xs1 |$encoding[19:15]
 |fd |$encoding[11:7]
 |===
 
@@ -11271,7 +11272,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xe20,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe20,"type":2}]}
 ....
 
 Description::
@@ -11282,8 +11283,8 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -11305,12 +11306,12 @@ Move half-precision value from floating-point to integer register
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe40,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe40,"type":2}]}
 ....
 
 Description::
-Moves the half-precision value in floating-point register rs1 represented in IEEE 754-2008
-encoding to the lower 16 bits of integer register rd.
+Moves the half-precision value in floating-point register fs1 represented in IEEE 754-2008
+encoding to the lower 16 bits of integer register xd.
 
 The bits are not modified in the transfer, and in particular, the payloads of non-canonical
 NaNs are preserved.
@@ -11324,7 +11325,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |fs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -11350,12 +11351,12 @@ Move single-precision value from floating-point to integer register
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe00,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe00,"type":2}]}
 ....
 
 Description::
 Moves the single-precision value in floating-point register rs1 represented in IEEE 754-2008
-encoding to the lower 32 bits of integer register rd.
+encoding to the lower 32 bits of integer register xd.
 The bits are not modified in the transfer, and in particular, the payloads of non-canonical
 NaNs are preserved.
 For RV64, the higher 32 bits of the destination register are filled with copies of the
@@ -11367,7 +11368,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |fs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -11389,7 +11390,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0xe21,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe21,"type":2}]}
 ....
 
 Description::
@@ -11400,8 +11401,8 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -11425,7 +11426,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "qs1","type":4},{"bits":12,"name": 0xe61,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe61,"type":2}]}
 ....
 
 Description::
@@ -11436,8 +11437,8 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -11461,7 +11462,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x59,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x59,"type":2}]}
 ....
 
 Description::
@@ -11472,9 +11473,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11498,7 +11499,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x5b,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x5b,"type":2}]}
 ....
 
 Description::
@@ -11509,9 +11510,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11535,7 +11536,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x4f,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "rs3","type":4}]}
+{"reg":[{"bits":7,"name": 0x4f,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "fs3","type":4}]}
 ....
 
 Description::
@@ -11546,11 +11547,11 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs3 |$encoding[31:27]
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11572,7 +11573,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x4f,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "rs3","type":4}]}
+{"reg":[{"bits":7,"name": 0x4f,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "fs3","type":4}]}
 ....
 
 Description::
@@ -11583,11 +11584,11 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs3 |$encoding[31:27]
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11609,7 +11610,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x4f,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":5,"name": "qs3","type":4}]}
+{"reg":[{"bits":7,"name": 0x4f,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":5,"name": "fs3","type":4}]}
 ....
 
 Description::
@@ -11620,11 +11621,11 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs3 |$encoding[31:27]
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11683,7 +11684,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x4b,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "rs3","type":4}]}
+{"reg":[{"bits":7,"name": 0x4b,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "fs3","type":4}]}
 ....
 
 Description::
@@ -11694,11 +11695,11 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs3 |$encoding[31:27]
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11720,7 +11721,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x4b,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "rs3","type":4}]}
+{"reg":[{"bits":7,"name": 0x4b,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "fs3","type":4}]}
 ....
 
 Description::
@@ -11731,11 +11732,11 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs3 |$encoding[31:27]
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11757,7 +11758,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x4b,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":5,"name": "qs3","type":4}]}
+{"reg":[{"bits":7,"name": 0x4b,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":5,"name": "fs3","type":4}]}
 ....
 
 Description::
@@ -11768,11 +11769,11 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs3 |$encoding[31:27]
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11831,7 +11832,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0x424,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x424,"type":2}]}
 ....
 
 Description::
@@ -11842,9 +11843,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11868,7 +11869,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0x444,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x444,"type":2}]}
 ....
 
 Description::
@@ -11879,9 +11880,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11905,7 +11906,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":12,"name": 0x464,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x464,"type":2}]}
 ....
 
 Description::
@@ -11916,9 +11917,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -11942,7 +11943,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0x404,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x404,"type":2}]}
 ....
 
 Description::
@@ -11953,7 +11954,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
 |fd |$encoding[11:7]
 |===
@@ -11977,7 +11978,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0x425,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x425,"type":2}]}
 ....
 
 Description::
@@ -11988,9 +11989,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12014,7 +12015,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0x445,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x445,"type":2}]}
 ....
 
 Description::
@@ -12025,9 +12026,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12051,7 +12052,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":12,"name": 0x465,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x465,"type":2}]}
 ....
 
 Description::
@@ -12062,9 +12063,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12088,7 +12089,7 @@ Floating-point Round Single-precision to Integer with Inexact
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x405,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x405,"type":2}]}
 ....
 
 Description::
@@ -12099,7 +12100,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|xs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
 |fd |$encoding[11:7]
 |===
@@ -12158,7 +12159,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x11,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x11,"type":2}]}
 ....
 
 Description::
@@ -12169,9 +12170,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12193,7 +12194,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x12,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x12,"type":2}]}
 ....
 
 Description::
@@ -12204,9 +12205,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12228,7 +12229,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": 0x13,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x13,"type":2}]}
 ....
 
 Description::
@@ -12239,9 +12240,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
-|qd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12300,7 +12301,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x11,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x11,"type":2}]}
 ....
 
 Description::
@@ -12311,9 +12312,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12335,7 +12336,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x12,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x12,"type":2}]}
 ....
 
 Description::
@@ -12346,9 +12347,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12370,7 +12371,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": 0x13,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x13,"type":2}]}
 ....
 
 Description::
@@ -12381,9 +12382,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
-|qd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12442,7 +12443,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x11,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x11,"type":2}]}
 ....
 
 Description::
@@ -12453,9 +12454,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12477,7 +12478,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x12,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x12,"type":2}]}
 ....
 
 Description::
@@ -12488,9 +12489,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12512,7 +12513,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": 0x13,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x13,"type":2}]}
 ....
 
 Description::
@@ -12523,9 +12524,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
-|qd |$encoding[11:7]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12630,7 +12631,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
 ....
 
 Description::
@@ -12642,7 +12643,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |{$encoding[31:25], $encoding[11:7]}
-|qs2 |$encoding[24:20]
+|fs2 |$encoding[24:20]
 |xs1 |$encoding[19:15]
 |===
 
@@ -12665,7 +12666,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0x5a0,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x5a0,"type":2}]}
 ....
 
 Description::
@@ -12676,9 +12677,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12700,7 +12701,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":12,"name": 0x5c0,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x5c0,"type":2}]}
 ....
 
 Description::
@@ -12711,9 +12712,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12735,7 +12736,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":12,"name": 0x5e0,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x5e0,"type":2}]}
 ....
 
 Description::
@@ -12746,9 +12747,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs1 |$encoding[19:15]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12805,7 +12806,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x5,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x5,"type":2}]}
 ....
 
 Description::
@@ -12816,10 +12817,10 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12841,7 +12842,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x6,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x6,"type":2}]}
 ....
 
 Description::
@@ -12852,10 +12853,10 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -12877,7 +12878,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "qd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "qs1","type":4},{"bits":5,"name": "qs2","type":4},{"bits":7,"name": 0x7,"type":2}]}
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x7,"type":2}]}
 ....
 
 Description::
@@ -12888,10 +12889,10 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|qs2 |$encoding[24:20]
-|qs1 |$encoding[19:15]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
 |rm |$encoding[14:12]
-|qd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -13681,7 +13682,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "rl","type":4},{"bits":6,"name": 0xd,"type":2}]}
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x340,"type":2}]}
 ....
 
 Description::
@@ -13692,9 +13693,8 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rl |$encoding[25]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -13825,7 +13825,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "rl","type":4},{"bits":6,"name": 0xd,"type":2}]}
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x340,"type":2}]}
 ....
 
 Description::
@@ -13836,9 +13836,8 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rl |$encoding[25]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -13897,7 +13896,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "rl","type":4},{"bits":6,"name": 0xd,"type":2}]}
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x340,"type":2}]}
 ....
 
 Description::
@@ -13908,9 +13907,8 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rl |$encoding[25]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -14002,15 +14000,15 @@ Load reserved doubleword
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x2,"type":2}]}
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "rl != 1","type":4},{"bits":1,"name": "aq != 1","type":4},{"bits":5,"name": 0x2,"type":2}]}
 ....
 
 Description::
-Loads a word from the address in rs1, places the value in rd,
+Loads a word from the address in xs1, places the value in xd,
 and registers a _reservation set_  -- a set of bytes that subsumes the bytes in the
 addressed word.
 
-The address in rs1 must be 8-byte aligned.
+The address in xs1 must be 8-byte aligned.
 
 If the address is not naturally aligned, a `LoadAddressMisaligned` exception or an
 `LoadAccessFault` exception will be generated. The access-fault exception can be generated
@@ -14051,8 +14049,8 @@ Decode Variables::
 |Variable Name |Location
 |aq |$encoding[26]
 |rl |$encoding[25]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -14074,7 +14072,7 @@ Load reserved word
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x2,"type":2}]}
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "rl != 1","type":4},{"bits":1,"name": "aq != 1","type":4},{"bits":5,"name": 0x2,"type":2}]}
 ....
 
 Description::
@@ -14221,7 +14219,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "rl","type":4},{"bits":6,"name": 0xd,"type":2}]}
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x340,"type":2}]}
 ....
 
 Description::
@@ -14232,9 +14230,8 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rl |$encoding[25]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -15599,7 +15596,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":15,"name": 0x2f,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":1,"name": 0x1,"type":2},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x7,"type":2}]}
+{"reg":[{"bits":15,"name": 0x2f,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1d,"type":2}]}
 ....
 
 Description::
@@ -15610,9 +15607,8 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|aq |$encoding[26]
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
 |===
 
 Included in::
@@ -15634,16 +15630,16 @@ Store conditional doubleword
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x3,"type":2}]}
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x3,"type":2}]}
 ....
 
 Description::
-xref:insts:sc_d.adoc#udb:doc:inst:sc_d[sc.d] conditionally writes a doubleword in _rs2_ to the address in _rs1_:
+xref:insts:sc_d.adoc#udb:doc:inst:sc_d[sc.d] conditionally writes a doubleword in _xs2_ to the address in _xs1_:
 the xref:insts:sc_d.adoc#udb:doc:inst:sc_d[sc.d] succeeds only if the reservation is still valid and the
 reservation set contains the bytes being written. If the xref:insts:sc_d.adoc#udb:doc:inst:sc_d[sc.d] succeeds,
-the instruction writes the doubleword in _rs2_ to memory, and it writes zero to _rd_.
+the instruction writes the doubleword in _xs2_ to memory, and it writes zero to _xd_.
 If the xref:insts:sc_d.adoc#udb:doc:inst:sc_d[sc.d] fails, the instruction does not write to memory, and it writes a
-nonzero value to _rd_. For the purposes of memory protection, a failed xref:insts:sc_d.adoc#udb:doc:inst:sc_d[sc.d]
+nonzero value to _xd_. For the purposes of memory protection, a failed xref:insts:sc_d.adoc#udb:doc:inst:sc_d[sc.d]
 may be treated like a store. Regardless of success or failure, executing an
 xref:insts:sc_d.adoc#udb:doc:inst:sc_d[sc.d] instruction invalidates any reservation held by this hart.
 
@@ -15651,7 +15647,7 @@ The failure code with value 1 encodes an unspecified failure.
 Other failure codes are reserved at this time.
 Portable software should only assume the failure code will be non-zero.
 
-The address held in _rs1_ must be naturally aligned to the size of the operand
+The address held in _xs1_ must be naturally aligned to the size of the operand
 (_i.e._, eight-byte aligned).
 If the address is not naturally aligned, an address-misaligned exception or an
 access-fault exception will be generated.
@@ -15739,9 +15735,9 @@ Decode Variables::
 |Variable Name |Location
 |aq |$encoding[26]
 |rl |$encoding[25]
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -15763,30 +15759,30 @@ Store conditional word
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x3,"type":2}]}
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl != 1","type":4},{"bits":1,"name": "aq != 1","type":4},{"bits":5,"name": 0x3,"type":2}]}
 ....
 
 Description::
-xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w] conditionally writes a word in _rs2_ to the address in _rs1_:
+xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w] conditionally writes a word in _xs2_ to the address in _xs1_:
 the xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w] succeeds only if the reservation is still valid and the
 reservation set contains the bytes being written. If the xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w] succeeds,
-the instruction writes the word in _rs2_ to memory, and it writes zero to _rd_.
+the instruction writes the word in _xs2_ to memory, and it writes zero to _xd_.
 If the xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w] fails, the instruction does not write to memory, and it writes a
-nonzero value to _rd_. For the purposes of memory protection, a failed xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w]
+nonzero value to _xd_. For the purposes of memory protection, a failed xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w]
 may be treated like a store. Regardless of success or failure, executing an
 xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w] instruction invalidates any reservation held by this hart.
 
 <%- if MXLEN == 64 -%>
 [NOTE]
 If a value other than 0 or 1 is defined as a result for xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w], the value will before
-sign-extended into _rd_.
+sign-extended into _xd_.
 <%- end -%>
 
 The failure code with value 1 encodes an unspecified failure.
 Other failure codes are reserved at this time.
 Portable software should only assume the failure code will be non-zero.
 
-The address held in _rs1_ must be naturally aligned to the size of the operand
+The address held in _xs1_ must be naturally aligned to the size of the operand
 (_i.e._, eight-byte aligned for doublewords and four-byte aligned for words).
 If the address is not naturally aligned, an address-misaligned exception or an
 access-fault exception will be generated.
@@ -15874,9 +15870,9 @@ Decode Variables::
 |Variable Name |Location
 |aq |$encoding[26]
 |rl |$encoding[25]
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -15999,7 +15995,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":15,"name": 0x302f,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":1,"name": 0x1,"type":2},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x7,"type":2}]}
+{"reg":[{"bits":15,"name": 0x302f,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x1d,"type":2}]}
 ....
 
 Description::
@@ -16010,7 +16006,6 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|aq |$encoding[26]
 |rs2 |$encoding[24:20]
 |rs1 |$encoding[19:15]
 |===
@@ -16436,7 +16431,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":15,"name": 0x102f,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":1,"name": 0x1,"type":2},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x7,"type":2}]}
+{"reg":[{"bits":15,"name": 0x102f,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x1d,"type":2}]}
 ....
 
 Description::
@@ -16447,7 +16442,6 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|aq |$encoding[26]
 |rs2 |$encoding[24:20]
 |rs1 |$encoding[19:15]
 |===
@@ -18414,7 +18408,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":15,"name": 0x202f,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":1,"name": 0x1,"type":2},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x7,"type":2}]}
+{"reg":[{"bits":15,"name": 0x202f,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x1d,"type":2}]}
 ....
 
 Description::
@@ -18425,7 +18419,6 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|aq |$encoding[26]
 |rs2 |$encoding[24:20]
 |rs1 |$encoding[19:15]
 |===


### PR DESCRIPTION
- Correct operand and register names to be correct name/type
- Correct field names
- Add missing rounding mode in a places
- Similar changes in documentation and IDL
- Change `fctmod.w.d` to require `rtz` rounding mode be specified
  to match the spec
- Correct implementation of load and store conditionals
  (although some are still missing)