### PR TITLE
fix(data): vsetvli/vsetivli: correct assembly and fields

### DIFF
--- a/arch/inst/V/vsetivli.yaml
+++ b/arch/inst/V/vsetivli.yaml
@@ -7,12 +7,18 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: V
-assembly: xd, uimm, vtypei
+assembly: xd, uimm, sew, lmul, ta, ma
 encoding:
-  match: 11---------------111-----1010111
+  match: 1100-------------111-----1010111
   variables:
-    - name: vtypei
-      location: 29-20
+    - name: ma
+      location: 27
+    - name: ta
+      location: 26
+    - name: sew
+      location: 25-23
+    - name: lmul
+      location: 22-20
     - name: uimm
       location: 19-15
     - name: xd

--- a/arch/inst/V/vsetvli.yaml
+++ b/arch/inst/V/vsetvli.yaml
@@ -7,12 +7,18 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: V
-assembly: xd, xs1, vtypei
+assembly: xd, xs1, sew, lmul, ta, ma
 encoding:
-  match: 0----------------111-----1010111
+  match: 0000-------------111-----1010111
   variables:
-    - name: xs1
-      location: 30-20
+    - name: ma
+      location: 27
+    - name: ta
+      location: 26
+    - name: sew
+      location: 25-23
+    - name: lmul
+      location: 22-20
     - name: xs1
       location: 19-15
     - name: xd

--- a/backends/instructions_appendix/all_instructions.golden.adoc
+++ b/backends/instructions_appendix/all_instructions.golden.adoc
@@ -1,6 +1,6 @@
 = Instruction Appendix
 :doctype: book
-:wavedrom: /workspaces/riscv-unified-db/node_modules/.bin/wavedrom-cli
+:wavedrom: /workspace/riscv-unified-db/node_modules/.bin/wavedrom-cli
 // Now the document header is complete and the wavedrom attribute is active.
 
 
@@ -34985,7 +34985,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "uimm","type":4},{"bits":10,"name": "vtypei","type":4},{"bits":2,"name": 0x3,"type":2}]}
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "uimm","type":4},{"bits":3,"name": "lmul","type":4},{"bits":3,"name": "sew","type":4},{"bits":1,"name": "ta","type":4},{"bits":1,"name": "ma","type":4},{"bits":4,"name": 0xc,"type":2}]}
 ....
 
 Description::
@@ -34996,7 +34996,10 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|vtypei |$encoding[29:20]
+|ma |$encoding[27]
+|ta |$encoding[26]
+|sew |$encoding[25:23]
+|lmul |$encoding[22:20]
 |uimm |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -35055,7 +35058,7 @@ No synopsis available
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":11,"name": "xs1","type":4},{"bits":1,"name": 0x0,"type":2}]}
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":3,"name": "lmul","type":4},{"bits":3,"name": "sew","type":4},{"bits":1,"name": "ta","type":4},{"bits":1,"name": "ma","type":4},{"bits":4,"name": 0x0,"type":2}]}
 ....
 
 Description::
@@ -35066,7 +35069,10 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|xs1 |$encoding[30:20]
+|ma |$encoding[27]
+|ta |$encoding[26]
+|sew |$encoding[25:23]
+|lmul |$encoding[22:20]
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===


### PR DESCRIPTION
`vsetvli` and `vsetivli` accept the _components_ of VTYPEI as
individual parameters, and they are encoded in individual fields.
    
...with a few additional `0` bits as a result, per the
definition of vtype.