### PR TITLE
inst/B: use the new instruction schema

### DIFF
--- a/spec/std/isa/inst/B/clmul.yaml
+++ b/spec/std/isa/inst/B/clmul.yaml
@@ -12,15 +12,17 @@ description: |
 definedBy:
   anyOf: [Zbc, Zbkc]
 assembly: xd, xs1, xs2
-encoding:
-  match: 0000101----------001-----0110011
-  variables:
-    - name: xs2
-      location: 24-20
-    - name: xs1
-      location: 19-15
-    - name: xd
-      location: 11-7
+format:
+  $inherits:
+    - inst_subtype/R/R-x.yaml#/data
+  opcodes:
+    funct7:
+      display_name: CLMUL
+      value: 0b0000101
+    funct3:
+      display_name: CLMUL
+      value: 0b001
+    opcode: { $inherits: inst_opcode/OP.yaml#/data }
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/B/clmulh.yaml
+++ b/spec/std/isa/inst/B/clmulh.yaml
@@ -17,7 +17,7 @@ format:
     - inst_subtype/R/R-x.yaml#/data
   opcodes:
     funct7:
-      display_name: CLMULH
+      display_name: CLMUL
       value: 0b0000101
     funct3:
       display_name: CLMULH

--- a/spec/std/isa/inst/B/clmulh.yaml
+++ b/spec/std/isa/inst/B/clmulh.yaml
@@ -12,15 +12,17 @@ description: |
 definedBy:
   anyOf: [Zbc, Zbkc]
 assembly: xd, xs1, xs2
-encoding:
-  match: 0000101----------011-----0110011
-  variables:
-    - name: xs2
-      location: 24-20
-    - name: xs1
-      location: 19-15
-    - name: xd
-      location: 11-7
+format:
+  $inherits:
+    - inst_subtype/R/R-x.yaml#/data
+  opcodes:
+    funct7:
+      display_name: CLMULH
+      value: 0b0000101
+    funct3:
+      display_name: CLMULH
+      value: 0b011
+    opcode: { $inherits: inst_opcode/OP.yaml#/data }
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/B/orn.yaml
+++ b/spec/std/isa/inst/B/orn.yaml
@@ -12,15 +12,17 @@ description: |
 definedBy:
   anyOf: [Zbb, Zbkb]
 assembly: xd, xs1, xs2
-encoding:
-  match: 0100000----------110-----0110011
-  variables:
-    - name: xs2
-      location: 24-20
-    - name: xs1
-      location: 19-15
-    - name: xd
-      location: 11-7
+format:
+  $inherits:
+    - inst_subtype/R/R-x.yaml#/data
+  opcodes:
+    funct7:
+      display_name: ORN
+      value: 0b0100000
+    funct3:
+      display_name: ORN
+      value: 0b110
+    opcode: { $inherits: inst_opcode/OP.yaml#/data }
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/B/rol.yaml
+++ b/spec/std/isa/inst/B/rol.yaml
@@ -12,15 +12,17 @@ description: |
 definedBy:
   anyOf: [Zbb, Zbkb]
 assembly: xd, xs1, xs2
-encoding:
-  match: 0110000----------001-----0110011
-  variables:
-    - name: xs2
-      location: 24-20
-    - name: xs1
-      location: 19-15
-    - name: xd
-      location: 11-7
+format:
+  $inherits:
+    - inst_subtype/R/R-x.yaml#/data
+  opcodes:
+    funct7:
+      display_name: ROL
+      value: 0b0110000
+    funct3:
+      display_name: ROL
+      value: 0b001
+    opcode: { $inherits: inst_opcode/OP.yaml#/data }
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/B/rolw.yaml
+++ b/spec/std/isa/inst/B/rolw.yaml
@@ -14,15 +14,17 @@ definedBy:
   anyOf: [Zbb, Zbkb]
 assembly: xd, xs1, xs2
 base: 64
-encoding:
-  match: 0110000----------001-----0111011
-  variables:
-    - name: xs2
-      location: 24-20
-    - name: xs1
-      location: 19-15
-    - name: xd
-      location: 11-7
+format:
+  $inherits:
+    - inst_subtype/R/R-x.yaml#/data
+  opcodes:
+    funct7:
+      display_name: ROLW
+      value: 0b0110000
+    funct3:
+      display_name: ROLW
+      value: 0b001
+    opcode: { $inherits: inst_opcode/OP-32.yaml#/data }
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/B/ror.yaml
+++ b/spec/std/isa/inst/B/ror.yaml
@@ -12,15 +12,17 @@ description: |
 definedBy:
   anyOf: [Zbb, Zbkb]
 assembly: xd, xs1, xs2
-encoding:
-  match: 0110000----------101-----0110011
-  variables:
-    - name: xs2
-      location: 24-20
-    - name: xs1
-      location: 19-15
-    - name: xd
-      location: 11-7
+format:
+  $inherits:
+    - inst_subtype/R/R-x.yaml#/data
+  opcodes:
+    funct7:
+      display_name: ROR
+      value: 0b0110000
+    funct3:
+      display_name: ROR
+      value: 0b101
+    opcode: { $inherits: inst_opcode/OP.yaml#/data }
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/B/rorw.yaml
+++ b/spec/std/isa/inst/B/rorw.yaml
@@ -15,15 +15,17 @@ definedBy:
   anyOf: [Zbb, Zbkb]
 assembly: xd, xs1, xs2
 base: 64
-encoding:
-  match: 0110000----------101-----0111011
-  variables:
-    - name: xs2
-      location: 24-20
-    - name: xs1
-      location: 19-15
-    - name: xd
-      location: 11-7
+format:
+  $inherits:
+    - inst_subtype/R/R-x.yaml#/data
+  opcodes:
+    funct7:
+      display_name: RORW
+      value: 0b0110000
+    funct3:
+      display_name: RORW
+      value: 0b101
+    opcode: { $inherits: inst_opcode/OP-32.yaml#/data }
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/B/xnor.yaml
+++ b/spec/std/isa/inst/B/xnor.yaml
@@ -12,15 +12,17 @@ description: |
 definedBy:
   anyOf: [Zbb, Zbkb]
 assembly: xd, xs1, xs2
-encoding:
-  match: 0100000----------100-----0110011
-  variables:
-    - name: xs2
-      location: 24-20
-    - name: xs1
-      location: 19-15
-    - name: xd
-      location: 11-7
+format:
+  $inherits:
+    - inst_subtype/R/R-x.yaml#/data
+  opcodes:
+    funct7:
+      display_name: XNOR
+      value: 0b0100000
+    funct3:
+      display_name: XNOR
+      value: 0b100
+    opcode: { $inherits: inst_opcode/OP.yaml#/data }
 access:
   s: always
   u: always


### PR DESCRIPTION
In (#686), a new instruction schema was created
for types/subtypes. This commit changes B/clmul,
B/clmulh, B/orn, B/rol, B/rolw, B/ror, B/rorw,
B/xnor instructions to use the new schema. They
all are of the same subtypes. It is also part of
effort in (#655).