### PR TITLE
fix(data): stack-pointer instruction assembly needs stack-pointer

### DIFF
--- a/arch/inst/C/c.addi16sp.yaml
+++ b/arch/inst/C/c.addi16sp.yaml
@@ -13,7 +13,7 @@ definedBy:
   anyOf:
     - C
     - Zca
-assembly: imm
+assembly: imm(sp)
 encoding:
   match: 011-00010-----01
   variables:

--- a/arch/inst/C/c.addi4spn.yaml
+++ b/arch/inst/C/c.addi4spn.yaml
@@ -13,7 +13,7 @@ definedBy:
   anyOf:
     - C
     - Zca
-assembly: xd, imm
+assembly: xd, imm(sp)
 encoding:
   match: 000-----------00
   variables:

--- a/arch/inst/C/c.ldsp.yaml
+++ b/arch/inst/C/c.ldsp.yaml
@@ -16,7 +16,7 @@ definedBy:
     - C
     - Zca
 base: 64
-assembly: xd, imm
+assembly: xd, imm(sp)
 encoding:
   match: 011-----------10
   variables:

--- a/arch/inst/C/c.lwsp.yaml
+++ b/arch/inst/C/c.lwsp.yaml
@@ -14,7 +14,7 @@ definedBy:
   anyOf:
     - C
     - Zca
-assembly: xd, imm
+assembly: xd, imm(sp)
 encoding:
   match: 010-----------10
   variables:

--- a/arch/inst/C/c.sdsp.yaml
+++ b/arch/inst/C/c.sdsp.yaml
@@ -14,7 +14,7 @@ definedBy:
     - C
     - Zca
 base: 64
-assembly: xs2, imm
+assembly: xs2, imm(sp)
 encoding:
   match: 111-----------10
   variables:

--- a/arch/inst/C/c.swsp.yaml
+++ b/arch/inst/C/c.swsp.yaml
@@ -13,7 +13,7 @@ definedBy:
   anyOf:
     - C
     - Zca
-assembly: xs2, imm
+assembly: xs2, imm(sp)
 encoding:
   match: 110-----------10
   variables:

--- a/arch/inst/Zcd/c.fldsp.yaml
+++ b/arch/inst/Zcd/c.fldsp.yaml
@@ -15,7 +15,7 @@ definedBy:
         - C
         - D
     - Zcd
-assembly: fd, imm
+assembly: fd, imm(sp)
 encoding:
   match: 001-----------10
   variables:

--- a/arch/inst/Zcd/c.fsdsp.yaml
+++ b/arch/inst/Zcd/c.fsdsp.yaml
@@ -15,7 +15,7 @@ definedBy:
         - C
         - D
     - Zcd
-assembly: fs2, imm
+assembly: fs2, imm(sp)
 encoding:
   match: 101-----------10
   variables:

--- a/arch/inst/Zcf/c.flwsp.yaml
+++ b/arch/inst/Zcf/c.flwsp.yaml
@@ -15,7 +15,7 @@ definedBy:
         - C
         - F
     - Zcf
-assembly: fd, imm
+assembly: fd, imm(sp)
 base: 32
 encoding:
   match: 011-----------10

--- a/arch/inst/Zcf/c.fswsp.yaml
+++ b/arch/inst/Zcf/c.fswsp.yaml
@@ -15,7 +15,7 @@ definedBy:
         - C
         - F
     - Zcf
-assembly: fs2, imm
+assembly: fs2, imm(sp)
 base: 32
 encoding:
   match: 111-----------10


### PR DESCRIPTION
PR #804 removed the `(sp)` operand from stack-pointer-based instructions. This change was motivated by comparing the assembly with the RISC-V Sail model.

Unfortunately, the Sail model was incorrect in comparison to the RISC-V spec, the spec being the current "single source of truth".

Add the stack pointer operand back to these instructions.

Fixes issue #833.