### PR TITLE
style: add assembly syntax to generated instruction appendix

### DIFF
--- a/backends/instructions_appendix/all_instructions.golden.adoc
+++ b/backends/instructions_appendix/all_instructions.golden.adoc
@@ -10,6 +10,9 @@
 Synopsis::
 Integer add
 
+Assembly::
+add xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -45,6 +48,9 @@ Included in::
 
 Synopsis::
 Add unsigned word
+
+Assembly::
+add.uw xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -82,6 +88,9 @@ Included in::
 Synopsis::
 Add immediate
 
+Assembly::
+addi xd, xs1, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -116,6 +125,9 @@ Included in::
 Synopsis::
 Add immediate word
 
+Assembly::
+addiw xd, xs1, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -149,6 +161,9 @@ Included in::
 
 Synopsis::
 Add word
+
+Assembly::
+addw xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -185,6 +200,9 @@ Included in::
 
 Synopsis::
 AES final round decryption instruction for RV32
+
+Assembly::
+aes32dsi xd, xs1, xs2, bs
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -223,6 +241,9 @@ Included in::
 
 Synopsis::
 AES middle round decryption instruction for RV32
+
+Assembly::
+aes32dsmi xd, xs1, xs2, bs
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -263,6 +284,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+aes32esi xd, xs1, xs2, bs
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -298,6 +322,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+aes32esmi xd, xs1, xs2, bs
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -335,6 +362,9 @@ Included in::
 Synopsis::
 AES decrypt final round
 
+Assembly::
+aes64ds xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -370,6 +400,9 @@ Included in::
 
 Synopsis::
 AES decrypt middle round
+
+Assembly::
+aes64dsm xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -407,6 +440,9 @@ Included in::
 Synopsis::
 AES encrypt final round
 
+Assembly::
+aes64es xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -442,6 +478,9 @@ Included in::
 
 Synopsis::
 AES encrypt middle round
+
+Assembly::
+aes64esm xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -479,6 +518,9 @@ Included in::
 Synopsis::
 AES Decrypt KeySchedule MixColumns
 
+Assembly::
+aes64im xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -514,6 +556,9 @@ Included in::
 
 Synopsis::
 AES Key Schedule Instruction 1
+
+Assembly::
+aes64ks1i xd, xs1, rnum
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -556,6 +601,9 @@ Included in::
 Synopsis::
 AES Key Schedule Instruction 2
 
+Assembly::
+aes64ks2 xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -594,6 +642,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amoadd.b xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -630,6 +681,9 @@ Included in::
 
 Synopsis::
 Atomic fetch-and-add doubleword
+
+Assembly::
+amoadd.d xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -673,6 +727,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amoadd.h xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -709,6 +766,9 @@ Included in::
 
 Synopsis::
 Atomic fetch-and-add word
+
+Assembly::
+amoadd.w xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -752,6 +812,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amoand.b xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -788,6 +851,9 @@ Included in::
 
 Synopsis::
 Atomic fetch-and-and doubleword
+
+Assembly::
+amoand.d xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -831,6 +897,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amoand.h xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -867,6 +936,9 @@ Included in::
 
 Synopsis::
 Atomic fetch-and-and word
+
+Assembly::
+amoand.w xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -910,6 +982,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amocas.b xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -946,6 +1021,9 @@ Included in::
 
 Synopsis::
 Atomic Compare-and-Swap Doubleword
+
+Assembly::
+amocas.d xd, xs2, (xs1)
 
 Encoding::
 [NOTE]
@@ -1046,6 +1124,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amocas.h xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -1082,6 +1163,9 @@ Included in::
 
 Synopsis::
 Atomic Compare-and-Swap Quadword
+
+Assembly::
+amocas.q xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -1152,6 +1236,9 @@ Included in::
 Synopsis::
 Atomic Compare-and-Swap Word
 
+Assembly::
+amocas.w xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -1221,6 +1308,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amomax.b xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -1257,6 +1347,9 @@ Included in::
 
 Synopsis::
 Atomic MAX doubleword
+
+Assembly::
+amomax.d xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -1300,6 +1393,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amomax.h xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -1336,6 +1432,9 @@ Included in::
 
 Synopsis::
 Atomic MAX word
+
+Assembly::
+amomax.w xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -1379,6 +1478,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amomaxu.b xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -1415,6 +1517,9 @@ Included in::
 
 Synopsis::
 Atomic MAX unsigned doubleword
+
+Assembly::
+amomaxu.d xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -1458,6 +1563,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amomaxu.h xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -1494,6 +1602,9 @@ Included in::
 
 Synopsis::
 Atomic MAX unsigned word
+
+Assembly::
+amomaxu.w xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -1537,6 +1648,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amomin.b xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -1573,6 +1687,9 @@ Included in::
 
 Synopsis::
 Atomic MIN doubleword
+
+Assembly::
+amomin.d xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -1616,6 +1733,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amomin.h xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -1652,6 +1772,9 @@ Included in::
 
 Synopsis::
 Atomic MIN word
+
+Assembly::
+amomin.w xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -1695,6 +1818,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amominu.b xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -1731,6 +1857,9 @@ Included in::
 
 Synopsis::
 Atomic MIN unsigned doubleword
+
+Assembly::
+amominu.d xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -1774,6 +1903,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amominu.h xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -1810,6 +1942,9 @@ Included in::
 
 Synopsis::
 Atomic MIN unsigned word
+
+Assembly::
+amominu.w xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -1853,6 +1988,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amoor.b xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -1889,6 +2027,9 @@ Included in::
 
 Synopsis::
 Atomic fetch-and-or doubleword
+
+Assembly::
+amoor.d xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -1932,6 +2073,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amoor.h xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -1968,6 +2112,9 @@ Included in::
 
 Synopsis::
 Atomic fetch-and-or word
+
+Assembly::
+amoor.w xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -2011,6 +2158,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amoswap.b xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -2047,6 +2197,9 @@ Included in::
 
 Synopsis::
 Atomic SWAP doubleword
+
+Assembly::
+amoswap.d xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -2089,6 +2242,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amoswap.h xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -2125,6 +2281,9 @@ Included in::
 
 Synopsis::
 Atomic SWAP word
+
+Assembly::
+amoswap.w xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -2167,6 +2326,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amoxor.b xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -2203,6 +2365,9 @@ Included in::
 
 Synopsis::
 Atomic fetch-and-xor doubleword
+
+Assembly::
+amoxor.d xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -2246,6 +2411,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+amoxor.h xd, xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -2282,6 +2450,9 @@ Included in::
 
 Synopsis::
 Atomic fetch-and-xor word
+
+Assembly::
+amoxor.w xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -2325,6 +2496,9 @@ Included in::
 Synopsis::
 And
 
+Assembly::
+and xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -2359,6 +2533,9 @@ Included in::
 Synopsis::
 And immediate
 
+Assembly::
+andi xd, xs1, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -2392,6 +2569,9 @@ Included in::
 
 Synopsis::
 AND with inverted operand
+
+Assembly::
+andn xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -2431,6 +2611,9 @@ Included in::
 Synopsis::
 Add upper immediate to pc
 
+Assembly::
+auipc xd, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -2463,6 +2646,9 @@ Included in::
 
 Synopsis::
 Single-Bit clear (Register)
+
+Assembly::
+bclr xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -2499,6 +2685,9 @@ Included in::
 
 Synopsis::
 Single-Bit clear (Immediate)
+
+Assembly::
+bclri xd, xs1, shamt
 
 Encoding::
 [NOTE]
@@ -2559,6 +2748,9 @@ Included in::
 Synopsis::
 Branch if equal
 
+Assembly::
+beq xs1, xs2, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -2597,6 +2789,9 @@ Included in::
 Synopsis::
 Single-Bit extract (Register)
 
+Assembly::
+bext xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -2632,6 +2827,9 @@ Included in::
 
 Synopsis::
 Single-Bit extract (Immediate)
+
+Assembly::
+bexti xd, xs1, shamt
 
 Encoding::
 [NOTE]
@@ -2692,6 +2890,9 @@ Included in::
 Synopsis::
 Branch if greater than or equal
 
+Assembly::
+bge xs1, xs2, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -2729,6 +2930,9 @@ Included in::
 
 Synopsis::
 Branch if greater than or equal unsigned
+
+Assembly::
+bgeu xs1, xs2, imm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -2768,6 +2972,9 @@ Included in::
 Synopsis::
 Single-Bit invert (Register)
 
+Assembly::
+binv xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -2803,6 +3010,9 @@ Included in::
 
 Synopsis::
 Single-Bit invert (Immediate)
+
+Assembly::
+binvi xd, xs1, shamt
 
 Encoding::
 [NOTE]
@@ -2863,6 +3073,9 @@ Included in::
 Synopsis::
 Branch if less than
 
+Assembly::
+blt xs1, xs2, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -2900,6 +3113,9 @@ Included in::
 
 Synopsis::
 Branch if less than unsigned
+
+Assembly::
+bltu xs1, xs2, imm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -2939,6 +3155,9 @@ Included in::
 Synopsis::
 Branch if not equal
 
+Assembly::
+bne xs1, xs2, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -2977,6 +3196,9 @@ Included in::
 Synopsis::
 Reverse bits in bytes
 
+Assembly::
+brev8 xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -3010,6 +3232,9 @@ Included in::
 
 Synopsis::
 Single-Bit set (Register)
+
+Assembly::
+bset xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -3046,6 +3271,9 @@ Included in::
 
 Synopsis::
 Single-Bit set (Immediate)
+
+Assembly::
+bseti xd, xs1, shamt
 
 Encoding::
 [NOTE]
@@ -3106,6 +3334,9 @@ Included in::
 Synopsis::
 Add
 
+Assembly::
+c.add xd, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -3142,6 +3373,9 @@ Included in::
 
 Synopsis::
 Add a sign-extended non-zero immediate
+
+Assembly::
+c.addi xd, imm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -3182,6 +3416,9 @@ Included in::
 Synopsis::
 Add a sign-extended non-zero immediate
 
+Assembly::
+c.addi16sp sp, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -3219,6 +3456,9 @@ Included in::
 
 Synopsis::
 Add a zero-extended non-zero immediate, scaled by 4, to the stack pointer
+
+Assembly::
+c.addi4spn xd, sp, imm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -3259,6 +3499,9 @@ Included in::
 Synopsis::
 Add a sign-extended non-zero immediate
 
+Assembly::
+c.addiw xd, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -3298,6 +3541,9 @@ Included in::
 Synopsis::
 Add word
 
+Assembly::
+c.addw xd, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -3335,6 +3581,9 @@ Included in::
 
 Synopsis::
 And
+
+Assembly::
+c.and xd, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -3374,6 +3623,9 @@ Included in::
 Synopsis::
 And immediate
 
+Assembly::
+c.andi xd, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -3412,6 +3664,9 @@ Included in::
 Synopsis::
 Branch if Equal Zero
 
+Assembly::
+c.beqz xs1, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -3448,6 +3703,9 @@ Included in::
 
 Synopsis::
 Branch if NOT Equal Zero
+
+Assembly::
+c.bnez xs1, imm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -3528,6 +3786,9 @@ Included in::
 Synopsis::
 Load double-precision
 
+Assembly::
+c.fld fd, imm(xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -3564,6 +3825,9 @@ Included in::
 Synopsis::
 Load doubleword into floating-point register from stack
 
+Assembly::
+c.fldsp fd, imm(sp)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -3598,6 +3862,9 @@ Included in::
 
 Synopsis::
 Load single-precision
+
+Assembly::
+c.flw fd, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -3635,6 +3902,9 @@ Included in::
 Synopsis::
 Load word into floating-point register from stack
 
+Assembly::
+c.flwsp fd, imm(sp)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -3669,6 +3939,9 @@ Included in::
 
 Synopsis::
 Store double-precision
+
+Assembly::
+c.fsd fs2, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -3706,6 +3979,9 @@ Included in::
 Synopsis::
 Store double-precision value to stack
 
+Assembly::
+c.fsdsp fs2, imm(sp)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -3740,6 +4016,9 @@ Included in::
 
 Synopsis::
 Store single-precision
+
+Assembly::
+c.fsw fs2, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -3777,6 +4056,9 @@ Included in::
 Synopsis::
 Store single-precision value to stack
 
+Assembly::
+c.fswsp fs2, imm(sp)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -3811,6 +4093,9 @@ Included in::
 
 Synopsis::
 Jump
+
+Assembly::
+c.j imm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -3848,6 +4133,9 @@ Included in::
 Synopsis::
 Jump and Link
 
+Assembly::
+c.jal imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -3883,6 +4171,9 @@ Included in::
 
 Synopsis::
 Jump and Link Register
+
+Assembly::
+c.jalr xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -3920,6 +4211,9 @@ Included in::
 Synopsis::
 Jump Register
 
+Assembly::
+c.jr xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -3955,6 +4249,9 @@ Included in::
 
 Synopsis::
 Load unsigned byte, 16-bit encoding
+
+Assembly::
+c.lbu xd, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -3994,6 +4291,9 @@ Included in::
 
 Synopsis::
 Load double
+
+Assembly::
+c.ld xd, imm(xs1)
 
 Encoding::
 [NOTE]
@@ -4060,6 +4360,9 @@ Included in::
 Synopsis::
 Load doubleword from stack pointer
 
+Assembly::
+c.ldsp xd, imm(sp)
+
 Encoding::
 [NOTE]
 This instruction has different encodings in RV32 and RV64
@@ -4122,6 +4425,9 @@ Included in::
 Synopsis::
 Load signed halfword, 16-bit encoding
 
+Assembly::
+c.lh xd, imm(xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -4160,6 +4466,9 @@ Included in::
 
 Synopsis::
 Load unsigned halfword, 16-bit encoding
+
+Assembly::
+c.lhu xd, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -4200,6 +4509,9 @@ Included in::
 Synopsis::
 Load the sign-extended 6-bit immediate
 
+Assembly::
+c.li xd, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -4237,6 +4549,9 @@ Included in::
 
 Synopsis::
 Load the non-zero 6-bit immediate field into bits 17-12 of the destination register
+
+Assembly::
+c.lui xd, imm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -4277,6 +4592,9 @@ Included in::
 Synopsis::
 Load word
 
+Assembly::
+c.lw xd, imm(xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -4316,6 +4634,9 @@ Included in::
 
 Synopsis::
 Load word from stack pointer
+
+Assembly::
+c.lwsp xd, imm(sp)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -4389,6 +4710,9 @@ Included in::
 Synopsis::
 Multiply, 16-bit encoding
 
+Assembly::
+c.mul xd, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -4424,6 +4748,9 @@ Included in::
 
 Synopsis::
 Move Register
+
+Assembly::
+c.mv xd, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -4493,6 +4820,9 @@ Included in::
 Synopsis::
 Bitwise not, 16-bit encoding
 
+Assembly::
+c.not xd
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -4528,6 +4858,9 @@ Included in::
 
 Synopsis::
 Or
+
+Assembly::
+c.or xd, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -4567,6 +4900,9 @@ Included in::
 Synopsis::
 Store unsigned byte, 16-bit encoding
 
+Assembly::
+c.sb xs2, imm(xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -4605,6 +4941,9 @@ Included in::
 
 Synopsis::
 Store double
+
+Assembly::
+c.sd xs2, imm(xs1)
 
 Encoding::
 [NOTE]
@@ -4670,6 +5009,9 @@ Included in::
 Synopsis::
 Store doubleword to stack
 
+Assembly::
+c.sdsp xs2, imm(sp)
+
 Encoding::
 [NOTE]
 This instruction has different encodings in RV32 and RV64
@@ -4732,6 +5074,9 @@ Included in::
 Synopsis::
 Sign-extend byte, 16-bit encoding
 
+Assembly::
+c.sext.b xd
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -4769,6 +5114,9 @@ Included in::
 Synopsis::
 Sign-extend halfword, 16-bit encoding
 
+Assembly::
+c.sext.h xd
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -4805,6 +5153,9 @@ Included in::
 
 Synopsis::
 Store unsigned halfword, 16-bit encoding
+
+Assembly::
+c.sh xs2, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -4844,6 +5195,9 @@ Included in::
 
 Synopsis::
 Shift left logical immediate
+
+Assembly::
+c.slli xd, shamt
 
 Encoding::
 [NOTE]
@@ -4902,6 +5256,9 @@ Included in::
 
 Synopsis::
 Shift right arithmetical immediate
+
+Assembly::
+c.srai xd, shamt
 
 Encoding::
 [NOTE]
@@ -4962,6 +5319,9 @@ Included in::
 Synopsis::
 Shift right logical immediate
 
+Assembly::
+c.srli xd, shamt
+
 Encoding::
 [NOTE]
 This instruction has different encodings in RV32 and RV64
@@ -5021,6 +5381,9 @@ Included in::
 Synopsis::
 Subtract
 
+Assembly::
+c.sub xd, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -5059,6 +5422,9 @@ Included in::
 Synopsis::
 Subtract word
 
+Assembly::
+c.subw xd, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -5096,6 +5462,9 @@ Included in::
 
 Synopsis::
 Store word
+
+Assembly::
+c.sw xs2, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -5137,6 +5506,9 @@ Included in::
 Synopsis::
 Store word to stack
 
+Assembly::
+c.swsp xs2, imm(sp)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -5176,6 +5548,9 @@ Included in::
 Synopsis::
 Exclusive Or
 
+Assembly::
+c.xor xd, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -5214,6 +5589,9 @@ Included in::
 Synopsis::
 Zero-extend byte, 16-bit encoding
 
+Assembly::
+c.zext.b xd
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -5250,6 +5628,9 @@ Included in::
 
 Synopsis::
 Zero-extend halfword, 16-bit encoding
+
+Assembly::
+c.zext.h xd
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -5288,6 +5669,9 @@ Included in::
 Synopsis::
 Zero-extend word, 16-bit encoding
 
+Assembly::
+c.zext.w xd
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -5323,6 +5707,9 @@ Included in::
 
 Synopsis::
 Cache Block Clean
+
+Assembly::
+cbo.clean (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -5385,6 +5772,9 @@ Included in::
 Synopsis::
 Cache Block Flush
 
+Assembly::
+cbo.flush (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -5439,6 +5829,9 @@ Included in::
 
 Synopsis::
 Cache Block Invalidate
+
+Assembly::
+cbo.inval (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -5534,6 +5927,9 @@ Included in::
 Synopsis::
 Cache Block Zero
 
+Assembly::
+cbo.zero (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -5591,6 +5987,9 @@ Included in::
 Synopsis::
 Carry-less multiply (low-part)
 
+Assembly::
+clmul xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -5627,6 +6026,9 @@ Included in::
 
 Synopsis::
 Carry-less multiply (high-part)
+
+Assembly::
+clmulh xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -5665,6 +6067,9 @@ Included in::
 Synopsis::
 Carry-less multiply (reversed)
 
+Assembly::
+clmulr xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -5699,6 +6104,9 @@ Included in::
 
 Synopsis::
 Count leading zero bits
+
+Assembly::
+clz xd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -5737,6 +6145,9 @@ Included in::
 Synopsis::
 Count leading zero bits in word
 
+Assembly::
+clzw xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -5773,6 +6184,9 @@ Included in::
 Synopsis::
 Move two s0-s7 registers into a0-a1
 
+Assembly::
+cm.mva01s r1s, r2s
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -5807,6 +6221,9 @@ Included in::
 
 Synopsis::
 Move a0-a1 into two registers of s0-s7
+
+Assembly::
+cm.mvsa01 r1s, r2s
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -5844,6 +6261,9 @@ Included in::
 
 Synopsis::
 Destroy function call stack frame
+
+Assembly::
+cm.pop reg_list, stack_adj
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -5887,6 +6307,9 @@ Included in::
 Synopsis::
 Destroy function call stack frame and return to `ra`
 
+Assembly::
+cm.popret reg_list, stack_adj
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -5928,6 +6351,9 @@ Included in::
 
 Synopsis::
 Destroy function call stack frame, move zero to `a0` and return to `ra`
+
+Assembly::
+cm.popretz reg_list, stack_adj
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -5971,6 +6397,9 @@ Included in::
 Synopsis::
 Create function call stack frame
 
+Assembly::
+cm.push reg_list, -stack_adj
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -6013,6 +6442,9 @@ Included in::
 
 Synopsis::
 Count set bits
+
+Assembly::
+cpop xd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -6060,6 +6492,9 @@ Included in::
 Synopsis::
 Count set bits in word
 
+Assembly::
+cpopw xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -6105,6 +6540,9 @@ Included in::
 
 Synopsis::
 Atomic Read and Clear Bits in CSR
+
+Assembly::
+csrrc xd, csr, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -6152,6 +6590,9 @@ Included in::
 Synopsis::
 Atomic Read and Clear Bits in CSR with Immediate
 
+Assembly::
+csrrci xd, csr, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -6191,6 +6632,9 @@ Included in::
 
 Synopsis::
 Atomic Read and Set Bits in CSR
+
+Assembly::
+csrrs xd, csr, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -6234,6 +6678,9 @@ Included in::
 Synopsis::
 Atomic Read and Set Bits in CSR with Immediate
 
+Assembly::
+csrrsi xd, csr, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -6273,6 +6720,9 @@ Included in::
 
 Synopsis::
 Atomic Read/Write CSR
+
+Assembly::
+csrrw xd, csr, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -6315,6 +6765,9 @@ Included in::
 Synopsis::
 Atomic Read/Write CSR Immediate
 
+Assembly::
+csrrwi xd, csr, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -6356,6 +6809,9 @@ Included in::
 Synopsis::
 Count trailing zero bits
 
+Assembly::
+ctz xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -6393,6 +6849,9 @@ Included in::
 
 Synopsis::
 Count trailing zero bits in word
+
+Assembly::
+ctzw xd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -6432,6 +6891,9 @@ Included in::
 Synopsis::
 Conditional zero, if condition is equal to zero
 
+Assembly::
+czero.eqz xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -6470,6 +6932,9 @@ Included in::
 Synopsis::
 Conditional zero, if condition is nonzero
 
+Assembly::
+czero.nez xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -6507,6 +6972,9 @@ Included in::
 
 Synopsis::
 Signed division
+
+Assembly::
+div xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -6548,6 +7016,9 @@ Included in::
 Synopsis::
 Unsigned division
 
+Assembly::
+divu xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -6587,6 +7058,9 @@ Included in::
 Synopsis::
 Unsigned 32-bit division
 
+Assembly::
+divuw xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -6625,6 +7099,9 @@ Included in::
 
 Synopsis::
 Signed 32-bit division
+
+Assembly::
+divw xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -6668,6 +7145,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+dret dret
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -6781,6 +7261,9 @@ Included in::
 Synopsis::
 Floating-point Add Double-precision
 
+Assembly::
+fadd.d fd, fs1, fs2, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -6818,6 +7301,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fadd.h fd, fs1, fs2, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -6853,6 +7339,9 @@ Included in::
 
 Synopsis::
 Floating-point Add Quad-precision
+
+Assembly::
+fadd.q fd, fs1, fs2, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -6891,6 +7380,9 @@ Included in::
 Synopsis::
 Single-precision floating-point addition
 
+Assembly::
+fadd.s fd, fs1, fs2, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -6928,6 +7420,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fclass.d xd, fs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -6961,6 +7456,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fclass.h xd, fs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -6996,6 +7494,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fclass.q xd, fs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7029,6 +7530,9 @@ Included in::
 
 Synopsis::
 Single-precision floating-point classify
+
+Assembly::
+fclass.s xd, fs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -7088,6 +7592,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fcvt.bf16.s fd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7122,6 +7629,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fcvt.d.h fd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -7160,6 +7670,9 @@ Included in::
 Synopsis::
 Floating-point Convert Long to Double-precision
 
+Assembly::
+fcvt.d.l fd, xs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7195,6 +7708,9 @@ Included in::
 
 Synopsis::
 Floating-point Convert Unsigned Long to Double-precision
+
+Assembly::
+fcvt.d.lu fd, xs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -7232,6 +7748,9 @@ Included in::
 Synopsis::
 Floating-point Convert Quad-precision to Double-precision
 
+Assembly::
+fcvt.d.q fd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7266,6 +7785,9 @@ Included in::
 
 Synopsis::
 Floating-point Convert Single-precision to Double-precision
+
+Assembly::
+fcvt.d.s fd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -7305,6 +7827,9 @@ Included in::
 Synopsis::
 Floating-point Convert Word to Double-precision
 
+Assembly::
+fcvt.d.w fd, xs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7341,6 +7866,9 @@ Included in::
 
 Synopsis::
 Floating-point Convert Unsigned Word to Double-precision
+
+Assembly::
+fcvt.d.wu fd, xs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -7379,6 +7907,9 @@ Included in::
 Synopsis::
 Floating-point Convert Double-precision to Half-precision
 
+Assembly::
+fcvt.h.d fd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7416,6 +7947,9 @@ Included in::
 Synopsis::
 Floating-point Convert Long to Half-precision
 
+Assembly::
+fcvt.h.l fd, xs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7451,6 +7985,9 @@ Included in::
 Synopsis::
 Floating-point Convert Unsigned Long to Half-precision
 
+Assembly::
+fcvt.h.lu fd, xs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7485,6 +8022,9 @@ Included in::
 
 Synopsis::
 Floating-point Convert Quad-precision to Half-precision
+
+Assembly::
+fcvt.h.q fd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -7522,6 +8062,9 @@ Included in::
 
 Synopsis::
 Convert half-precision float to a single-precision float
+
+Assembly::
+fcvt.h.s fd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -7566,6 +8109,9 @@ Included in::
 Synopsis::
 Floating-point Convert Word to Half-precision
 
+Assembly::
+fcvt.h.w fd, xs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7601,6 +8147,9 @@ Included in::
 Synopsis::
 Floating-point Convert Unsigned Word to Half-precision
 
+Assembly::
+fcvt.h.wu fd, xs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7635,6 +8184,9 @@ Included in::
 
 Synopsis::
 Floating-point Convert Double-precision to Long
+
+Assembly::
+fcvt.l.d xd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -7672,6 +8224,9 @@ Included in::
 Synopsis::
 Floating-point Convert Half-precision to Long
 
+Assembly::
+fcvt.l.h xd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7707,6 +8262,9 @@ Included in::
 Synopsis::
 Floating-point Convert Quad-precision to Long
 
+Assembly::
+fcvt.l.q xd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7741,6 +8299,9 @@ Included in::
 
 Synopsis::
 Floating-point Convert Single-precision to Long
+
+Assembly::
+fcvt.l.s xd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -7778,6 +8339,9 @@ Included in::
 Synopsis::
 Floating-point Convert Double-precision to Unsigned Long
 
+Assembly::
+fcvt.lu.d xd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7814,6 +8378,9 @@ Included in::
 Synopsis::
 Floating-point Convert Half-precision to Unsigned Long
 
+Assembly::
+fcvt.lu.h xd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7849,6 +8416,9 @@ Included in::
 Synopsis::
 Floating-point Convert Quad-precision to Unsigned Long
 
+Assembly::
+fcvt.lu.q xd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7883,6 +8453,9 @@ Included in::
 
 Synopsis::
 Floating-point Convert Single-precision to Unsigned Long
+
+Assembly::
+fcvt.lu.s xd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -7920,6 +8493,9 @@ Included in::
 Synopsis::
 Floating-point Convert Double-precision to Quad-precision
 
+Assembly::
+fcvt.q.d fd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -7954,6 +8530,9 @@ Included in::
 
 Synopsis::
 Floating-point Convert Half-precision to Quad-precision
+
+Assembly::
+fcvt.q.h fd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -7992,6 +8571,9 @@ Included in::
 Synopsis::
 Floating-point Convert Long to Quad-precision
 
+Assembly::
+fcvt.q.l fd, xs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8026,6 +8608,9 @@ Included in::
 
 Synopsis::
 Floating-point Convert Unsigned Long to Quad-precision
+
+Assembly::
+fcvt.q.lu fd, xs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -8062,6 +8647,9 @@ Included in::
 Synopsis::
 Floating-point Convert Single-precision to Quad-precision
 
+Assembly::
+fcvt.q.s fd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8096,6 +8684,9 @@ Included in::
 
 Synopsis::
 Floating-point Convert Word to Quad-precision
+
+Assembly::
+fcvt.q.w fd, xs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -8132,6 +8723,9 @@ Included in::
 Synopsis::
 Floating-point Convert Unsigned Word to Quad-precision
 
+Assembly::
+fcvt.q.wu fd, xs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8167,6 +8761,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fcvt.s.bf16 fd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8201,6 +8798,9 @@ Included in::
 
 Synopsis::
 Floating-point Convert Double-precision to Single-precision
+
+Assembly::
+fcvt.s.d fd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -8239,6 +8839,9 @@ Included in::
 
 Synopsis::
 Convert single-precision float to a half-precision float
+
+Assembly::
+fcvt.s.h fd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -8280,6 +8883,9 @@ Included in::
 Synopsis::
 Floating-point Convert Long to Single-precision
 
+Assembly::
+fcvt.s.l fd, xs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8316,6 +8922,9 @@ Included in::
 Synopsis::
 Floating-point Convert Unsigned Long to Single-precision
 
+Assembly::
+fcvt.s.lu fd, xs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8351,6 +8960,9 @@ Included in::
 Synopsis::
 Floating-point Convert Quad-precision to Single-precision
 
+Assembly::
+fcvt.s.q fd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8385,6 +8997,9 @@ Included in::
 
 Synopsis::
 Convert signed 32-bit integer to single-precision float
+
+Assembly::
+fcvt.s.w fd, xs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -8430,6 +9045,9 @@ Included in::
 Synopsis::
 Convert unsigned 32-bit integer to single-precision float
 
+Assembly::
+fcvt.s.wu fd, xs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8474,6 +9092,9 @@ Included in::
 Synopsis::
 Floating-point Convert Double-precision to Word
 
+Assembly::
+fcvt.w.d xd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8510,6 +9131,9 @@ Included in::
 Synopsis::
 Floating-point Convert Half-precision to Word
 
+Assembly::
+fcvt.w.h xd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8545,6 +9169,9 @@ Included in::
 Synopsis::
 Floating-point Convert Quad-precision to Word
 
+Assembly::
+fcvt.w.q xd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8579,6 +9206,9 @@ Included in::
 
 Synopsis::
 Convert single-precision float to signed word.
+
+Assembly::
+fcvt.w.s xd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -8643,6 +9273,9 @@ Included in::
 Synopsis::
 Floating-point Convert Double-precision to Unsigned Word
 
+Assembly::
+fcvt.wu.d xd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8679,6 +9312,9 @@ Included in::
 Synopsis::
 Floating-point Convert Half-precision to Word
 
+Assembly::
+fcvt.wu.h xd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8714,6 +9350,9 @@ Included in::
 Synopsis::
 Floating-point Convert Unsigned Quad-precision to Word
 
+Assembly::
+fcvt.wu.q xd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8748,6 +9387,9 @@ Included in::
 
 Synopsis::
 Convert single-precision float to unsigned word.
+
+Assembly::
+fcvt.wu.s xd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -8811,6 +9453,9 @@ Included in::
 Synopsis::
 Floating-point Convert Double-precision to Word with Modulo
 
+Assembly::
+fcvtmod.w.d xd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8856,6 +9501,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fdiv.d fd, fs1, fs2, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8891,6 +9539,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fdiv.h fd, fs1, fs2, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -8928,6 +9579,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fdiv.q fd, fs1, fs2, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8964,6 +9618,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fdiv.s fd, fs1, fs2, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -8999,6 +9656,9 @@ Included in::
 
 Synopsis::
 Memory oxdering fence
+
+Assembly::
+fence pred, succ
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -9255,6 +9915,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+feq.d xd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -9289,6 +9952,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+feq.h xd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -9325,6 +9991,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+feq.q xd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -9359,6 +10028,9 @@ Included in::
 
 Synopsis::
 Single-precision floating-point equal
+
+Assembly::
+feq.s xd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -9399,6 +10071,9 @@ Included in::
 Synopsis::
 Load Double-precision Floating-Point
 
+Assembly::
+fld fd, imm(xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -9433,6 +10108,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fle.d xd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -9469,6 +10147,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fle.h xd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -9504,6 +10185,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fle.q xd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -9538,6 +10222,9 @@ Included in::
 
 Synopsis::
 Single-precision floating-point less than or equal
+
+Assembly::
+fle.s xd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -9579,6 +10266,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fleq.d xd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -9615,6 +10305,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fleq.h xd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -9653,6 +10346,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fleq.q xd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -9690,6 +10386,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fleq.s xd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -9724,6 +10423,9 @@ Included in::
 
 Synopsis::
 Half-precision floating-point load
+
+Assembly::
+flh fd, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -9768,6 +10470,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fli.d fd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -9803,6 +10508,9 @@ Included in::
 
 Synopsis::
 Floating-point Load Immediate Half-precision
+
+Assembly::
+fli.h fd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -9840,6 +10548,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fli.q fd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -9876,6 +10587,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fli.s fd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -9909,6 +10623,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+flq fd, xs1, imm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -9945,6 +10662,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+flt.d xd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -9979,6 +10699,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+flt.h xd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -10015,6 +10738,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+flt.q xd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -10049,6 +10775,9 @@ Included in::
 
 Synopsis::
 Single-precision floating-point less than
+
+Assembly::
+flt.s xd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -10088,6 +10817,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fltq.d xd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -10124,6 +10856,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fltq.h xd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -10162,6 +10897,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fltq.q fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -10199,6 +10937,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fltq.s xd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -10233,6 +10974,9 @@ Included in::
 
 Synopsis::
 Single-precision floating-point load
+
+Assembly::
+flw fd, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -10271,6 +11015,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmadd.d fd, fs1, fs2, fs3, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -10307,6 +11054,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fmadd.h fd, fs1, fs2, fs3, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -10345,6 +11095,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmadd.q fd, fs1, fs2, fs3, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -10381,6 +11134,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fmadd.s fd, fs1, fs2, fs3, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -10419,6 +11175,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmax.d fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -10453,6 +11212,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fmax.h fd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -10489,6 +11251,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmax.q fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -10524,6 +11289,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmax.s fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -10558,6 +11326,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fmaxm.d fd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -10596,6 +11367,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmaxm.h fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -10632,6 +11406,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fmaxm.q fd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -10670,6 +11447,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmaxm.s fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -10704,6 +11484,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fmin.d fd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -10740,6 +11523,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmin.h fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -10774,6 +11560,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fmin.q fd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -10810,6 +11599,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmin.s fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -10844,6 +11636,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fminm.d fd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -10882,6 +11677,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fminm.h fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -10918,6 +11716,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fminm.q fd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -10956,6 +11757,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fminm.s fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -10990,6 +11794,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fmsub.d fd, fs1, fs2, fs3, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -11028,6 +11835,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmsub.h fd, fs1, fs2, fs3, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -11064,6 +11874,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fmsub.q fd, fs1, fs2, fs3, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -11102,6 +11915,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmsub.s fd, fs1, fs2, fs3, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -11139,6 +11955,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmul.d fd, fs1, fs2, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -11174,6 +11993,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fmul.h fd, fs1, fs2, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -11211,6 +12033,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmul.q fd, fs1, fs2, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -11246,6 +12071,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fmul.s fd, fs1, fs2, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -11283,6 +12111,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmv.d.x fd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -11316,6 +12147,9 @@ Included in::
 
 Synopsis::
 Half-precision floating-point move from integer
+
+Assembly::
+fmv.h.x fd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -11354,6 +12188,9 @@ Included in::
 Synopsis::
 Single-precision floating-point move from integer
 
+Assembly::
+fmv.w.x fd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -11391,6 +12228,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmv.x.d xd, fs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -11424,6 +12264,9 @@ Included in::
 
 Synopsis::
 Move half-precision value from floating-point to integer register
+
+Assembly::
+fmv.x.h xd, fs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -11470,6 +12313,9 @@ Included in::
 Synopsis::
 Move single-precision value from floating-point to integer register
 
+Assembly::
+fmv.x.w xd, fs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -11509,6 +12355,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmvh.x.d xd, fs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -11545,6 +12394,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmvh.x.q xd, fs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -11580,6 +12432,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fmvp.d.x fd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -11618,6 +12473,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fmvp.q.x fd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -11654,6 +12512,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fnmadd.d fd, fs1, fs2, fs3, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -11692,6 +12553,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fnmadd.h fd, fs1, fs2, fs3, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -11728,6 +12592,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fnmadd.q fd, fs1, fs2, fs3, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -11766,6 +12633,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fnmadd.s fd, fs1, fs2, fs3, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -11802,6 +12672,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fnmsub.d fd, fs1, fs2, fs3, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -11840,6 +12713,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fnmsub.h fd, fs1, fs2, fs3, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -11876,6 +12752,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fnmsub.q fd, fs1, fs2, fs3, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -11914,6 +12793,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fnmsub.s fd, fs1, fs2, fs3, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -11950,6 +12832,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fround.d fd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -11988,6 +12873,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fround.h fd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -12024,6 +12912,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fround.q fd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -12062,6 +12953,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fround.s fd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -12096,6 +12990,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+froundnx.d fd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -12134,6 +13031,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+froundnx.h fd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -12170,6 +13070,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+froundnx.q fd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -12208,6 +13111,9 @@ Included in::
 Synopsis::
 Floating-point Round Single-precision to Integer with Inexact
 
+Assembly::
+froundnx.s fd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -12242,6 +13148,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fsd fs2, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -12278,6 +13187,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fsgnj.d fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -12312,6 +13224,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fsgnj.h fd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -12348,6 +13263,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fsgnj.q fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -12382,6 +13300,9 @@ Included in::
 
 Synopsis::
 Single-precision sign inject
+
+Assembly::
+fsgnj.s fd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -12420,6 +13341,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fsgnjn.d fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -12454,6 +13378,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fsgnjn.h fd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -12490,6 +13417,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fsgnjn.q fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -12524,6 +13454,9 @@ Included in::
 
 Synopsis::
 Single-precision sign inject negate
+
+Assembly::
+fsgnjn.s fd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -12562,6 +13495,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fsgnjx.d fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -12596,6 +13532,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fsgnjx.h fd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -12632,6 +13571,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fsgnjx.q fd, fs1, fs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -12666,6 +13608,9 @@ Included in::
 
 Synopsis::
 Single-precision sign inject exclusive or
+
+Assembly::
+fsgnjx.s fd, fs1, fs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -12703,6 +13648,9 @@ Included in::
 
 Synopsis::
 Half-precision floating-point store
+
+Assembly::
+fsh fs2, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -12750,6 +13698,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fsq fs2, imm(xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -12784,6 +13735,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fsqrt.d fd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -12820,6 +13774,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fsqrt.h fd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -12854,6 +13811,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fsqrt.q fd, fs1, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -12890,6 +13850,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fsqrt.s fd, fs1, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -12924,6 +13887,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+fsub.d fd, fs1, fs2, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -12961,6 +13927,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fsub.h fd, fs1, fs2, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -12997,6 +13966,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+fsub.q fd, fs1, fs2, rm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13032,6 +14004,9 @@ Included in::
 
 Synopsis::
 Single-precision floating-point subtraction
+
+Assembly::
+fsub.s fd, fs1, fs2, rm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -13070,6 +14045,9 @@ Included in::
 Synopsis::
 Single-precision floating-point store
 
+Assembly::
+fsw fs2, imm(xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13107,6 +14085,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+hfence.gvma xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13141,6 +14122,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+hfence.vvma xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13174,6 +14158,9 @@ Included in::
 
 Synopsis::
 Invalidate cached address translations
+
+Assembly::
+hinval.gvma xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -13212,6 +14199,9 @@ Included in::
 Synopsis::
 Invalidate cached address translations
 
+Assembly::
+hinval.vvma xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13249,6 +14239,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+hlv.b xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13282,6 +14275,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+hlv.bu xd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -13317,6 +14313,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+hlv.d xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13350,6 +14349,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+hlv.h xd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -13385,6 +14387,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+hlv.hu xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13418,6 +14423,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+hlv.w xd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -13453,6 +14461,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+hlv.wu xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13486,6 +14497,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+hlvx.hu xd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -13521,6 +14535,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+hlvx.wu xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13554,6 +14571,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+hsv.b xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -13589,6 +14609,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+hsv.d xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13622,6 +14645,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+hsv.h xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -13657,6 +14683,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+hsv.w xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13690,6 +14719,9 @@ Included in::
 
 Synopsis::
 Jump and link
+
+Assembly::
+jal xd, imm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -13725,6 +14757,9 @@ Included in::
 
 Synopsis::
 Jump and link register
+
+Assembly::
+jalr xd, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -13764,6 +14799,9 @@ Included in::
 Synopsis::
 Load byte
 
+Assembly::
+lb xd, imm(xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13801,6 +14839,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+lb.aq xd, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13834,6 +14875,9 @@ Included in::
 
 Synopsis::
 Load byte unsigned
+
+Assembly::
+lbu xd, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -13872,6 +14916,9 @@ Included in::
 Synopsis::
 Load doubleword
 
+Assembly::
+ld xd, imm(xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13907,6 +14954,9 @@ Included in::
 
 Synopsis::
 Load doubleword to even/odd register pair
+
+Assembly::
+ld xd, offset(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -13944,6 +14994,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+ld.aq xd, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -13977,6 +15030,9 @@ Included in::
 
 Synopsis::
 Load halfword
+
+Assembly::
+lh xd, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -14015,6 +15071,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+lh.aq xd, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -14048,6 +15107,9 @@ Included in::
 
 Synopsis::
 Load halfword unsigned
+
+Assembly::
+lhu xd, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -14086,6 +15148,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+lpad imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -14118,6 +15183,9 @@ Included in::
 
 Synopsis::
 Load reserved doubleword
+
+Assembly::
+lr.d xd, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -14190,6 +15258,9 @@ Included in::
 
 Synopsis::
 Load reserved word
+
+Assembly::
+lr.w xd, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -14268,6 +15339,9 @@ Included in::
 Synopsis::
 Load upper immediate
 
+Assembly::
+lui xd, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -14300,6 +15374,9 @@ Included in::
 
 Synopsis::
 Load word
+
+Assembly::
+lw xd, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -14338,6 +15415,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+lw.aq xd, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -14371,6 +15451,9 @@ Included in::
 
 Synopsis::
 Load word unsigned
+
+Assembly::
+lwu xd, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -14408,6 +15491,9 @@ Included in::
 
 Synopsis::
 Maximum
+
+Assembly::
+max xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -14452,6 +15538,9 @@ Included in::
 Synopsis::
 Unsigned maximum
 
+Assembly::
+maxu xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -14486,6 +15575,9 @@ Included in::
 
 Synopsis::
 Minimum
+
+Assembly::
+min xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -14522,6 +15614,9 @@ Included in::
 Synopsis::
 Unsigned minimum
 
+Assembly::
+minu xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -14557,6 +15652,9 @@ Included in::
 Synopsis::
 Machine mode resume from the RNMI or Double Trap handler
 
+Assembly::
+mnret mnret
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -14589,6 +15687,9 @@ Included in::
 
 Synopsis::
 Mock Instruction (Just for testing UDB)
+
+Assembly::
+mock xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -14629,6 +15730,9 @@ Included in::
 Synopsis::
 May-be-operation (1 source register)
 
+Assembly::
+mop.r.n xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -14664,6 +15768,9 @@ Included in::
 
 Synopsis::
 May-be-operation (2 source registers)
+
+Assembly::
+mop.rr.n xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -14732,6 +15839,9 @@ Included in::
 Synopsis::
 Signed multiply
 
+Assembly::
+mul xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -14778,6 +15888,9 @@ Included in::
 
 Synopsis::
 Signed multiply high
+
+Assembly::
+mulh xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -14826,6 +15939,9 @@ Included in::
 Synopsis::
 Signed/unsigned multiply high
 
+Assembly::
+mulhsu xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -14872,6 +15988,9 @@ Included in::
 
 Synopsis::
 Unsigned multiply high
+
+Assembly::
+mulhu xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -14920,6 +16039,9 @@ Included in::
 Synopsis::
 Signed 32-bit multiply
 
+Assembly::
+mulw xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -14966,6 +16088,9 @@ Included in::
 Synopsis::
 Or
 
+Assembly::
+or xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -14999,6 +16124,9 @@ Included in::
 
 Synopsis::
 Bitware OR-combine, byte granule
+
+Assembly::
+orc.b xd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -15036,6 +16164,9 @@ Included in::
 Synopsis::
 Or immediate
 
+Assembly::
+ori xd, xs1, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -15069,6 +16200,9 @@ Included in::
 
 Synopsis::
 OR with inverted operand
+
+Assembly::
+orn xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -15107,6 +16241,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+pack xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -15141,6 +16278,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+packh xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -15177,6 +16317,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+packw xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -15211,6 +16354,9 @@ Included in::
 
 Synopsis::
 Signed remainder
+
+Assembly::
+rem xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -15251,6 +16397,9 @@ Included in::
 Synopsis::
 Unsigned remainder
 
+Assembly::
+remu xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -15285,6 +16434,9 @@ Included in::
 
 Synopsis::
 Unsigned 32-bit remainder
+
+Assembly::
+remuw xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -15323,6 +16475,9 @@ Included in::
 
 Synopsis::
 Signed 32-bit remainder
+
+Assembly::
+remw xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -15363,6 +16518,9 @@ Included in::
 
 Synopsis::
 Byte-reverse register (RV64 encoding)
+
+Assembly::
+rev8 xd, xs1
 
 Encoding::
 [NOTE]
@@ -15429,6 +16587,9 @@ Included in::
 Synopsis::
 Rotate left (Register)
 
+Assembly::
+rol xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -15465,6 +16626,9 @@ Included in::
 
 Synopsis::
 Rotate left word (Register)
+
+Assembly::
+rolw xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -15504,6 +16668,9 @@ Included in::
 Synopsis::
 Rotate right (Register)
 
+Assembly::
+ror xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -15540,6 +16707,9 @@ Included in::
 
 Synopsis::
 Rotate right (Immediate)
+
+Assembly::
+rori xd, xs1, shamt
 
 Encoding::
 [NOTE]
@@ -15601,6 +16771,9 @@ Included in::
 Synopsis::
 Rotate right word (Immediate)
 
+Assembly::
+roriw xd, xs1, shamt
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -15639,6 +16812,9 @@ Included in::
 
 Synopsis::
 Rotate right word (Register)
+
+Assembly::
+rorw xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -15679,6 +16855,9 @@ Included in::
 Synopsis::
 Store byte
 
+Assembly::
+sb xs2, imm(xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -15715,6 +16894,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sb.rl xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -15748,6 +16930,9 @@ Included in::
 
 Synopsis::
 Store conditional doubleword
+
+Assembly::
+sc.d xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -15877,6 +17062,9 @@ Included in::
 
 Synopsis::
 Store conditional word
+
+Assembly::
+sc.w xd, xs2, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -16013,6 +17201,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sctrclr sctrclr
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -16041,6 +17232,9 @@ Included in::
 
 Synopsis::
 Store doubleword
+
+Assembly::
+sd xs2, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -16078,6 +17272,9 @@ Included in::
 Synopsis::
 Store doubleword from even/odd register pair
 
+Assembly::
+sd xs2, offset(xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -16114,6 +17311,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sd.rl xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -16147,6 +17347,9 @@ Included in::
 
 Synopsis::
 Sign-extend byte
+
+Assembly::
+sext.b xd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -16182,6 +17385,9 @@ Included in::
 
 Synopsis::
 Sign-extend halfword
+
+Assembly::
+sext.h xd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -16248,6 +17454,9 @@ Included in::
 
 Synopsis::
 Supervisor memory-management fence
+
+Assembly::
+sfence.vma xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -16514,6 +17723,9 @@ Included in::
 Synopsis::
 Store halfword
 
+Assembly::
+sh xs2, imm(xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -16550,6 +17762,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sh.rl xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -16583,6 +17798,9 @@ Included in::
 
 Synopsis::
 Shift left by 1 and add
+
+Assembly::
+sh1add xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -16618,6 +17836,9 @@ Included in::
 
 Synopsis::
 Shift unsigned word left by 1 and add
+
+Assembly::
+sh1add.uw xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -16656,6 +17877,9 @@ Included in::
 Synopsis::
 Shift left by 2 and add
 
+Assembly::
+sh2add xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -16690,6 +17914,9 @@ Included in::
 
 Synopsis::
 Shift unsigned word left by 2 and add
+
+Assembly::
+sh2add.uw xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -16728,6 +17955,9 @@ Included in::
 Synopsis::
 Shift left by 3 and add
 
+Assembly::
+sh3add xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -16762,6 +17992,9 @@ Included in::
 
 Synopsis::
 Shift unsigned word left by 3 and add
+
+Assembly::
+sh3add.uw xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -16800,6 +18033,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sha256sig0 xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -16833,6 +18069,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+sha256sig1 xd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -16868,6 +18107,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sha256sum0 xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -16901,6 +18143,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+sha256sum1 xd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -16936,6 +18181,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sha512sig0 xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -16969,6 +18217,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+sha512sig0h xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -17005,6 +18256,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sha512sig0l xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -17040,6 +18294,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sha512sig1 xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -17073,6 +18330,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+sha512sig1h xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -17109,6 +18369,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sha512sig1l xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -17144,6 +18407,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sha512sum0 xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -17177,6 +18443,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+sha512sum0r xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -17213,6 +18482,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sha512sum1 xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -17246,6 +18518,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+sha512sum1r xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -17282,6 +18557,9 @@ Included in::
 Synopsis::
 Invalidate cached address translations
 
+Assembly::
+sinval.vma xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -17314,6 +18592,9 @@ Included in::
 
 Synopsis::
 Shift left logical
+
+Assembly::
+sll xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -17349,6 +18630,9 @@ Included in::
 
 Synopsis::
 Shift left logical immediate
+
+Assembly::
+slli xd, xs1, shamt
 
 Encoding::
 [NOTE]
@@ -17406,6 +18690,9 @@ Included in::
 Synopsis::
 Shift left unsigned word (Immediate)
 
+Assembly::
+slli.uw xd, xs1, shamt
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -17445,6 +18732,9 @@ Included in::
 Synopsis::
 Shift left logical immediate word
 
+Assembly::
+slliw xd, xs1, shamt
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -17478,6 +18768,9 @@ Included in::
 
 Synopsis::
 Shift left logical word
+
+Assembly::
+sllw xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -17513,6 +18806,9 @@ Included in::
 
 Synopsis::
 Set on less than
+
+Assembly::
+slt xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -17550,6 +18846,9 @@ Included in::
 Synopsis::
 Set on less than immediate
 
+Assembly::
+slti xd, xs1, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -17585,6 +18884,9 @@ Included in::
 
 Synopsis::
 Set on less than immediate unsigned
+
+Assembly::
+sltiu xd, xs1, imm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -17626,6 +18928,9 @@ Included in::
 Synopsis::
 Set on less than unsigned
 
+Assembly::
+sltu xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -17661,6 +18966,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+sm3p0 xd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -17698,6 +19006,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sm3p1 xd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -17733,6 +19044,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+sm4ed xd, xs1, xs2, bs
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -17772,6 +19086,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sm4ks xd, xs1, xs2, bs
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -17810,6 +19127,9 @@ Included in::
 Synopsis::
 Shift right arithmetic
 
+Assembly::
+sra xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -17844,6 +19164,9 @@ Included in::
 
 Synopsis::
 Shift right arithmetic immediate
+
+Assembly::
+srai xd, xs1, shamt
 
 Encoding::
 [NOTE]
@@ -17903,6 +19226,9 @@ Included in::
 Synopsis::
 Shift right arithmetic immediate word
 
+Assembly::
+sraiw xd, xs1, shamt
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -17938,6 +19264,9 @@ Included in::
 
 Synopsis::
 Shift right arithmetic word
+
+Assembly::
+sraw xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -18040,6 +19369,9 @@ Included in::
 Synopsis::
 Shift right logical
 
+Assembly::
+srl xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -18074,6 +19406,9 @@ Included in::
 
 Synopsis::
 Shift right logical immediate
+
+Assembly::
+srli xd, xs1, shamt
 
 Encoding::
 [NOTE]
@@ -18131,6 +19466,9 @@ Included in::
 Synopsis::
 Shift right logical immediate word
 
+Assembly::
+srliw xd, xs1, shamt
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -18164,6 +19502,9 @@ Included in::
 
 Synopsis::
 Shift right logical word
+
+Assembly::
+srlw xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -18199,6 +19540,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+ssamoswap.d xd, xs2, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -18237,6 +19581,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+ssamoswap.w xd, xs2, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -18274,6 +19621,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sspopchk.x1 sspopchk_x1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -18302,6 +19652,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+sspopchk.x5 sspopchk_x5
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -18332,6 +19685,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sspush.x1 sspush_x1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -18361,6 +19717,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sspush.x5 sspush_x5
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -18389,6 +19748,9 @@ Included in::
 
 Synopsis::
 Read ssp into a Register
+
+Assembly::
+ssrdp xd
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -18422,6 +19784,9 @@ Included in::
 
 Synopsis::
 Subtract
+
+Assembly::
+sub xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -18457,6 +19822,9 @@ Included in::
 Synopsis::
 Subtract word
 
+Assembly::
+subw xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -18490,6 +19858,9 @@ Included in::
 
 Synopsis::
 Store word
+
+Assembly::
+sw xs2, imm(xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -18527,6 +19898,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+sw.rl xs2, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -18560,6 +19934,9 @@ Included in::
 
 Synopsis::
 Bit deinterleave
+
+Assembly::
+unzip xd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -18597,6 +19974,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vaadd.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -18632,6 +20012,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vaadd.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -18669,6 +20052,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vaaddu.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -18704,6 +20090,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vaaddu.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -18741,6 +20130,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vadc.vim vd, vs2, imm, v0
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -18775,6 +20167,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vadc.vvm vd, vs2, vs1, v0
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -18811,6 +20206,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vadc.vxm vd, vs2, xs1, v0
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -18845,6 +20243,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vadd.vi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -18882,6 +20283,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vadd.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -18917,6 +20321,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vadd.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -18954,6 +20361,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vaesdf.vs vd, vs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -18987,6 +20397,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vaesdf.vv vd, vs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -19022,6 +20435,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vaesdm.vs vd, vs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19055,6 +20471,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vaesdm.vv vd, vs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -19090,6 +20509,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vaesef.vs vd, vs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19123,6 +20545,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vaesef.vv vd, vs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -19158,6 +20583,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vaesem.vs vd, vs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19192,6 +20620,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vaesem.vv vd, vs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19225,6 +20656,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vaeskf1.vi vd, vs2, imm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -19261,6 +20695,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vaeskf2.vi vd, vs2, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19296,6 +20733,9 @@ Included in::
 Synopsis::
 Vector AES round zero
 
+Assembly::
+vaesz.vs vd, vs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19329,6 +20769,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vand.vi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -19366,6 +20809,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vand.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19401,6 +20847,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vand.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -19438,6 +20887,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vandn.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19473,6 +20925,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vandn.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -19510,6 +20965,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vasub.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19545,6 +21003,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vasub.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -19582,6 +21043,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vasubu.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19617,6 +21081,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vasubu.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -19654,6 +21121,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vbrev.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19689,6 +21159,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vbrev8.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19723,6 +21196,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vclmul.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -19760,6 +21236,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vclmul.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19795,6 +21274,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vclmulh.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -19832,6 +21314,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vclmulh.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19868,6 +21353,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vclz.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19902,6 +21390,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vcompress.vm vd, vs2, vs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -19938,6 +21429,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vcpop.m xd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -19972,6 +21466,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vcpop.v vd, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -20008,6 +21505,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vctz.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -20042,6 +21542,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vdiv.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -20079,6 +21582,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vdiv.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -20114,6 +21620,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vdivu.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -20151,6 +21660,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vdivu.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -20186,6 +21698,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfadd.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -20223,6 +21738,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfadd.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -20259,6 +21777,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfclass.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -20293,6 +21814,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfcvt.f.x.v vd, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -20329,6 +21853,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfcvt.f.xu.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -20363,6 +21890,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfcvt.rtz.x.f.v vd, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -20399,6 +21929,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfcvt.rtz.xu.f.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -20433,6 +21966,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfcvt.x.f.v vd, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -20469,6 +22005,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfcvt.xu.f.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -20503,6 +22042,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfdiv.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -20540,6 +22082,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfdiv.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -20576,6 +22121,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfirst.m xd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -20610,6 +22158,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfmacc.vf vd, fs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -20647,6 +22198,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfmacc.vv vd, vs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -20682,6 +22236,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfmadd.vf vd, fs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -20719,6 +22276,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfmadd.vv vd, vs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -20754,6 +22314,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfmax.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -20791,6 +22354,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfmax.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -20827,6 +22393,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfmerge.vfm vd, vs2, fs1, v0
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -20861,6 +22430,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfmin.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -20898,6 +22470,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfmin.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -20933,6 +22508,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfmsac.vf vd, fs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -20970,6 +22548,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfmsac.vv vd, vs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21005,6 +22586,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfmsub.vf vd, fs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -21042,6 +22626,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfmsub.vv vd, vs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21077,6 +22664,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfmul.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -21114,6 +22704,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfmul.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21150,6 +22743,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfmv.f.s fd, vs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21183,6 +22779,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfmv.s.f vd, fs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -21218,6 +22817,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfmv.v.f vd, fs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21251,6 +22853,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfncvt.f.f.w vd, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -21287,6 +22892,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfncvt.f.x.w vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21321,6 +22929,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfncvt.f.xu.w vd, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -21357,6 +22968,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfncvt.rod.f.f.w vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21391,6 +23005,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfncvt.rtz.x.f.w vd, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -21427,6 +23044,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfncvt.rtz.xu.f.w vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21461,6 +23081,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfncvt.x.f.w vd, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -21497,6 +23120,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfncvt.xu.f.w vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21532,6 +23158,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfncvtbf16.f.f.w vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21566,6 +23195,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfnmacc.vf vd, fs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -21603,6 +23235,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfnmacc.vv vd, vs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21638,6 +23273,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfnmadd.vf vd, fs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -21675,6 +23313,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfnmadd.vv vd, vs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21710,6 +23351,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfnmsac.vf vd, fs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -21747,6 +23391,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfnmsac.vv vd, vs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21782,6 +23429,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfnmsub.vf vd, fs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -21819,6 +23469,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfnmsub.vv vd, vs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21854,6 +23507,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfrdiv.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -21891,6 +23547,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfrec7.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21925,6 +23584,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfredmax.vs vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -21962,6 +23624,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfredmin.vs vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -21997,6 +23662,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfredosum.vs vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -22034,6 +23702,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfredusum.vs vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -22070,6 +23741,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfrsqrt7.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -22104,6 +23778,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfrsub.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -22141,6 +23818,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfsgnj.vf vd, vs2, fs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -22176,6 +23856,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfsgnj.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -22213,6 +23896,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfsgnjn.vf vd, vs2, fs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -22248,6 +23934,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfsgnjn.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -22285,6 +23974,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfsgnjx.vf vd, vs2, fs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -22320,6 +24012,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfsgnjx.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -22357,6 +24052,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfslide1down.vf vd, vs2, fs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -22392,6 +24090,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfslide1up.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -22429,6 +24130,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfsqrt.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -22463,6 +24167,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfsub.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -22500,6 +24207,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfsub.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -22535,6 +24245,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfwadd.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -22572,6 +24285,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwadd.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -22607,6 +24323,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfwadd.wf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -22644,6 +24363,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwadd.wv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -22680,6 +24402,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwcvt.f.f.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -22714,6 +24439,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfwcvt.f.x.v vd, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -22750,6 +24478,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwcvt.f.xu.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -22784,6 +24515,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfwcvt.rtz.x.f.v vd, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -22820,6 +24554,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwcvt.rtz.xu.f.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -22854,6 +24591,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfwcvt.x.f.v vd, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -22890,6 +24630,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwcvt.xu.f.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -22925,6 +24668,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwcvtbf16.f.f.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -22959,6 +24705,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfwmacc.vf vd, fs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -22996,6 +24745,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwmacc.vv vd, vs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23031,6 +24783,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfwmaccbf16.vf vd, fs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -23068,6 +24823,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwmaccbf16.vv vd, vs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23103,6 +24861,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfwmsac.vf vd, fs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -23140,6 +24901,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwmsac.vv vd, vs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23175,6 +24939,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfwmul.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -23212,6 +24979,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwmul.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23247,6 +25017,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfwnmacc.vf vd, fs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -23284,6 +25057,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwnmacc.vv vd, vs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23319,6 +25095,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfwnmsac.vf vd, fs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -23356,6 +25135,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwnmsac.vv vd, vs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23391,6 +25173,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfwredosum.vs vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -23428,6 +25213,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwredusum.vs vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23463,6 +25251,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfwsub.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -23500,6 +25291,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwsub.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23535,6 +25329,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vfwsub.wf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -23572,6 +25369,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vfwsub.wv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23608,6 +25408,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vghsh.vv vd, vs2, vs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23643,6 +25446,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vgmul.vv vd, vs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23677,6 +25483,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vid.v vd, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23710,6 +25519,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+viota.m vd, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -23746,6 +25558,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vl1re16.v vd, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23779,6 +25594,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vl1re32.v vd, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -23814,6 +25632,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vl1re64.v vd, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23847,6 +25668,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vl1re8.v vd, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -23882,6 +25706,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vl2re16.v vd, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23915,6 +25742,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vl2re32.v vd, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -23950,6 +25780,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vl2re64.v vd, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -23983,6 +25816,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vl2re8.v vd, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -24018,6 +25854,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vl4re16.v vd, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -24051,6 +25890,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vl4re32.v vd, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -24086,6 +25928,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vl4re64.v vd, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -24119,6 +25964,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vl4re8.v vd, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -24154,6 +26002,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vl8re16.v vd, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -24187,6 +26038,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vl8re32.v vd, (xs1)
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -24222,6 +26076,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vl8re64.v vd, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -24256,6 +26113,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vl8re8.v vd, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -24289,6 +26149,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vle16.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -24325,6 +26188,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vle16ff.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -24359,6 +26225,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vle32.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -24395,6 +26264,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vle32ff.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -24429,6 +26301,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vle64.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -24465,6 +26340,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vle64ff.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -24499,6 +26377,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vle8.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -24535,6 +26416,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vle8ff.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -24570,6 +26454,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlm.v vd, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -24603,6 +26490,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -24640,6 +26530,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -24675,6 +26568,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -24712,6 +26608,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -24747,6 +26646,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxseg2ei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -24784,6 +26686,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxseg2ei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -24819,6 +26724,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxseg2ei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -24856,6 +26764,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxseg2ei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -24891,6 +26802,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxseg3ei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -24928,6 +26842,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxseg3ei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -24963,6 +26880,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxseg3ei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -25000,6 +26920,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxseg3ei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -25035,6 +26958,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxseg4ei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -25072,6 +26998,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxseg4ei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -25107,6 +27036,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxseg4ei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -25144,6 +27076,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxseg4ei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -25179,6 +27114,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxseg5ei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -25216,6 +27154,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxseg5ei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -25251,6 +27192,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxseg5ei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -25288,6 +27232,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxseg5ei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -25323,6 +27270,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxseg6ei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -25360,6 +27310,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxseg6ei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -25395,6 +27348,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxseg6ei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -25432,6 +27388,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxseg6ei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -25467,6 +27426,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxseg7ei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -25504,6 +27466,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxseg7ei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -25539,6 +27504,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxseg7ei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -25576,6 +27544,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxseg7ei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -25611,6 +27582,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxseg8ei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -25648,6 +27622,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxseg8ei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -25683,6 +27660,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vloxseg8ei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -25720,6 +27700,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vloxseg8ei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -25755,6 +27738,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlse16.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -25792,6 +27778,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlse32.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -25827,6 +27816,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlse64.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -25864,6 +27856,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlse8.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -25900,6 +27895,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg2e16.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -25934,6 +27932,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg2e16ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -25970,6 +27971,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg2e32.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -26004,6 +28008,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg2e32ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -26040,6 +28047,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg2e64.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -26074,6 +28084,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg2e64ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -26110,6 +28123,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg2e8.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -26144,6 +28160,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg2e8ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -26180,6 +28199,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg3e16.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -26214,6 +28236,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg3e16ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -26250,6 +28275,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg3e32.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -26284,6 +28312,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg3e32ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -26320,6 +28351,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg3e64.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -26354,6 +28388,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg3e64ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -26390,6 +28427,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg3e8.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -26424,6 +28464,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg3e8ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -26460,6 +28503,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg4e16.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -26494,6 +28540,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg4e16ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -26530,6 +28579,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg4e32.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -26564,6 +28616,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg4e32ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -26600,6 +28655,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg4e64.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -26634,6 +28692,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg4e64ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -26670,6 +28731,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg4e8.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -26704,6 +28768,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg4e8ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -26740,6 +28807,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg5e16.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -26774,6 +28844,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg5e16ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -26810,6 +28883,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg5e32.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -26844,6 +28920,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg5e32ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -26880,6 +28959,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg5e64.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -26914,6 +28996,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg5e64ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -26950,6 +29035,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg5e8.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -26984,6 +29072,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg5e8ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -27020,6 +29111,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg6e16.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -27054,6 +29148,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg6e16ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -27090,6 +29187,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg6e32.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -27124,6 +29224,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg6e32ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -27160,6 +29263,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg6e64.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -27194,6 +29300,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg6e64ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -27230,6 +29339,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg6e8.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -27264,6 +29376,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg6e8ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -27300,6 +29415,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg7e16.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -27334,6 +29452,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg7e16ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -27370,6 +29491,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg7e32.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -27404,6 +29528,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg7e32ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -27440,6 +29567,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg7e64.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -27474,6 +29604,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg7e64ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -27510,6 +29643,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg7e8.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -27544,6 +29680,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg7e8ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -27580,6 +29719,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg8e16.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -27614,6 +29756,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg8e16ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -27650,6 +29795,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg8e32.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -27684,6 +29832,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg8e32ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -27720,6 +29871,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg8e64.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -27754,6 +29908,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlseg8e64ff.v vd, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -27790,6 +29947,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg8e8.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -27825,6 +29985,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlseg8e8ff.v vd, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -27859,6 +30022,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlsseg2e16.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -27896,6 +30062,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlsseg2e32.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -27931,6 +30100,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlsseg2e64.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -27968,6 +30140,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlsseg2e8.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -28003,6 +30178,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlsseg3e16.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -28040,6 +30218,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlsseg3e32.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -28075,6 +30256,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlsseg3e64.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -28112,6 +30296,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlsseg3e8.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -28147,6 +30334,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlsseg4e16.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -28184,6 +30374,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlsseg4e32.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -28219,6 +30412,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlsseg4e64.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -28256,6 +30452,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlsseg4e8.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -28291,6 +30490,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlsseg5e16.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -28328,6 +30530,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlsseg5e32.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -28363,6 +30568,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlsseg5e64.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -28400,6 +30608,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlsseg5e8.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -28435,6 +30646,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlsseg6e16.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -28472,6 +30686,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlsseg6e32.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -28507,6 +30724,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlsseg6e64.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -28544,6 +30764,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlsseg6e8.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -28579,6 +30802,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlsseg7e16.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -28616,6 +30842,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlsseg7e32.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -28651,6 +30880,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlsseg7e64.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -28688,6 +30920,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlsseg7e8.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -28723,6 +30958,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlsseg8e16.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -28760,6 +30998,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlsseg8e32.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -28795,6 +31036,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vlsseg8e64.v vd, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -28832,6 +31076,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vlsseg8e8.v vd, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -28867,6 +31114,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -28904,6 +31154,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -28939,6 +31192,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -28976,6 +31232,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -29011,6 +31270,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxseg2ei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -29048,6 +31310,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxseg2ei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -29083,6 +31348,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxseg2ei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -29120,6 +31388,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxseg2ei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -29155,6 +31426,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxseg3ei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -29192,6 +31466,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxseg3ei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -29227,6 +31504,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxseg3ei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -29264,6 +31544,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxseg3ei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -29299,6 +31582,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxseg4ei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -29336,6 +31622,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxseg4ei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -29371,6 +31660,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxseg4ei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -29408,6 +31700,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxseg4ei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -29443,6 +31738,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxseg5ei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -29480,6 +31778,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxseg5ei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -29515,6 +31816,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxseg5ei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -29552,6 +31856,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxseg5ei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -29587,6 +31894,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxseg6ei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -29624,6 +31934,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxseg6ei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -29659,6 +31972,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxseg6ei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -29696,6 +32012,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxseg6ei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -29731,6 +32050,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxseg7ei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -29768,6 +32090,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxseg7ei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -29803,6 +32128,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxseg7ei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -29840,6 +32168,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxseg7ei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -29875,6 +32206,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxseg8ei16.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -29912,6 +32246,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxseg8ei32.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -29947,6 +32284,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vluxseg8ei64.v vd, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -29984,6 +32324,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vluxseg8ei8.v vd, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30019,6 +32362,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmacc.vv vd, vs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -30056,6 +32402,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmacc.vx vd, xs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30092,6 +32441,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmadc.vi vd, vs2, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30126,6 +32478,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmadc.vim vd, vs2, imm, v0
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -30162,6 +32517,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmadc.vv vd, vs2, vs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30196,6 +32554,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmadc.vvm vd, vs2, vs1, v0
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -30232,6 +32593,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmadc.vx vd, vs2, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30267,6 +32631,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmadc.vxm vd, vs2, xs1, v0
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30301,6 +32668,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmadd.vv vd, vs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -30338,6 +32708,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmadd.vx vd, xs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30374,6 +32747,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmand.mm vd, vs2, vs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30409,6 +32785,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmandn.mm vd, vs2, vs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30443,6 +32822,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmax.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -30480,6 +32862,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmax.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30515,6 +32900,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmaxu.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -30552,6 +32940,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmaxu.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30588,6 +32979,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmerge.vim vd, vs2, imm, v0
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30622,6 +33016,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmerge.vvm vd, vs2, vs1, v0
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -30658,6 +33055,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmerge.vxm vd, vs2, xs1, v0
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30692,6 +33092,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmfeq.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -30729,6 +33132,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmfeq.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30764,6 +33170,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmfge.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -30801,6 +33210,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmfgt.vf vd, vs2, fs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30836,6 +33248,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmfle.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -30873,6 +33288,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmfle.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30908,6 +33326,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmflt.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -30945,6 +33366,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmflt.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -30980,6 +33404,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmfne.vf vd, vs2, fs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -31017,6 +33444,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmfne.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -31052,6 +33482,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmin.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -31089,6 +33522,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmin.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -31124,6 +33560,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vminu.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -31161,6 +33600,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vminu.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -31197,6 +33639,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmnand.mm vd, vs2, vs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -31231,6 +33676,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmnor.mm vd, vs2, vs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -31267,6 +33715,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmor.mm vd, vs2, vs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -31301,6 +33752,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmorn.mm vd, vs2, vs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -31337,6 +33791,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmsbc.vv vd, vs2, vs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -31371,6 +33828,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmsbc.vvm vd, vs2, vs1, v0
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -31407,6 +33867,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmsbc.vx vd, vs2, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -31441,6 +33904,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmsbc.vxm vd, vs2, xs1, v0
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -31477,6 +33943,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmsbf.m vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -31511,6 +33980,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmseq.vi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -31548,6 +34020,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmseq.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -31583,6 +34058,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmseq.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -31620,6 +34098,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmsgt.vi vd, vs2, imm, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -31655,6 +34136,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmsgt.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -31692,6 +34176,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmsgtu.vi vd, vs2, imm, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -31727,6 +34214,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmsgtu.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -31764,6 +34254,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmsif.m vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -31798,6 +34291,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmsle.vi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -31835,6 +34331,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmsle.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -31870,6 +34369,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmsle.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -31907,6 +34409,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmsleu.vi vd, vs2, imm, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -31942,6 +34447,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmsleu.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -31979,6 +34487,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmsleu.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -32014,6 +34525,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmslt.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -32051,6 +34565,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmslt.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -32086,6 +34603,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmsltu.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -32123,6 +34643,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmsltu.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -32158,6 +34681,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmsne.vi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -32195,6 +34721,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmsne.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -32230,6 +34759,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmsne.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -32267,6 +34799,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmsof.m vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -32301,6 +34836,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmul.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -32338,6 +34876,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmul.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -32373,6 +34914,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmulh.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -32410,6 +34954,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmulh.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -32445,6 +34992,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmulhsu.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -32482,6 +35032,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmulhsu.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -32517,6 +35070,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmulhu.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -32554,6 +35110,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmulhu.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -32590,6 +35149,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmv.s.x vd, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -32623,6 +35185,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmv.v.i vd, imm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -32658,6 +35223,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmv.v.v vd, vs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -32691,6 +35259,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmv.v.x vd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -32726,6 +35297,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmv.x.s xd, vs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -32759,6 +35333,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmv1r.v vd, vs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -32794,6 +35371,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmv2r.v vd, vs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -32827,6 +35407,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmv4r.v vd, vs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -32862,6 +35445,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmv8r.v vd, vs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -32895,6 +35481,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vmxnor.mm vd, vs2, vs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -32931,6 +35520,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vmxor.mm vd, vs2, vs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -32965,6 +35557,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vnclip.wi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -33002,6 +35597,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vnclip.wv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -33037,6 +35635,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vnclip.wx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -33074,6 +35675,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vnclipu.wi vd, vs2, imm, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -33109,6 +35713,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vnclipu.wv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -33146,6 +35753,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vnclipu.wx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -33181,6 +35791,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vnmsac.vv vd, vs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -33218,6 +35831,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vnmsac.vx vd, xs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -33253,6 +35869,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vnmsub.vv vd, vs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -33290,6 +35909,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vnmsub.vx vd, xs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -33325,6 +35947,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vnsra.wi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -33362,6 +35987,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vnsra.wv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -33397,6 +36025,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vnsra.wx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -33434,6 +36065,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vnsrl.wi vd, vs2, imm, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -33469,6 +36103,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vnsrl.wv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -33506,6 +36143,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vnsrl.wx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -33541,6 +36181,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vor.vi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -33578,6 +36221,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vor.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -33613,6 +36259,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vor.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -33650,6 +36299,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vredand.vs vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -33685,6 +36337,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vredmax.vs vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -33722,6 +36377,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vredmaxu.vs vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -33757,6 +36415,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vredmin.vs vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -33794,6 +36455,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vredminu.vs vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -33829,6 +36493,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vredor.vs vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -33866,6 +36533,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vredsum.vs vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -33901,6 +36571,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vredxor.vs vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -33938,6 +36611,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vrem.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -33973,6 +36649,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vrem.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -34010,6 +36689,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vremu.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -34045,6 +36727,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vremu.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -34082,6 +36767,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vrev8.v vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -34116,6 +36804,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vrgather.vi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -34153,6 +36844,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vrgather.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -34188,6 +36882,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vrgather.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -34225,6 +36922,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vrgatherei16.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -34260,6 +36960,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vrol.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -34297,6 +37000,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vrol.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -34332,6 +37038,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vror.vi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -34369,6 +37078,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vror.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -34404,6 +37116,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vror.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -34441,6 +37156,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vrsub.vi vd, vs2, imm, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -34476,6 +37194,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vrsub.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -34513,6 +37234,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vs1r.v vs3, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -34546,6 +37270,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vs2r.v vs3, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -34581,6 +37308,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vs4r.v vs3, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -34615,6 +37345,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vs8r.v vs3, xs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -34648,6 +37381,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsadd.vi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -34685,6 +37421,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsadd.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -34720,6 +37459,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsadd.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -34757,6 +37499,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsaddu.vi vd, vs2, imm, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -34792,6 +37537,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsaddu.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -34829,6 +37577,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsaddu.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -34865,6 +37616,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsbc.vvm vd, vs2, vs1, v0
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -34899,6 +37653,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsbc.vxm vd, vs2, xs1, v0
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -34935,6 +37692,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vse16.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -34969,6 +37729,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vse32.v vs3, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -35005,6 +37768,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vse64.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -35039,6 +37805,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vse8.v vs3, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -35075,6 +37844,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsetivli xd, uimm, vtypei
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -35109,6 +37881,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsetvl xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -35145,6 +37920,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsetvli xd, xs1, vtypei
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -35179,6 +37957,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsext.vf2 vd, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -35215,6 +37996,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsext.vf4 vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -35249,6 +38033,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsext.vf8 vd, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -35285,6 +38072,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsha2ch.vv vd, vs2, vs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -35319,6 +38109,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsha2cl.vv vd, vs2, vs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -35355,6 +38148,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsha2ms.vv vd, vs2, vs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -35389,6 +38185,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vslide1down.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -35426,6 +38225,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vslide1up.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -35461,6 +38263,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vslidedown.vi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -35498,6 +38303,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vslidedown.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -35533,6 +38341,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vslideup.vi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -35570,6 +38381,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vslideup.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -35605,6 +38419,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsll.vi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -35642,6 +38459,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsll.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -35677,6 +38497,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsll.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -35714,6 +38537,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsm.v vs3, (xs1)
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -35747,6 +38573,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsm3c.vi vd, vs2, imm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -35785,6 +38614,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsm3me.vv vd, vs2, vs1
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -35821,6 +38653,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsm4k.vi vd, vs2, imm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -35859,6 +38694,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsm4r.vs vd, vs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -35894,6 +38732,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsm4r.vv vd, vs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -35931,6 +38772,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsmul.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -35966,6 +38810,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsmul.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -36003,6 +38850,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxei16.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -36038,6 +38888,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxei32.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -36075,6 +38928,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxei64.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -36110,6 +38966,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxei8.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -36147,6 +39006,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxseg2ei16.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -36182,6 +39044,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxseg2ei32.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -36219,6 +39084,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxseg2ei64.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -36254,6 +39122,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxseg2ei8.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -36291,6 +39162,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxseg3ei16.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -36326,6 +39200,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxseg3ei32.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -36363,6 +39240,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxseg3ei64.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -36398,6 +39278,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxseg3ei8.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -36435,6 +39318,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxseg4ei16.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -36470,6 +39356,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxseg4ei32.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -36507,6 +39396,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxseg4ei64.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -36542,6 +39434,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxseg4ei8.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -36579,6 +39474,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxseg5ei16.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -36614,6 +39512,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxseg5ei32.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -36651,6 +39552,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxseg5ei64.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -36686,6 +39590,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxseg5ei8.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -36723,6 +39630,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxseg6ei16.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -36758,6 +39668,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxseg6ei32.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -36795,6 +39708,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxseg6ei64.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -36830,6 +39746,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxseg6ei8.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -36867,6 +39786,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxseg7ei16.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -36902,6 +39824,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxseg7ei32.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -36939,6 +39864,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxseg7ei64.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -36974,6 +39902,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxseg7ei8.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -37011,6 +39942,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxseg8ei16.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -37046,6 +39980,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxseg8ei32.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -37083,6 +40020,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsoxseg8ei64.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -37118,6 +40058,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsoxseg8ei8.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -37155,6 +40098,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsra.vi vd, vs2, imm, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -37190,6 +40136,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsra.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -37227,6 +40176,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsra.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -37262,6 +40214,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsrl.vi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -37299,6 +40254,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsrl.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -37334,6 +40292,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsrl.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -37371,6 +40332,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsse16.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -37406,6 +40370,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsse32.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -37443,6 +40410,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsse64.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -37478,6 +40448,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsse8.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -37515,6 +40488,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsseg2e16.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -37549,6 +40525,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsseg2e32.v vs3, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -37585,6 +40564,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsseg2e64.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -37619,6 +40601,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsseg2e8.v vs3, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -37655,6 +40640,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsseg3e16.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -37689,6 +40677,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsseg3e32.v vs3, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -37725,6 +40716,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsseg3e64.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -37759,6 +40753,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsseg3e8.v vs3, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -37795,6 +40792,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsseg4e16.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -37829,6 +40829,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsseg4e32.v vs3, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -37865,6 +40868,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsseg4e64.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -37899,6 +40905,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsseg4e8.v vs3, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -37935,6 +40944,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsseg5e16.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -37969,6 +40981,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsseg5e32.v vs3, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -38005,6 +41020,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsseg5e64.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -38039,6 +41057,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsseg5e8.v vs3, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -38075,6 +41096,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsseg6e16.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -38109,6 +41133,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsseg6e32.v vs3, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -38145,6 +41172,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsseg6e64.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -38179,6 +41209,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsseg6e8.v vs3, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -38215,6 +41248,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsseg7e16.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -38249,6 +41285,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsseg7e32.v vs3, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -38285,6 +41324,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsseg7e64.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -38319,6 +41361,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsseg7e8.v vs3, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -38355,6 +41400,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsseg8e16.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -38389,6 +41437,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsseg8e32.v vs3, (xs1), vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -38425,6 +41476,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsseg8e64.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -38460,6 +41514,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsseg8e8.v vs3, (xs1), vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -38494,6 +41551,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssra.vi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -38531,6 +41591,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssra.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -38566,6 +41629,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssra.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -38603,6 +41669,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssrl.vi vd, vs2, imm, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -38638,6 +41707,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssrl.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -38675,6 +41747,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssrl.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -38710,6 +41785,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssseg2e16.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -38747,6 +41825,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssseg2e32.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -38782,6 +41863,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssseg2e64.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -38819,6 +41903,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssseg2e8.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -38854,6 +41941,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssseg3e16.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -38891,6 +41981,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssseg3e32.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -38926,6 +42019,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssseg3e64.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -38963,6 +42059,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssseg3e8.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -38998,6 +42097,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssseg4e16.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -39035,6 +42137,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssseg4e32.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -39070,6 +42175,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssseg4e64.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -39107,6 +42215,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssseg4e8.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -39142,6 +42253,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssseg5e16.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -39179,6 +42293,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssseg5e32.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -39214,6 +42331,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssseg5e64.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -39251,6 +42371,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssseg5e8.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -39286,6 +42409,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssseg6e16.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -39323,6 +42449,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssseg6e32.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -39358,6 +42487,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssseg6e64.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -39395,6 +42527,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssseg6e8.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -39430,6 +42565,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssseg7e16.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -39467,6 +42605,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssseg7e32.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -39502,6 +42643,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssseg7e64.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -39539,6 +42683,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssseg7e8.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -39574,6 +42721,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssseg8e16.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -39611,6 +42761,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssseg8e32.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -39646,6 +42799,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssseg8e64.v vs3, (xs1), xs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -39683,6 +42839,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssseg8e8.v vs3, (xs1), xs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -39718,6 +42877,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssub.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -39755,6 +42917,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssub.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -39790,6 +42955,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vssubu.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -39827,6 +42995,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vssubu.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -39862,6 +43033,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsub.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -39899,6 +43073,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsub.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -39934,6 +43111,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxei16.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -39971,6 +43151,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxei32.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -40006,6 +43189,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxei64.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -40043,6 +43229,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxei8.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -40078,6 +43267,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxseg2ei16.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -40115,6 +43307,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxseg2ei32.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -40150,6 +43345,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxseg2ei64.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -40187,6 +43385,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxseg2ei8.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -40222,6 +43423,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxseg3ei16.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -40259,6 +43463,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxseg3ei32.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -40294,6 +43501,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxseg3ei64.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -40331,6 +43541,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxseg3ei8.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -40366,6 +43579,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxseg4ei16.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -40403,6 +43619,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxseg4ei32.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -40438,6 +43657,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxseg4ei64.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -40475,6 +43697,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxseg4ei8.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -40510,6 +43735,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxseg5ei16.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -40547,6 +43775,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxseg5ei32.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -40582,6 +43813,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxseg5ei64.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -40619,6 +43853,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxseg5ei8.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -40654,6 +43891,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxseg6ei16.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -40691,6 +43931,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxseg6ei32.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -40726,6 +43969,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxseg6ei64.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -40763,6 +44009,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxseg6ei8.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -40798,6 +44047,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxseg7ei16.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -40835,6 +44087,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxseg7ei32.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -40870,6 +44125,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxseg7ei64.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -40907,6 +44165,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxseg7ei8.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -40942,6 +44203,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxseg8ei16.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -40979,6 +44243,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxseg8ei32.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -41014,6 +44281,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vsuxseg8ei64.v vs3, (xs1), vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -41051,6 +44321,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vsuxseg8ei8.v vs3, (xs1), vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -41086,6 +44359,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwadd.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -41123,6 +44399,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwadd.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -41158,6 +44437,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwadd.wv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -41195,6 +44477,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwadd.wx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -41230,6 +44515,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwaddu.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -41267,6 +44555,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwaddu.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -41302,6 +44593,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwaddu.wv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -41339,6 +44633,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwaddu.wx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -41374,6 +44671,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwmacc.vv vd, vs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -41411,6 +44711,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwmacc.vx vd, xs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -41446,6 +44749,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwmaccsu.vv vd, vs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -41483,6 +44789,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwmaccsu.vx vd, xs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -41518,6 +44827,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwmaccu.vv vd, vs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -41555,6 +44867,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwmaccu.vx vd, xs1, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -41590,6 +44905,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwmaccus.vx vd, xs1, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -41627,6 +44945,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwmul.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -41662,6 +44983,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwmul.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -41699,6 +45023,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwmulsu.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -41734,6 +45061,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwmulsu.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -41771,6 +45101,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwmulu.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -41806,6 +45139,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwmulu.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -41843,6 +45179,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwredsum.vs vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -41878,6 +45217,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwredsumu.vs vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -41915,6 +45257,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwsll.vi vd, vs2, imm, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -41950,6 +45295,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwsll.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -41987,6 +45335,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwsll.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -42022,6 +45373,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwsub.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -42059,6 +45413,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwsub.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -42094,6 +45451,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwsub.wv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -42131,6 +45491,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwsub.wx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -42166,6 +45529,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwsubu.vv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -42203,6 +45569,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwsubu.vx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -42238,6 +45607,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vwsubu.wv vd, vs2, vs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -42275,6 +45647,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vwsubu.wx vd, vs2, xs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -42310,6 +45685,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vxor.vi vd, vs2, imm, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -42347,6 +45725,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vxor.vv vd, vs2, vs1, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -42382,6 +45763,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vxor.vx vd, vs2, xs1, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -42419,6 +45803,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vzext.vf2 vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -42454,6 +45841,9 @@ Included in::
 Synopsis::
 No synopsis available
 
+Assembly::
+vzext.vf4 vd, vs2, vm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -42488,6 +45878,9 @@ Included in::
 
 Synopsis::
 No synopsis available
+
+Assembly::
+vzext.vf8 vd, vs2, vm
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -42705,6 +46098,9 @@ Included in::
 Synopsis::
 Exclusive NOR
 
+Assembly::
+xnor xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -42742,6 +46138,9 @@ Included in::
 Synopsis::
 Exclusive Or
 
+Assembly::
+xor xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -42776,6 +46175,9 @@ Included in::
 Synopsis::
 Exclusive Or immediate
 
+Assembly::
+xori xd, xs1, imm
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -42809,6 +46211,9 @@ Included in::
 
 Synopsis::
 Crossbar permutation (nibbles)
+
+Assembly::
+xperm4 xd, xs1, xs2
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -42847,6 +46252,9 @@ Included in::
 Synopsis::
 Crossbar permutation (bytes)
 
+Assembly::
+xperm8 xd, xs1, xs2
+
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -42883,6 +46291,9 @@ Included in::
 
 Synopsis::
 Zero-extend halfword
+
+Assembly::
+zext.h xd, xs1
 
 Encoding::
 [NOTE]
@@ -42942,6 +46353,9 @@ Included in::
 
 Synopsis::
 Bit interleave
+
+Assembly::
+zip xd, xs1
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]

--- a/backends/instructions_appendix/templates/instructions.adoc.erb
+++ b/backends/instructions_appendix/templates/instructions.adoc.erb
@@ -10,7 +10,7 @@
 Synopsis::
 <%= inst.long_name %>
 
-<%- if ENV['ASSEMBLY']=="1" && inst.assembly.to_s.strip != "" -%>
+<%- if inst.assembly.to_s.strip != "" -%>
 Assembly::
 <%= inst.fix_entities("#{inst.name.downcase} #{inst.assembly}") %>
 


### PR DESCRIPTION
It's time.

After a number of recent commits to both UDB and RISC-V Sail repositories, the only differences between the two with respect to assembly syntax are:
- `amo*.{aq,rl}` missing in UDB
- `mop.r.n`, `mop.rr.n`, `c.mop.n` appear unexpanded
- issue #821
- `vsetvli`, `vsetivli` have 2 forms of assembly syntax, and only a single syntax can be expressed currently in UDB

(And there are a number of instructions missing in Sail that are in UDB.)

Make the assembly syntax unconditionally appear in the generated instruction appendix.