### PR TITLE
Xqci: Fix unintended overflows

### DIFF
--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.c.extu.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.c.extu.yaml
@@ -32,5 +32,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg width = width_minus1 + 1;
-  X[rd] = (X[rd] >> 0) & ((32'b1 << width) - 1);
+  XReg width = width_minus1 `+ 1;
+  X[rd] = (X[rd] >> 0) & ((33'b1 << width) - 1);

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.ext.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.ext.yaml
@@ -37,6 +37,6 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg width = width_minus1 + 1;
-  XReg unsigned_extraction = (X[rs1] >> shamt) & ((32'b1 << width) - 1);
+  XReg width = width_minus1 `+ 1;
+  XReg unsigned_extraction = (X[rs1] >> shamt) & ((33'b1 << width) - 1);
   X[rd] = sext(unsigned_extraction, width);

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.extd.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.extd.yaml
@@ -38,5 +38,5 @@ access:
   vu: always
 operation(): |
   Bits<{1'b0, MXLEN}*2> pair = {X[rs1 + 1], X[rs1]};
-  XReg width = width_minus1 + 1;
-  X[rd] = sext((pair >> shamt) & ((32'b1 << width) - 1), width);
+  XReg width = width_minus1 `+ 1;
+  X[rd] = sext((pair >> shamt) & ((33'b1 << width) - 1), width);

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.extdpr.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.extdpr.yaml
@@ -9,7 +9,7 @@ name: qc.extdpr
 long_name: Extract bits from pair signed, packed descriptor (Register)
 description: |
   Extract a subset of bits from the register pair [`rs1`, `rs1`+1] into `rd`, and sign extend the result.
-  The width of the subset is determined by `rs2` bits [13:8] (0..32),
+  The width of the subset is determined by `rs2` bits [13:8] (0..63),
   and the offset of the subset is determined by `rs2` bits [5:0] (0..63).
   In case when `rs2` bit [13] == 1 width is enforced to 32.
   In case when width == 0, to the destination register written 0.
@@ -43,7 +43,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][5:0];
   if (width > 0) {
-    X[rd] = sext((pair >> shamt) & ((32'b1 << width) - 1), width);
+    X[rd] = sext((pair >> shamt) & ((33'b1 << width) - 1), width);
   } else {
     X[rd] = 0;
   }

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.extdprh.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.extdprh.yaml
@@ -43,7 +43,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][21:16];
   if (width > 0) {
-    X[rd] = sext((pair >> shamt) & ((32'b1 << width) - 1), width);
+    X[rd] = sext((pair >> shamt) & ((33'b1 << width) - 1), width);
   } else {
     X[rd] = 0;
   }

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.extdr.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.extdr.yaml
@@ -43,7 +43,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][5:0];
   if (width > 0) {
-    X[rd] = sext((pair >> shamt) & ((32'b1 << width) - 1), width);
+    X[rd] = sext((pair >> shamt) & ((33'b1 << width) - 1), width);
   } else {
     X[rd] = 0;
   }

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.extdu.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.extdu.yaml
@@ -38,5 +38,5 @@ access:
   vu: always
 operation(): |
   Bits<{1'b0, MXLEN}*2> pair = {X[rs1 + 1], X[rs1]};
-  XReg width = width_minus1 + 1;
-  X[rd] = (pair >> shamt) & ((32'b1 << width) - 1);
+  XReg width = width_minus1 `+ 1;
+  X[rd] = (pair >> shamt) & ((33'b1 << width) - 1);

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.extdupr.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.extdupr.yaml
@@ -43,7 +43,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][5:0];
   if (width > 0) {
-    X[rd] = (pair >> shamt) & ((32'b1 << width) - 1);
+    X[rd] = (pair >> shamt) & ((33'b1 << width) - 1);
   } else {
     X[rd] = 0;
   }

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.extduprh.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.extduprh.yaml
@@ -43,7 +43,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][21:16];
   if (width > 0) {
-    X[rd] = (pair >> shamt) & ((32'b1 << width) - 1);
+    X[rd] = (pair >> shamt) & ((33'b1 << width) - 1);
   } else {
     X[rd] = 0;
   }

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.extdur.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.extdur.yaml
@@ -43,7 +43,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][5:0];
   if (width > 0) {
-    X[rd] = (pair >> shamt) & ((32'b1 << width) - 1);
+    X[rd] = (pair >> shamt) & ((33'b1 << width) - 1);
   } else {
     X[rd] = 0;
   }

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.extu.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.extu.yaml
@@ -37,5 +37,5 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg width = width_minus1 + 1;
-  X[rd] = (X[rs1] >> shamt) & ((32'b1 << width) - 1);
+  XReg width = width_minus1 `+ 1;
+  X[rd] = (X[rs1] >> shamt) & ((33'b1 << width) - 1);

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.insb.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.insb.yaml
@@ -36,7 +36,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg width = width_minus1 + 1;
-  XReg mask = ((32'b1 << width) - 1) << shamt;
+  XReg width = width_minus1 `+ 1;
+  XReg mask = ((33'b1 << width) - 1) << shamt;
   XReg orig_val = X[rd];
   X[rd] = (orig_val & ~mask) | ((X[rs1] << shamt) & mask);

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.insbh.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.insbh.yaml
@@ -41,9 +41,9 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg width = width_minus1 + 1;
+  XReg width = width_minus1 `+ 1;
   if (width + shamt > 32) {
-    XReg shifted_one = 32'b1 << (width + shamt - 32);
+    Bits<33> shifted_one = 33'b1 << (width + shamt - 32);
     XReg mask = (shifted_one - 1);
     XReg orig_val = X[rd];
     XReg shifted_rs1 = X[rs1] >> (32 - shamt);

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.insbhr.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.insbhr.yaml
@@ -45,7 +45,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][4:0];
   if ((width + shamt > 32) && (width > 0)) {
-    XReg shifted_one = 32'b1 << (width + shamt - 32);
+    Bits<33> shifted_one = 33'b1 << (width + shamt - 32);
     XReg mask = (shifted_one - 1);
     XReg orig_val = X[rd];
     XReg shifted_rs1 = X[rs1] >> (32 - shamt);

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.insbi.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.insbi.yaml
@@ -36,7 +36,7 @@ access:
   vs: always
   vu: always
 operation(): |
-  XReg width = width_minus1 + 1;
-  XReg mask = ((32'b1 << width) - 1) << shamt;
+  XReg width = width_minus1 `+ 1;
+  XReg mask = ((33'b1 << width) - 1) << shamt;
   XReg orig_val = X[rd];
   X[rd] = (orig_val & ~mask) | ((imm << shamt) & mask);

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.insbpr.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.insbpr.yaml
@@ -41,7 +41,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][4:0];
   if (width > 0) {
-    XReg mask = ((32'b1 << width) - 1) << shamt;
+    XReg mask = ((33'b1 << width) - 1) << shamt;
     XReg orig_val = X[rd];
     X[rd] = (orig_val & ~mask) | ((X[rs1] << shamt) & mask);
   }

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.insbprh.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.insbprh.yaml
@@ -41,7 +41,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][20:16];
   if (width > 0) {
-    XReg mask = ((32'b1 << width) - 1) << shamt;
+    XReg mask = ((33'b1 << width) - 1) << shamt;
     XReg orig_val = X[rd];
     X[rd] = (orig_val & ~mask) | ((X[rs1] << shamt) & mask);
   }

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.insbr.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.insbr.yaml
@@ -41,7 +41,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs2][4:0];
   if (width > 0) {
-    XReg mask = ((32'b1 << width) - 1) << shamt;
+    XReg mask = ((33'b1 << width) - 1) << shamt;
     XReg orig_val = X[rd];
     X[rd] = (orig_val & ~mask) | ((X[rs1] << shamt) & mask);
   }

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.insbri.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.insbri.yaml
@@ -41,7 +41,7 @@ operation(): |
   XReg width = (width_bits > 32) ? 32 : width_bits;
   XReg shamt = X[rs1][4:0];
   if (width > 0) {
-    XReg mask = ((32'b1 << width) - 1) << shamt;
+    XReg mask = ((33'b1 << width) - 1) << shamt;
     XReg orig_val = X[rd];
     X[rd] = (orig_val & ~mask) | ((imm << shamt) & mask);
   }


### PR DESCRIPTION
This commit fixes two kinds of bugs:

1. Xreg width = width_minus1 + 1, where width_minus1 is a Bits<N> type with N smaller than 32. Since the C literal "1" is 1 bit in size it will be extended to N bits and the N-bit addition might overflow. The range of width is then [1,31] instead of [1,32] as intended.

2. (32'b1 << width)-1, similar problem, a shift of 32 will overflow meaning a 32-bit mask will be 0.

1. is fixed by using a widening add and 2. by swapping 32'b1 -> 33'b1. An alternative for 2. is computing the mask via {32{1}} >> (32-width).

What is the rationale for having C-style literals be represented by as few bits as possible, whereas Verilog-style literals are MXLEN when no explicit size is given? Why not have both be MXLEN in size? I feel this will lead to over-use of widening operations or a lot of unintended bugs when using C literals.