### PR TITLE
andn: use the new instruction schema

### DIFF
--- a/backends/instructions_appendix/all_instructions.golden.adoc
+++ b/backends/instructions_appendix/all_instructions.golden.adoc
@@ -1,6 +1,6 @@
 = Instruction Appendix
 :doctype: book
-:wavedrom: /workspace/riscv-unified-db/node_modules/.bin/wavedrom-cli
+:wavedrom: /home/uniqueusman/riscv-unified-db/node_modules/.bin/wavedrom-cli
 // Now the document header is complete and the wavedrom attribute is active.
 
 
@@ -2396,7 +2396,7 @@ AND with inverted operand
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "rd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "rs1","type":4},{"bits":5,"name": "rs2","type":4},{"bits":7,"name": 0x20,"type":2}]}
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x20,"type":2}]}
 ....
 
 Description::
@@ -2408,9 +2408,9 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|rs2 |$encoding[24:20]
-|rs1 |$encoding[19:15]
-|rd |$encoding[11:7]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
 |===
 
 Included in::

--- a/spec/std/isa/inst/B/andn.yaml
+++ b/spec/std/isa/inst/B/andn.yaml
@@ -13,15 +13,17 @@ description: |
 definedBy:
   anyOf: [Zbb, Zbkb]
 assembly: xd, xs1, xs2
-encoding:
-  match: 0100000----------111-----0110011
-  variables:
-    - name: rs2
-      location: 24-20
-    - name: rs1
-      location: 19-15
-    - name: rd
-      location: 11-7
+format:
+  $inherits:
+    - inst_subtype/R/R-x.yaml#/data
+  opcodes:
+    funct7:
+      display_name: ANDN
+      value: 0b0100000
+    funct3:
+      display_name: ANDN
+      value: 0b111
+    opcode: { $inherits: inst_opcode/OP.yaml#/data }
 access:
   s: always
   u: always
@@ -33,7 +35,7 @@ operation(): |
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  X[rd] = X[rs2] & ~X[rs1];
+  X[xd] = X[xs2] & ~X[xs1];
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/spec/std/isa/inst_opcode/OP.yaml
+++ b/spec/std/isa/inst_opcode/OP.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../schemas/inst_opcode_schema.json#
+
+$schema: inst_opcode_schema.json#
+kind: instruction_opcode
+name: OP
+
+data:
+  display_name: OP
+  value: 0b0110011


### PR DESCRIPTION
In (#686), a new instruction schema was created
for types/subtypes. This commit change B/andn
instruction to use the new schema. It is also part of effort in (#655).