### PR TITLE
Modify Smaia extension and add Machine-Level AIA CSRs (Phase 1 of Issue #566)

### DIFF
--- a/arch/csr/midelegh.yaml
+++ b/arch/csr/midelegh.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: midelegh
+long_name: Upper 32 bits of mideleg
+address: 0x313
+writable: true
+priv_mode: M
+length: 32
+definedBy: Smaia
+description: |
+  The `midelegh` CSR holds the upper 32 bits of the 64-bit `mideleg` CSR on RV32 systems.
+  This register is present only when Supervisor mode is implemented.
+
+  Like `mideleg`, `midelegh` controls interrupt delegation from M-mode to HS/S-mode.
+  Bits in `midelegh` correspond to interrupt causes 32 through 63. When a bit is set,
+  the corresponding interrupt is delegated to S-mode if it occurs while executing in
+  S-mode or U-mode.
+
+  The set of writable bits in this register is WARL — an implementation may not support
+  delegation for all interrupt causes. Supported bits can be discovered by writing all 1s
+  to the register and reading back the result.
+
+  Bits corresponding to unsupported or unimplemented interrupts must be read-only zero.
+
+fields:
+  midelegh:
+    location: 31-0
+    type: RW-R
+    sw_write(csr_value): |
+
+    description: |
+      Interrupt delegation bits 32-63. Each bit, when set, delegates the corresponding
+      interrupt to HS/S-mode. Bits corresponding to unimplemented or non-delegatable interrupts
+      are read-only zero.
+    reset_value: 0

--- a/arch/csr/mieh.yaml
+++ b/arch/csr/mieh.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: mieh
+long_name: Upper 32 bits of Machine Interrupt Enable
+address: 0x314
+writable: true
+priv_mode: M
+length: 32
+definedBy: Smaia
+description: |
+  The `mieh` CSR holds the upper 32 bits of the 64-bit `mie` register on RV32 systems.
+
+  Like `mie`, this register enables individual interrupts, but for interrupt IDs 32–63.
+  This register is only present if Supervisor mode is implemented, and only meaningful
+  if external interrupt sources are defined in that upper range.
+
+  WARL: Writes to unsupported or unimplemented bits are ignored and read as zero.
+  Writable bits can be discovered by writing all 1s and reading back the value.
+
+fields:
+  mieh:
+    location: 31-0
+    type: RW-R
+    sw_write(csr_value): |
+    description: |
+      Interrupt enable bits 32-63. Each bit enables the corresponding interrupt
+      if supported. Unsupported bits are read-only zero.
+    reset_value: 0

--- a/arch/csr/miph.yaml
+++ b/arch/csr/miph.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: miph
+long_name: Machine Interrupt Pending High
+address: 0x354
+writable: true
+priv_mode: M
+length: 32
+definedBy: Smaia
+description: |
+  The `miph` CSR holds the upper 32 bits of the `mip` register on RV64 systems.
+  It is used in conjunction with `mip` to represent interrupt-pending bits above bit 31.
+
+  This CSR is only defined for RV64, and must not be implemented on RV32.
+
+  The `miph` CSR may contain pending status for platform-specific interrupts, especially
+  those mapped to bits 32 and above in `mip`.
+
+  Writing to `miph` affects the corresponding upper bits of `mip`. Similarly, reading from
+  `miph` returns the upper 32 bits of `mip`.
+
+  It is a read/write register in M-mode.
+
+  [NOTE]
+  ====
+  The `miph` register is not part of the base privilege specification but is defined
+  in the RISC-V privileged architecture when `mip` is wider than 32 bits, such as on RV64.
+  ====
+
+fields:
+  miph:
+    location: 31-0
+    type: RW
+    description: |
+      Interrupt-pending bits 32 through 63. Each bit corresponds to an interrupt
+      source above bit 31 in the full `mip` register. These bits reflect interrupt
+      pending status and are writable in M-mode.
+    reset_value: 0

--- a/arch/csr/mtopei.yaml
+++ b/arch/csr/mtopei.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+$schema: "csr_schema.json#"
+kind: csr
+
+name: mtopei
+long_name: Machine Top External Interrupt
+priv_mode: M
+address: 0x35C
+length: 32
+definedBy: Smaia
+
+description: |
+  The `mtopei` CSR (Machine Top External Pending and Enabled Interrupt) reflects the identity
+  of the highest-priority external interrupt that is both pending and enabled in the IMSIC's
+  machine-level interrupt file and that also exceeds the threshold in the `eithreshold` CSR.
+
+  - Reading `mtopei` returns the ID of the interrupt left-shifted by 16 bits.
+  - Writing to `mtopei` claims (acknowledges) the interrupt.
+  - Returns zero if no qualifying interrupt is found or threshold filtering eliminates them.
+
+  Exists only if an IMSIC is implemented.
+
+  See also: `stopei`, `vstopei`, `miselect`, `mireg`, `eithreshold`.
+
+fields:
+  TOPEI:
+    location: 0-31
+    base: 32
+    type: RW
+    reset_value: 0
+    description: |
+      Top pending-and-enabled interrupt ID shifted left by 16 bits.
+      Writing this field acknowledges (claims) the interrupt.
+      Returns zero if no interrupt matches the condition.

--- a/arch/csr/mtopi.yaml
+++ b/arch/csr/mtopi.yaml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+$schema: "csr_schema.json#"
+kind: csr
+
+name: mtopi
+long_name: Machine Top Interrupt
+priv_mode: M
+address: 0xFB0
+length: 32
+definedBy: Smaia
+
+description: |
+  The `mtopi` CSR (Machine Top Interrupt) is a read-only register that encodes the highest-priority
+  interrupt that is both pending and enabled at machine level, excluding those delegated to lower
+  privilege levels. This CSR is valid only when AIA is implemented.
+
+  The value of `mtopi` is:
+  - Zero if no eligible interrupt is pending and enabled.
+  - Non-zero if a valid interrupt is pending and enabled.
+
+  Field definitions:
+    - Bits 27:16 — IID (Interrupt Identity Number)
+    - Bits 7:0   — IPRIO (Interrupt Priority)
+    - All other bits are reserved and read as zeros.
+
+  Notes:
+  - Reading `mtopi` does not clear or affect any interrupt state.
+  - `mtopi` is *not* masked by `mstatus.MIE`.
+  - IPRIO = 1 when all `iprio` bytes are read-only zero.
+  - If the actual priority exceeds 255 → IPRIO = 255
+  - If priority is 0:
+    - IPRIO = 0 → if interrupt has *higher* default priority than machine external interrupt
+    - IPRIO = 255 → otherwise
+
+  See also: `mcause`, `mstatus.MPIE`, `mip`, `mie`, `mideleg`, `iprio`.
+
+fields:
+  IPRIO:
+    location: 7-0
+    base: 32
+    type: RO
+    reset_value: 0
+    description: |
+      Encoded priority of the top pending-and-enabled interrupt.
+      Value depends on the priority system of the platform.
+
+      - If actual priority is 1-255, this field holds that value.
+      - If all iprio[] bytes are zero, always returns 1 when `mtopi` is non-zero.
+      - If actual priority > 255, returns 255.
+      - If actual priority == 0:
+        - Returns 0 if IID has default priority higher than machine external interrupt.
+        - Returns 255 otherwise.
+  IID:
+    location: 27-16
+    base: 32
+    type: RO
+    reset_value: 0
+    description: |
+      Major identity number of the top pending-and-enabled machine-level interrupt.
+      IID = 0 means no qualifying interrupt is currently pending and enabled.
+  RESERVED:
+    location: 31-28
+    base: 32
+    type: RO
+    reset_value: 0
+    description: Reserved. Always reads as 0.

--- a/arch/csr/mvien.yaml
+++ b/arch/csr/mvien.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+$schema: "csr_schema.json#"
+kind: csr
+
+name: mvien
+long_name: Machine Virtual Interrupt Enables
+priv_mode: M
+address: 0x308
+length: 64
+definedBy: Smaia
+description: |
+  The `mvien` CSR (Machine Virtual Interrupt Enables) controls whether the virtual interrupt-pending
+  bits in register `mvip` are active and visible to supervisor mode via the `sip` CSR, even when the
+  corresponding bit in `mideleg` is 0.
+
+  Each bit in `mvien` corresponds to an interrupt cause [0–63]. A bit in `mvien` must be 1 to enable
+  delegation of the corresponding bit in `mvip` to supervisor mode.
+
+  - Bits 1 (SSIP) and 9 (SEIP) may be writable depending on platform implementation.
+  - Bit 5 (STIP) may be writable or read-only zero depending on `mip` configuration.
+  - Bits 0-12 (except 1, 5, 9) are reserved and must be read-only zeros.
+  - Bits 13-63 may be writable, read-only zero, or read-only one depending on platform/extension.
+
+  For RV32, the upper 32 bits of `mvien` are accessed via `mvienh` (CSR 0x309).
+
+  See also: `mvip`, `mideleg`, `sip`.
+
+fields:
+  SSIP:
+    location: 1
+    base: 64
+    type: RW-R
+    reset_value: 0
+    description: |
+      Supervisor software interrupt enable. May be writable or read-only zero depending on platform.
+      When 1, allows delegation of SSIP via `mvip` even if not delegated via `mideleg`.
+    sw_write(csr_value): |
+
+  STIP:
+    location: 5
+    base: 64
+    type: RW-R
+    reset_value: 0
+    description: |
+      Supervisor timer interrupt enable. Writable only if the corresponding `mip.STIP` bit is writable;
+      otherwise read-only zero.
+    sw_write(csr_value): |
+
+  SEIP:
+    location: 9
+    base: 64
+    type: RW-R
+    reset_value: 0
+    description: |
+      Supervisor external interrupt enable. Strongly recommended to be writable. Controls delegation
+      of SEIP via `mvip`.
+    sw_write(csr_value): |
+
+  VIE:
+    location: 63-13
+    base: 64
+    type: RW-R
+    reset_value: 0
+    description: |
+      Interrupt enable bits for virtual supervisor-level interrupts 13–63.
+      Writable, read-only zero, or read-only one depending on implementation or platform profile.
+    sw_write(csr_value): |
+
+  RESERVED:
+    location: 12-0
+    base: 64
+    type: RO
+    reset_value: 0
+    description: |
+      Reserved. Read-only zeros except for SSIP (bit 1), STIP (bit 5), and SEIP (bit 9).

--- a/arch/csr/mvienh.yaml
+++ b/arch/csr/mvienh.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+$schema: "csr_schema.json#"
+kind: csr
+
+name: mvienh
+long_name: Upper 32 bits of Machine Virtual Interrupt Enables
+priv_mode: M
+address: 0x318
+length: 32
+definedBy: Smaia
+
+description: |
+  The `mvienh` CSR provides access to the upper 32 bits of the 64-bit `mvien` register
+  on RV32 systems. It enables or disables delegation of virtual interrupt-pending bits
+  (in `mviph`) for interrupt causes numbered 63–32.
+
+  Each bit in `mvienh` corresponds to a virtual interrupt cause ID _i_ = 32 + _n_,
+  where _n_ = bit index in `mvienh`.
+
+  A bit in `mvienh` must be set to 1 for the corresponding `mviph` bit to be delegated
+  to supervisor mode (visible in `sip`), even if the interrupt is not delegated through
+  `mideleg`.
+
+  Writable bits vary by platform and extension. Bits may be read-only zero or one depending
+  on platform constraints or profiling.
+
+  See also: `mvien`, `mviph`, `mideleg`, `sip`.
+
+fields:
+  VIEH:
+    location: 31-0
+    base: 32
+    type: RW-R
+    reset_value: 0
+    description: |
+      *Virtual Interrupt Enables High*
+
+      Interrupt enable bits for virtual interrupt causes 32-63.
+
+      Each bit enables visibility of the corresponding `mviph` bit to supervisor mode,
+      even if not delegated via `mideleg`. Writable status for each bit is platform-specific.
+    sw_write(csr_value): |

--- a/arch/csr/mvip.yaml
+++ b/arch/csr/mvip.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+
+name: mvip
+long_name: Machine Virtual Interrupt Pending
+priv_mode: M
+address: 0x305
+length: 64
+definedBy: Smaia
+description: |
+  The `mvip` CSR (Machine Virtual Interrupt Pending) provides software-visible virtual interrupt pending bits
+  for supervisor-level interrupts. It enables M-mode to selectively delegate virtual interrupt signals
+  to S-mode via the `sip` register, even if the `mideleg` bit for the interrupt is 0.
+
+  Bits in `mvip` are meaningful when the corresponding bits in `mvien` are set to 1.
+  - Bits 1 (SSIP), 5 (STIP), and 9 (SEIP) are writable and may act as aliases to `mip` depending on the value of `mvien`.
+  - Other bits in the range [0-12] are reserved and must be hardwired to 0.
+  - Bits [13-63] are implementation-defined but generally writable.
+
+  `mvip` allows M-mode to emulate interrupt delivery behavior to S-mode without depending on real hardware interrupt signals.
+
+fields:
+  vip:
+    location: 63-0
+    type: RW
+    reset_value: 0
+    description: |
+      Each bit represents a virtual interrupt-pending bit. Bits 1 (SSIP), 5 (STIP), and 9 (SEIP) are writable and emulate
+      pending supervisor interrupts. Bits [0-12] other than these may be reserved. Bits [13–63] are implementation-defined.

--- a/arch/csr/mviph.yaml
+++ b/arch/csr/mviph.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+
+name: mviph
+long_name: Upper 32 bits of mvip
+priv_mode: M
+address: 0x319
+length: 32
+definedBy: Smaia
+description: |
+  The `mviph` CSR contains the upper 32 bits of the `mvip` CSR and is accessible on RV32 systems when `S-mode` is implemented.
+  It complements the lower 32 bits in `mvip` to provide full access to all 64 virtual interrupt-pending bits.
+
+  This CSR allows software running in M-mode to access or modify the upper portion of virtual interrupt-pending state for supervisor-level interrupts.
+
+fields:
+  vip_upper:
+    location: 31-0
+    type: RW
+    reset_value: 0
+    description: |
+      Upper 32 bits [63:32] of the `mvip` register. Represents virtual interrupt-pending bits
+      for supervisor-level interrupts. Behavior and meaning of these bits are determined by implementation and `mvien`.

--- a/arch/ext/Smaia.yaml
+++ b/arch/ext/Smaia.yaml
@@ -4,8 +4,21 @@ $schema: "ext_schema.json#"
 kind: extension
 name: Smaia
 long_name: Advanced Interrupt Architecture, M-mode extension
-description: Advanced Interrupt Architecture, M-mode extension
+description: |
+  The Smaia extension defines all new machine-level CSRs and behavioral changes to the interrupt system as
+  specified in the Advanced Interrupt Architecture (AIA) v1.0. It includes support for interrupt delegation,
+  virtual interrupt control, and prioritized interrupt delivery mechanisms.
+
+  This extension is applicable to harts that support machine-level AIA features. It includes support for
+  both local interrupt controller registers (like MVIP, MVIEN) and indirect CSR access mechanisms (via MISEL, MIREG).
+
+  This extension takes precedence over conflicting behavior from other extensions unless explicitly overridden
+  (e.g., by Smcsrind/Sscsrind).
+
+  The existence and behavior of certain CSRs may depend on the implementation's privilege support (M, S, H) and XLEN.
+
 type: privileged
+
 versions:
   - version: "1.0.0"
     state: ratified


### PR DESCRIPTION
This PR introduces initial support for the Smaia (Machine-Level Advanced Interrupt Architecture) extension, addressing [Issue #566](https://github.com/riscv-software-src/riscv-unified-db/issues/566).

New Machine-Level CSRs Added:
- mvien
- mvienh
- mviph
- miph
- mieh
- midelegh
- mtopoi
- mtopei
- mvip

These CSRs represent Phase 1 of the implementation, covering machine-level functionality. Supervisor- and VS-level CSRs will be added in a follow-up phase.