### PR TITLE
fix(data): correct floating point register names in places

### DIFF
--- a/arch/inst/Zcd/c.fld.yaml
+++ b/arch/inst/Zcd/c.fld.yaml
@@ -5,10 +5,10 @@ kind: instruction
 name: c.fld
 long_name: Load double-precision
 description: |
-  Loads a double precision floating-point value from memory into register rd.
+  Loads a double precision floating-point value from memory into register fd.
   It computes an effective address by adding the zero-extended offset, scaled by 8,
-  to the base address in register rs1.
-  It expands to `fld` `rd, offset(rs1)`.
+  to the base address in register xs1.
+  It expands to `fld` `fd, offset(xs1)`.
 definedBy:
   anyOf:
     - allOf:
@@ -22,9 +22,9 @@ encoding:
     - name: imm
       location: 6-5|12-10
       left_shift: 3
-    - name: rd
+    - name: fd
       location: 4-2
-    - name: rs1
+    - name: xs1
       location: 9-7
 access:
   s: always
@@ -36,6 +36,6 @@ operation(): |
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg virtual_address = X[creg2reg(rs1)] + imm;
+  XReg virtual_address = X[creg2reg(xs1)] + imm;
 
-  X[creg2reg(rd)] = sext(read_memory<64>(virtual_address, $encoding), 64);
+  f[fd] = sext(read_memory<64>(virtual_address, $encoding), 64);

--- a/arch/inst/Zcd/c.fldsp.yaml
+++ b/arch/inst/Zcd/c.fldsp.yaml
@@ -5,10 +5,10 @@ kind: instruction
 name: c.fldsp
 long_name: Load doubleword into floating-point register from stack
 description: |
-  Loads a double-precision floating-point value from memory into floating-point register rd.
+  Loads a double-precision floating-point value from memory into floating-point register fd.
   It computes its effective address by adding the zero-extended offset, scaled by 8,
   to the stack pointer, x2.
-  It expands to `fld` `rd, offset(x2)`.
+  It expands to `fld` `fd, offset(x2)`.
 definedBy:
   anyOf:
     - allOf:
@@ -22,7 +22,7 @@ encoding:
     - name: imm
       location: 4-2|12|6-5
       left_shift: 3
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always
@@ -39,4 +39,4 @@ operation(): |
 
   XReg virtual_address = X[2] + imm;
 
-  f[rd] = read_memory<64>(virtual_address, $encoding);
+  f[fd] = read_memory<64>(virtual_address, $encoding);

--- a/arch/inst/Zcd/c.fsd.yaml
+++ b/arch/inst/Zcd/c.fsd.yaml
@@ -5,10 +5,10 @@ kind: instruction
 name: c.fsd
 long_name: Store double-precision
 description: |
-  Stores a double precision floating-point value in register rs2 to memory.
+  Stores a double precision floating-point value in register fs2 to memory.
   It computes an effective address by adding the zero-extended offset, scaled by 8,
-  to the base address in register rs1.
-  It expands to `fsd` `rs2, offset(rs1)`.
+  to the base address in register xs1.
+  It expands to `fsd` `fs2, offset(xs1)`.
 definedBy:
   anyOf:
     - allOf:
@@ -22,9 +22,9 @@ encoding:
     - name: imm
       location: 6-5|12-10
       left_shift: 3
-    - name: rs2
+    - name: fs2
       location: 4-2
-    - name: rs1
+    - name: xs1
       location: 9-7
 access:
   s: always
@@ -36,6 +36,6 @@ operation(): |
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg virtual_address = X[creg2reg(rs1)] + imm;
+  XReg virtual_address = X[creg2reg(xs1)] + imm;
 
-  write_memory<64>(virtual_address, X[creg2reg(rs2)], $encoding);
+  write_memory<64>(virtual_address, X[creg2reg(fs2)], $encoding);

--- a/arch/inst/Zcd/c.fsdsp.yaml
+++ b/arch/inst/Zcd/c.fsdsp.yaml
@@ -5,10 +5,10 @@ kind: instruction
 name: c.fsdsp
 long_name: Store double-precision value to stack
 description: |
-  Stores a double-precision floating-point value in floating-point register rs2 to memory.
+  Stores a double-precision floating-point value in floating-point register fs2 to memory.
   It computes an effective address by adding the zero-extended offset, scaled by 8,
   to the stack pointer, x2.
-  It expands to `fsd` `rs2, offset(x2)`.
+  It expands to `fsd` `fs2, offset(x2)`.
 definedBy:
   anyOf:
     - allOf:
@@ -22,7 +22,7 @@ encoding:
     - name: imm
       location: 9-7|12-10
       left_shift: 3
-    - name: rs2
+    - name: fs2
       location: 6-2
 access:
   s: always
@@ -39,4 +39,4 @@ operation(): |
 
   XReg virtual_address = X[2] + imm;
 
-  write_memory<64>(virtual_address, f[rs2][63:0], $encoding);
+  write_memory<64>(virtual_address, f[fs2][63:0], $encoding);

--- a/arch/inst/Zcf/c.flw.yaml
+++ b/arch/inst/Zcf/c.flw.yaml
@@ -5,17 +5,17 @@ kind: instruction
 name: c.flw
 long_name: Load single-precision
 description: |
-  Loads a single precision floating-point value from memory into register rd.
+  Loads a single precision floating-point value from memory into register fd.
   It computes an effective address by adding the zero-extended offset, scaled by 4,
-  to the base address in register rs1.
-  It expands to `flw` `rd, offset(rs1)`.
+  to the base address in register xs1.
+  It expands to `flw` `fd, offset(xs1)`.
 definedBy:
   anyOf:
     - allOf:
         - C
         - F
     - Zcf
-assembly: xd, imm(xs1)
+assembly: fd, imm(xs1)
 base: 32
 encoding:
   match: 011-----------00
@@ -23,9 +23,9 @@ encoding:
     - name: imm
       location: 5|12-10|6
       left_shift: 2
-    - name: rd
+    - name: fd
       location: 4-2
-    - name: rs1
+    - name: xs1
       location: 9-7
 access:
   s: always
@@ -37,6 +37,6 @@ operation(): |
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg virtual_address = X[creg2reg(rs1)] + imm;
+  XReg virtual_address = X[creg2reg(xs1)] + imm;
 
-  X[creg2reg(rd)] = sext(read_memory<32>(virtual_address, $encoding), 32);
+  X[creg2reg(fd)] = sext(read_memory<32>(virtual_address, $encoding), 32);

--- a/arch/inst/Zcf/c.flwsp.yaml
+++ b/arch/inst/Zcf/c.flwsp.yaml
@@ -5,10 +5,10 @@ kind: instruction
 name: c.flwsp
 long_name: Load word into floating-point register from stack
 description: |
-  Loads a single-precision floating-point value from memory into floating-point register rd.
+  Loads a single-precision floating-point value from memory into floating-point register fd.
   It computes its effective address by adding the zero-extended offset, scaled by 4,
   to the stack pointer, x2.
-  It expands to `flw` `rd, offset(x2)`.
+  It expands to `flw` `fd, offset(x2)`.
 definedBy:
   anyOf:
     - allOf:
@@ -23,7 +23,7 @@ encoding:
     - name: imm
       location: 3-2|12|6-4
       left_shift: 2
-    - name: rd
+    - name: fd
       location: 11-7
 access:
   s: always
@@ -40,4 +40,4 @@ operation(): |
 
   XReg virtual_address = X[2] + imm;
 
-  f[rd] = read_memory<32>(virtual_address, $encoding);
+  f[fd] = read_memory<32>(virtual_address, $encoding);

--- a/arch/inst/Zcf/c.fsw.yaml
+++ b/arch/inst/Zcf/c.fsw.yaml
@@ -5,10 +5,10 @@ kind: instruction
 name: c.fsw
 long_name: Store single-precision
 description: |
-  Stores a single precision floating-point value in register rs2 to memory.
+  Stores a single precision floating-point value in register fs2 to memory.
   It computes an effective address by adding the zero-extended offset, scaled by 4,
-  to the base address in register rs1.
-  It expands to `fsw` `rs2, offset(rs1)`.
+  to the base address in register xs1.
+  It expands to `fsw` `fs2, offset(xs1)`.
 definedBy:
   anyOf:
     - allOf:
@@ -16,16 +16,16 @@ definedBy:
         - F
     - Zcf
 base: 32
-assembly: xs2, imm(xs1)
+assembly: fs2, imm(xs1)
 encoding:
   match: 111-----------00
   variables:
     - name: imm
       location: 5|12-10|6
       left_shift: 2
-    - name: rs2
+    - name: fs2
       location: 4-2
-    - name: rs1
+    - name: xs1
       location: 9-7
 access:
   s: always
@@ -37,6 +37,6 @@ operation(): |
     raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  XReg virtual_address = X[creg2reg(rs1)] + imm;
+  XReg virtual_address = X[creg2reg(xs1)] + imm;
 
-  write_memory<32>(virtual_address, X[creg2reg(rs2)][31:0], $encoding);
+  write_memory<32>(virtual_address, X[creg2reg(fs2)][31:0], $encoding);

--- a/arch/inst/Zcf/c.fswsp.yaml
+++ b/arch/inst/Zcf/c.fswsp.yaml
@@ -5,10 +5,10 @@ kind: instruction
 name: c.fswsp
 long_name: Store single-precision value to stack
 description: |
-  Stores a single-precision floating-point value in floating-point register rs2 to memory.
+  Stores a single-precision floating-point value in floating-point register fs2 to memory.
   It computes an effective address by adding the zero-extended offset, scaled by 4,
   to the stack pointer, x2.
-  It expands to `fsw` `rs2, offset(x2)`.
+  It expands to `fsw` `fs2, offset(x2)`.
 definedBy:
   anyOf:
     - allOf:
@@ -23,7 +23,7 @@ encoding:
     - name: imm
       location: 8-7|12-9
       left_shift: 2
-    - name: rs2
+    - name: fs2
       location: 6-2
 access:
   s: always
@@ -40,4 +40,4 @@ operation(): |
 
   XReg virtual_address = X[2] + imm;
 
-  write_memory<32>(virtual_address, f[rs2][31:0], $encoding);
+  write_memory<32>(virtual_address, f[fs2][31:0], $encoding);

--- a/backends/instructions_appendix/all_instructions.golden.adoc
+++ b/backends/instructions_appendix/all_instructions.golden.adoc
@@ -1,6 +1,6 @@
 = Instruction Appendix
 :doctype: book
-:wavedrom: /workspaces/riscv-unified-db/node_modules/.bin/wavedrom-cli
+:wavedrom: /workspace/riscv-unified-db/node_modules/.bin/wavedrom-cli
 // Now the document header is complete and the wavedrom attribute is active.
 
 
@@ -3531,14 +3531,14 @@ Load double-precision
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "rd","type":4},{"bits":2,"name": "imm[7:6]","type":4},{"bits":3,"name": "rs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x1,"type":2}]}
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "fd","type":4},{"bits":2,"name": "imm[7:6]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x1,"type":2}]}
 ....
 
 Description::
-Loads a double precision floating-point value from memory into register rd.
+Loads a double precision floating-point value from memory into register fd.
 It computes an effective address by adding the zero-extended offset, scaled by 8,
-to the base address in register rs1.
-It expands to xref:insts:fld.adoc#udb:doc:inst:fld[fld] `rd, offset(rs1)`.
+to the base address in register xs1.
+It expands to xref:insts:fld.adoc#udb:doc:inst:fld[fld] `fd, offset(xs1)`.
 
 
 Decode Variables::
@@ -3546,8 +3546,8 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |{$encoding[6:5], $encoding[12:10], 3'd0}
-|rd |$encoding[4:2]
-|rs1 |$encoding[9:7]
+|fd |$encoding[4:2]
+|xs1 |$encoding[9:7]
 |===
 
 Included in::
@@ -3567,14 +3567,14 @@ Load doubleword into floating-point register from stack
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "imm[4:3|8:6]","type":4},{"bits":5,"name": "rd","type":4},{"bits":1,"name": "imm[5]","type":4},{"bits":3,"name": 0x1,"type":2}]}
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "imm[4:3|8:6]","type":4},{"bits":5,"name": "fd","type":4},{"bits":1,"name": "imm[5]","type":4},{"bits":3,"name": 0x1,"type":2}]}
 ....
 
 Description::
-Loads a double-precision floating-point value from memory into floating-point register rd.
+Loads a double-precision floating-point value from memory into floating-point register fd.
 It computes its effective address by adding the zero-extended offset, scaled by 8,
 to the stack pointer, x2.
-It expands to xref:insts:fld.adoc#udb:doc:inst:fld[fld] `rd, offset(x2)`.
+It expands to xref:insts:fld.adoc#udb:doc:inst:fld[fld] `fd, offset(x2)`.
 
 
 Decode Variables::
@@ -3582,7 +3582,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |{$encoding[4:2], $encoding[12], $encoding[6:5], 3'd0}
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -3602,14 +3602,14 @@ Load single-precision
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "rd","type":4},{"bits":2,"name": "imm[2|6]","type":4},{"bits":3,"name": "rs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x3,"type":2}]}
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "fd","type":4},{"bits":2,"name": "imm[2|6]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x3,"type":2}]}
 ....
 
 Description::
-Loads a single precision floating-point value from memory into register rd.
+Loads a single precision floating-point value from memory into register fd.
 It computes an effective address by adding the zero-extended offset, scaled by 4,
-to the base address in register rs1.
-It expands to xref:insts:flw.adoc#udb:doc:inst:flw[flw] `rd, offset(rs1)`.
+to the base address in register xs1.
+It expands to xref:insts:flw.adoc#udb:doc:inst:flw[flw] `fd, offset(xs1)`.
 
 
 Decode Variables::
@@ -3617,8 +3617,8 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |{$encoding[5], $encoding[12:10], $encoding[6], 2'd0}
-|rd |$encoding[4:2]
-|rs1 |$encoding[9:7]
+|fd |$encoding[4:2]
+|xs1 |$encoding[9:7]
 |===
 
 Included in::
@@ -3638,14 +3638,14 @@ Load word into floating-point register from stack
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "imm[4:2|7:6]","type":4},{"bits":5,"name": "rd","type":4},{"bits":1,"name": "imm[5]","type":4},{"bits":3,"name": 0x3,"type":2}]}
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "imm[4:2|7:6]","type":4},{"bits":5,"name": "fd","type":4},{"bits":1,"name": "imm[5]","type":4},{"bits":3,"name": 0x3,"type":2}]}
 ....
 
 Description::
-Loads a single-precision floating-point value from memory into floating-point register rd.
+Loads a single-precision floating-point value from memory into floating-point register fd.
 It computes its effective address by adding the zero-extended offset, scaled by 4,
 to the stack pointer, x2.
-It expands to xref:insts:flw.adoc#udb:doc:inst:flw[flw] `rd, offset(x2)`.
+It expands to xref:insts:flw.adoc#udb:doc:inst:flw[flw] `fd, offset(x2)`.
 
 
 Decode Variables::
@@ -3653,7 +3653,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |{$encoding[3:2], $encoding[12], $encoding[6:4], 2'd0}
-|rd |$encoding[11:7]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -3673,14 +3673,14 @@ Store double-precision
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "rs2","type":4},{"bits":2,"name": "imm[7:6]","type":4},{"bits":3,"name": "rs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x5,"type":2}]}
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "fs2","type":4},{"bits":2,"name": "imm[7:6]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x5,"type":2}]}
 ....
 
 Description::
-Stores a double precision floating-point value in register rs2 to memory.
+Stores a double precision floating-point value in register fs2 to memory.
 It computes an effective address by adding the zero-extended offset, scaled by 8,
-to the base address in register rs1.
-It expands to xref:insts:fsd.adoc#udb:doc:inst:fsd[fsd] `rs2, offset(rs1)`.
+to the base address in register xs1.
+It expands to xref:insts:fsd.adoc#udb:doc:inst:fsd[fsd] `fs2, offset(xs1)`.
 
 
 Decode Variables::
@@ -3688,8 +3688,8 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |{$encoding[6:5], $encoding[12:10], 3'd0}
-|rs2 |$encoding[4:2]
-|rs1 |$encoding[9:7]
+|fs2 |$encoding[4:2]
+|xs1 |$encoding[9:7]
 |===
 
 Included in::
@@ -3709,14 +3709,14 @@ Store double-precision value to stack
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "rs2","type":4},{"bits":6,"name": "imm[5:3|8:6]","type":4},{"bits":3,"name": 0x5,"type":2}]}
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "fs2","type":4},{"bits":6,"name": "imm[5:3|8:6]","type":4},{"bits":3,"name": 0x5,"type":2}]}
 ....
 
 Description::
-Stores a double-precision floating-point value in floating-point register rs2 to memory.
+Stores a double-precision floating-point value in floating-point register fs2 to memory.
 It computes an effective address by adding the zero-extended offset, scaled by 8,
 to the stack pointer, x2.
-It expands to xref:insts:fsd.adoc#udb:doc:inst:fsd[fsd] `rs2, offset(x2)`.
+It expands to xref:insts:fsd.adoc#udb:doc:inst:fsd[fsd] `fs2, offset(x2)`.
 
 
 Decode Variables::
@@ -3724,7 +3724,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |{$encoding[9:7], $encoding[12:10], 3'd0}
-|rs2 |$encoding[6:2]
+|fs2 |$encoding[6:2]
 |===
 
 Included in::
@@ -3744,14 +3744,14 @@ Store single-precision
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "rs2","type":4},{"bits":2,"name": "imm[2|6]","type":4},{"bits":3,"name": "rs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x7,"type":2}]}
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "fs2","type":4},{"bits":2,"name": "imm[2|6]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x7,"type":2}]}
 ....
 
 Description::
-Stores a single precision floating-point value in register rs2 to memory.
+Stores a single precision floating-point value in register fs2 to memory.
 It computes an effective address by adding the zero-extended offset, scaled by 4,
-to the base address in register rs1.
-It expands to xref:insts:fsw.adoc#udb:doc:inst:fsw[fsw] `rs2, offset(rs1)`.
+to the base address in register xs1.
+It expands to xref:insts:fsw.adoc#udb:doc:inst:fsw[fsw] `fs2, offset(xs1)`.
 
 
 Decode Variables::
@@ -3759,8 +3759,8 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |{$encoding[5], $encoding[12:10], $encoding[6], 2'd0}
-|rs2 |$encoding[4:2]
-|rs1 |$encoding[9:7]
+|fs2 |$encoding[4:2]
+|xs1 |$encoding[9:7]
 |===
 
 Included in::
@@ -3780,14 +3780,14 @@ Store single-precision value to stack
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "rs2","type":4},{"bits":6,"name": "imm[5:2|7:6]","type":4},{"bits":3,"name": 0x7,"type":2}]}
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "fs2","type":4},{"bits":6,"name": "imm[5:2|7:6]","type":4},{"bits":3,"name": 0x7,"type":2}]}
 ....
 
 Description::
-Stores a single-precision floating-point value in floating-point register rs2 to memory.
+Stores a single-precision floating-point value in floating-point register fs2 to memory.
 It computes an effective address by adding the zero-extended offset, scaled by 4,
 to the stack pointer, x2.
-It expands to xref:insts:fsw.adoc#udb:doc:inst:fsw[fsw] `rs2, offset(x2)`.
+It expands to xref:insts:fsw.adoc#udb:doc:inst:fsw[fsw] `fs2, offset(x2)`.
 
 
 Decode Variables::
@@ -3795,7 +3795,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |imm |{$encoding[8:7], $encoding[12:9], 2'd0}
-|rs2 |$encoding[6:2]
+|fs2 |$encoding[6:2]
 |===
 
 Included in::


### PR DESCRIPTION
Old register names are being used in some places for
description, assembly, fields.
    
Related to https://github.com/riscv/sail-riscv/pull/1049

Fixes #843