### PR TITLE
fix(CI): update get_yaml_directory to return spec/std/isa/inst

### DIFF
--- a/ext/auto-inst/parsing.py
+++ b/ext/auto-inst/parsing.py
@@ -49,7 +49,7 @@ def get_json_path():
 
 
 def get_yaml_directory():
-    return "arch/inst/"
+    return "spec/std/isa/inst"
 
 
 def load_inherited_variable(var_path, repo_dir):


### PR DESCRIPTION
With the latest folder structure updates, the previous logic for resolving the YAML and JSON paths was outdated, causing LLVM-related tests to always be skipped. This commit updates the test to use the correct paths, ensuring that the tests run as intended and are no longer erroneously skipped.