### PR TITLE
fix(data): fix field names to be closer to operands

### DIFF
--- a/backends/instructions_appendix/all_instructions.golden.adoc
+++ b/backends/instructions_appendix/all_instructions.golden.adoc
@@ -1,6 +1,6 @@
 = Instruction Appendix
 :doctype: book
-:wavedrom: /workspaces/riscv-unified-db/node_modules/.bin/wavedrom-cli
+:wavedrom: /workspace/riscv-unified-db/node_modules/.bin/wavedrom-cli
 // Now the document header is complete and the wavedrom attribute is active.
 
 
@@ -7145,9 +7145,6 @@ Included in::
 
 Synopsis::
 No synopsis available
-
-Assembly::
-dret dret
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -15646,9 +15643,6 @@ Included in::
 Synopsis::
 Machine mode resume from the RNMI or Double Trap handler
 
-Assembly::
-mnret mnret
-
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
@@ -17194,9 +17188,6 @@ Included in::
 
 Synopsis::
 No synopsis available
-
-Assembly::
-sctrclr sctrclr
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -20645,7 +20636,7 @@ vaeskf1.vi vd, vs2, imm
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "zimm5","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x45,"type":2}]}
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x45,"type":2}]}
 ....
 
 Description::
@@ -20657,7 +20648,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |vs2 |$encoding[24:20]
-|zimm5 |$encoding[19:15]
+|imm |$encoding[19:15]
 |vd |$encoding[11:7]
 |===
 
@@ -20683,7 +20674,7 @@ vaeskf2.vi vd, vs2, imm
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "zimm5","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x55,"type":2}]}
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x55,"type":2}]}
 ....
 
 Description::
@@ -20695,7 +20686,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |vs2 |$encoding[24:20]
-|zimm5 |$encoding[19:15]
+|imm |$encoding[19:15]
 |vd |$encoding[11:7]
 |===
 
@@ -38562,7 +38553,7 @@ vsm3c.vi vd, vs2, imm
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "zimm5","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x57,"type":2}]}
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x57,"type":2}]}
 ....
 
 Description::
@@ -38574,7 +38565,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |vs2 |$encoding[24:20]
-|zimm5 |$encoding[19:15]
+|imm |$encoding[19:15]
 |vd |$encoding[11:7]
 |===
 
@@ -38642,7 +38633,7 @@ vsm4k.vi vd, vs2, imm
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "zimm5","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x43,"type":2}]}
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x43,"type":2}]}
 ....
 
 Description::
@@ -38654,7 +38645,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |vs2 |$encoding[24:20]
-|zimm5 |$encoding[19:15]
+|imm |$encoding[19:15]
 |vd |$encoding[11:7]
 |===
 
@@ -45245,7 +45236,7 @@ vwsll.vi vd, vs2, imm, vm
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "zimm5","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x35,"type":2}]}
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x35,"type":2}]}
 ....
 
 Description::
@@ -45258,7 +45249,7 @@ Decode Variables::
 |Variable Name |Location
 |vm |$encoding[25]
 |vs2 |$encoding[24:20]
-|zimm5 |$encoding[19:15]
+|imm |$encoding[19:15]
 |vd |$encoding[11:7]
 |===
 

--- a/spec/std/isa/inst/Sdext/dret.yaml
+++ b/spec/std/isa/inst/Sdext/dret.yaml
@@ -10,7 +10,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Sdext
-assembly: dret
+assembly: ""
 encoding:
   match: "01111011001000000000000001110011"
   variables: []

--- a/spec/std/isa/inst/Smdbltrp/sctrclr.yaml
+++ b/spec/std/isa/inst/Smdbltrp/sctrclr.yaml
@@ -10,7 +10,7 @@ long_name: No synopsis available
 description: |
   No description available.
 definedBy: Smdbltrp
-assembly: sctrclr
+assembly: ""
 encoding:
   match: "00010000010000000000000001110011"
   variables: []

--- a/spec/std/isa/inst/Smrnmi/mnret.yaml
+++ b/spec/std/isa/inst/Smrnmi/mnret.yaml
@@ -14,7 +14,7 @@ description: |
   also sets mstatus.MPRV to 0. If the Zicfilp extension is implemented, then if the new privileged mode is
   y, MNRET sets ELP to the logical AND of yLPE (see Section 22.1.1) and mnstatus.MNPELP.
 definedBy: Smrnmi
-assembly: mnret
+assembly: ""
 encoding:
   match: "01110000001000000000000001110011"
   variables: []

--- a/spec/std/isa/inst/Zvbb/vwsll.vi.yaml
+++ b/spec/std/isa/inst/Zvbb/vwsll.vi.yaml
@@ -18,7 +18,7 @@ encoding:
       location: 25-25
     - name: vs2
       location: 24-20
-    - name: zimm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/spec/std/isa/inst/Zvkned/vaeskf1.vi.yaml
+++ b/spec/std/isa/inst/Zvkned/vaeskf1.vi.yaml
@@ -16,7 +16,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: zimm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/spec/std/isa/inst/Zvkned/vaeskf2.vi.yaml
+++ b/spec/std/isa/inst/Zvkned/vaeskf2.vi.yaml
@@ -16,7 +16,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: zimm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/spec/std/isa/inst/Zvks/vsm3c.vi.yaml
+++ b/spec/std/isa/inst/Zvks/vsm3c.vi.yaml
@@ -17,7 +17,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: zimm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7

--- a/spec/std/isa/inst/Zvks/vsm4k.vi.yaml
+++ b/spec/std/isa/inst/Zvks/vsm4k.vi.yaml
@@ -17,7 +17,7 @@ encoding:
   variables:
     - name: vs2
       location: 24-20
-    - name: zimm5
+    - name: imm
       location: 19-15
     - name: vd
       location: 11-7


### PR DESCRIPTION
- `dret`, `mnret`, and `sctrclr` take no operands.
- ~~`sspush` and `sspopchk` are each single mnemonics that take a very
  restricted set of operand values.
  Also include a bit of documentation.~~
- `vaeskf1.vi`, `vaeskf2.vi`, `vsm3c.vi`, `vsm4k.vi`, `vwsll.vi`:
  renamed field to match operand.
