### PR TITLE
inst_type/I: Add I-type instruction schema

### DIFF
--- a/backends/instructions_appendix/all_instructions.golden.ado
+++ b/backends/instructions_appendix/all_instructions.golden.ado
@@ -1,0 +1,46367 @@
+= Instruction Appendix
+:doctype: book
+:wavedrom: /home/uniqueusman/riscv-unified-db/node_modules/.bin/wavedrom-cli
+// Now the document header is complete and the wavedrom attribute is active.
+
+
+[#udb:doc:inst:add]
+== add
+
+Synopsis::
+Integer add
+
+Assembly::
+add xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+Description::
+Add the value in xs1 to xs2, and store the result in xd.
+Any overflow is thrown away.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:add_uw]
+== add.uw
+
+Synopsis::
+Add unsigned word
+
+Assembly::
+add.uw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x4,"type":2}]}
+....
+
+Description::
+Performs an XLEN-wide addition between xs2 and the
+zero-extended least-significant word of xs1.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zba* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:addi]
+== addi
+
+Synopsis::
+Add immediate
+
+Assembly::
+addi xd, xs1, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+Adds an immediate value to the value in xs1, and store the result in xd
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:addiw]
+== addiw
+
+Synopsis::
+Add immediate word
+
+Assembly::
+addiw xd, xs1, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x1b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+Add an immediate to the 32-bit value in xs1, and store the sign extended result in xd
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:addw]
+== addw
+
+Synopsis::
+Add word
+
+Assembly::
+addw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+Description::
+Add the 32-bit values in xs1 to xs2, and store the sign-extended result in xd.
+Any overflow is thrown away.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:aes32dsi]
+== aes32dsi
+
+Synopsis::
+AES final round decryption instruction for RV32
+
+Assembly::
+aes32dsi xd, xs1, xs2, bs
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":5,"name": 0x15,"type":2},{"bits":2,"name": "bs","type":4}]}
+....
+
+Description::
+Sources a single byte from `xs2` according to `bs`. To this it applies the inverse AES
+SBox operation, and XOR's the result with `xs1`. This instruction must always be implemented such
+that its execution latency does not depend on the data being operated on.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|bs |$encoding[31:30]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknd* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:aes32dsmi]
+== aes32dsmi
+
+Synopsis::
+AES middle round decryption instruction for RV32
+
+Assembly::
+aes32dsmi xd, xs1, xs2, bs
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":5,"name": 0x17,"type":2},{"bits":2,"name": "bs","type":4}]}
+....
+
+Description::
+Sources a single byte from `xs2` according to `bs`. To this it applies the inverse AES
+SBox operation, and a partial inverse MixColumn, before XOR'ing the result with `xs1`. This
+instruction must always be implemented such that its execution latency does not depend on the
+data being operated on.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|bs |$encoding[31:30]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknd* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:aes32esi]
+== aes32esi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+aes32esi xd, xs1, xs2, bs
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":5,"name": 0x11,"type":2},{"bits":2,"name": "bs","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|bs |$encoding[31:30]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zkne* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:aes32esmi]
+== aes32esmi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+aes32esmi xd, xs1, xs2, bs
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":5,"name": 0x13,"type":2},{"bits":2,"name": "bs","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|bs |$encoding[31:30]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zkne* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:aes64ds]
+== aes64ds
+
+Synopsis::
+AES decrypt final round
+
+Assembly::
+aes64ds xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1d,"type":2}]}
+....
+
+Description::
+Uses the two 64-bit source registers to represent the entire AES state, and produces _half_ of the next
+round output, applying the Inverse ShiftRows and SubBytes steps.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknd* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:aes64dsm]
+== aes64dsm
+
+Synopsis::
+AES decrypt middle round
+
+Assembly::
+aes64dsm xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1f,"type":2}]}
+....
+
+Description::
+Uses the two 64-bit source registers to represent the entire AES state, and produces _half_ of the next
+round output, applying the Inverse ShiftRows, SubBytes and MixColumns steps.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknd* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:aes64es]
+== aes64es
+
+Synopsis::
+AES encrypt final round
+
+Assembly::
+aes64es xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x19,"type":2}]}
+....
+
+Description::
+Uses the two 64-bit source registers to represent the entire AES state, and produces _half_ of the next
+round output, applying the ShiftRows and SubBytes steps.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zkne* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:aes64esm]
+== aes64esm
+
+Synopsis::
+AES encrypt middle round
+
+Assembly::
+aes64esm xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1b,"type":2}]}
+....
+
+Description::
+Uses the two 64-bit source registers to represent the entire AES state, and produces _half_ of the next
+round output, applying the Inverse ShiftRows, SubBytes and MixColumns steps.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zkne* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:aes64im]
+== aes64im
+
+Synopsis::
+AES Decrypt KeySchedule MixColumns
+
+Assembly::
+aes64im xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x300,"type":2}]}
+....
+
+Description::
+The instruction applies the inverse MixColumns transformation to two columns of the state array,
+packed into a single 64-bit register. It is used to create the inverse cipher KeySchedule, according to
+the equivalent inverse cipher construction in (NIST, 2001) (Page 23, Section 5.3.5).
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknd* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:aes64ks1i]
+== aes64ks1i
+
+Synopsis::
+AES Key Schedule Instruction 1
+
+Assembly::
+aes64ks1i xd, xs1, rnum
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":4,"name": "rnum","type":4},{"bits":8,"name": 0x31,"type":2}]}
+....
+
+Description::
+This instruction implements the rotation, SubBytes and Round Constant addition steps of the AES
+block cipher Key Schedule.
+
+
+`rnum` must be in the range `0x0..0xA`. The values `0xB..0xF` are reserved.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|rnum |$encoding[23:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknd* | ~> 1.0.0
+
+| *Zkne* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:aes64ks2]
+== aes64ks2
+
+Synopsis::
+AES Key Schedule Instruction 2
+
+Assembly::
+aes64ks2 xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x3f,"type":2}]}
+....
+
+Description::
+This instruction implements the additional XOR'ing of key words as part of the AES block cipher
+Key Schedule.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknd* | ~> 1.0.0
+
+| *Zkne* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoadd_b]
+== amoadd.b
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amoadd.b xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoadd_d]
+== amoadd.d
+
+Synopsis::
+Atomic fetch-and-add doubleword
+
+Assembly::
+amoadd.d xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x0,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the doubleword at address _xs1_
+  * Write the loaded value into _xd_
+  * Add the value of register _xs2_ to the loaded value
+  * Write the sum to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoadd_h]
+== amoadd.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amoadd.h xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoadd_w]
+== amoadd.w
+
+Synopsis::
+Atomic fetch-and-add word
+
+Assembly::
+amoadd.w xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x0,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the word at address _xs1_
+  * Write the sign-extended value into _xd_
+  * Add the least-significant word of register _xs2_ to the loaded value
+  * Write the sum to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoand_b]
+== amoand.b
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amoand.b xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0xc,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoand_d]
+== amoand.d
+
+Synopsis::
+Atomic fetch-and-and doubleword
+
+Assembly::
+amoand.d xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0xc,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the doubleword at address _xs1_
+  * Write the loaded value into _xd_
+  * AND the value of register _xs2_ to the loaded value
+  * Write the result to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoand_h]
+== amoand.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amoand.h xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0xc,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoand_w]
+== amoand.w
+
+Synopsis::
+Atomic fetch-and-and word
+
+Assembly::
+amoand.w xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0xc,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the word at address _xs1_
+  * Write the sign-extended value into _xd_
+  * AND the least-significant word of register _xs2_ to the loaded value
+  * Write the result to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amocas_b]
+== amocas.b
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amocas.b xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x5,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amocas_d]
+== amocas.d
+
+Synopsis::
+Atomic Compare-and-Swap Doubleword
+
+Assembly::
+amocas.d xd, xs2, (xs1)
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd != {1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31}","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2 != {1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31}","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x5,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x5,"type":2}]}
+....
+
+Description::
+For RV32, AMOCAS.D atomically loads 64-bits of a data value from address in
+xs1, compares the loaded value to a 64-bit value held in a register pair
+consisting of xd and xd+1, and if the comparison is bitwise equal, then
+stores the 64-bit value held in the register pair xs2 and xs2+1 to the
+original address in xs1. The value loaded from memory is placed into the
+register pair xd and xd+1. The instruction requires the first register in
+the pair to be even numbered; encodings with odd-numbered registers
+specified in xs2 and xd are reserved. When the first register of a source
+register pair is x0, then both halves of the pair read as zero. When the
+first register of a destination register pair is x0, then the entire
+register result is discarded and neither destination register is written.
+
+For RV64, AMOCAS.D atomically loads 64-bits of a data value from address in
+xs1, compares the loaded value to a 64-bit value held in xd, and if the
+comparison is bitwise equal, then stores the 64-bit value held in xs2 to the
+original address in xs1. The value loaded from memory is placed into
+register xd.
+
+Just as for AMOs in the A extension, AMOCAS.D requires that the address held
+in xs1 be naturally aligned to the size of the operand (i.e., eight-byte
+aligned for doublewords). And the same exception options apply if the
+address is not naturally aligned.
+
+Just as for AMOs in the A extension, the AMOCAS.D optionally provides release
+consistency semantics, using the aq and rl bits, to help implement
+multiprocessor synchronization. The memory operation performed by an
+AMOCAS.D, when successful, has acquire semantics if aq bit is 1 and has
+release semantics if rl bit is 1. The memory operation performed by an
+AMOCAS.W/D/Q, when not successful, has acquire semantics if aq bit is 1 but
+does not have release semantics, regardless of rl.
+
+A FENCE instruction may be used to order the memory read access and, if
+produced, the memory write access by an AMOCAS.D instruction.
+
+[Note] An unsuccessful AMOCAS.D may either not perform a memory write or may
+write back the old value loaded from memory. The memory write, if produced,
+does not have release semantics, regardless of rl.
+
+An AMOCAS.D instruction always requires write permissions.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zacas* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amocas_h]
+== amocas.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amocas.h xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x5,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amocas_q]
+== amocas.q
+
+Synopsis::
+Atomic Compare-and-Swap Quadword
+
+Assembly::
+amocas.q xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd != {1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31}","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2 != {1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31}","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x5,"type":2}]}
+....
+
+Description::
+For RV64, AMOCAS.Q atomically loads 128-bits of a data value from address
+in xs1, compares the loaded value to a 128-bit value held in a register
+pair consisting of xd and xd+1, and if the comparison is bitwise equal,
+then stores the 128-bit value held in the register pair xs2 and xs2+1 to
+the original address in xs1. The value loaded from memory is placed into
+the register pair xd and xd+1. The instruction requires the first register
+in the pair to be even numbered; encodings with odd-numbered registers
+specified in xs2 and xd are reserved. When the first register of a source
+register pair is x0, then both halves of the pair read as zero. When the
+first register of a destination register pair is x0, then the entire
+register result is discarded and neither destination register is written.
+
+Just as for AMOs in the A extension, AMOCAS.Q requires that the address held
+in xs1 be naturally aligned to the size of the operand (i.e., sixteen-byte
+aligned for quadwords). And the same exception options apply if the
+address is not naturally aligned.
+
+Just as for AMOs in the A extension, the AMOCAS.Q optionally provides release
+consistency semantics, using the aq and rl bits, to help implement
+multiprocessor synchronization. The memory operation performed by an
+AMOCAS.Q, when successful, has acquire semantics if aq bit is 1 and has
+release semantics if rl bit is 1. The memory operation performed by an
+AMOCAS.W/D/Q, when not successful, has acquire semantics if aq bit is 1 but
+does not have release semantics, regardless of rl.
+
+A FENCE instruction may be used to order the memory read access and, if
+produced, the memory write access by an AMOCAS.Q instruction.
+
+[Note] An unsuccessful AMOCAS.Q may either not perform a memory write or
+may write back the old value loaded from memory. The memory write, if
+produced, does not have release semantics, regardless of rl.
+
+An AMOCAS.Q instruction always requires write permissions.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zacas* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amocas_w]
+== amocas.w
+
+Synopsis::
+Atomic Compare-and-Swap Word
+
+Assembly::
+amocas.w xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x5,"type":2}]}
+....
+
+Description::
+For RV32, AMOCAS.W atomically loads a 32-bit data value from address in xs1,
+compares the loaded value to the 32-bit value held in xd, and if the
+comparison is bitwise equal, then stores the 32-bit value held in xs2 to the
+original address in xs1. The value loaded from memory is placed into
+register xd.
+
+For RV64, AMOCAS.W atomically loads a 32-bit data value from address in xs1,
+compares the loaded value to the lower 32 bits of the value held in xd, and
+if the comparison is bitwise equal, then stores the lower 32 bits of the
+value held in xs2 to the original address in xs1. The 32-bit value loaded
+from memory is sign-extended and is placed into register xd.
+
+Just as for AMOs in the A extension, AMOCAS.W requires that the address held
+in xs1 be naturally aligned to the size of the operand (i.e., four-byte
+aligned for words). And the same exception options apply if the address is
+not naturally aligned.
+
+Just as for AMOs in the A extension, the AMOCAS.W optionally provides release
+consistency semantics, using the aq and rl bits, to help implement
+multiprocessor synchronization. The memory operation performed by an
+AMOCAS.W, when successful, has acquire semantics if aq bit is 1 and has
+release semantics if rl bit is 1. The memory operation performed by an
+AMOCAS.W/D/Q, when not successful, has acquire semantics if aq bit is 1 but
+does not have release semantics, regardless of rl.
+
+A FENCE instruction may be used to order the memory read access and, if
+produced, the memory write access by an AMOCAS.W instruction.
+
+[Note] An unsuccessful AMOCAS.W may either not perform a memory write or may
+write back the old value loaded from memory. The memory write, if produced,
+does not have release semantics, regardless of rl.
+
+An AMOCAS.W instruction always requires write permissions.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zacas* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amomax_b]
+== amomax.b
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amomax.b xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x14,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amomax_d]
+== amomax.d
+
+Synopsis::
+Atomic MAX doubleword
+
+Assembly::
+amomax.d xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x14,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the doubleword at address _xs1_
+  * Write the loaded value into _xd_
+  * Signed compare the value of register _xs2_ to the loaded value, and select the maximum value
+  * Write the maximum to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amomax_h]
+== amomax.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amomax.h xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x14,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amomax_w]
+== amomax.w
+
+Synopsis::
+Atomic MAX word
+
+Assembly::
+amomax.w xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x14,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the word at address _xs1_
+  * Write the sign-extended value into _xd_
+  * Signed compare the least-significant word of register _xs2_ to the loaded value, and select the maximum value
+  * Write the maximum to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amomaxu_b]
+== amomaxu.b
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amomaxu.b xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x1c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amomaxu_d]
+== amomaxu.d
+
+Synopsis::
+Atomic MAX unsigned doubleword
+
+Assembly::
+amomaxu.d xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x1c,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the doubleword at address _xs1_
+  * Write the loaded value into _xd_
+  * Unsigned compare the value of register _xs2_ to the loaded value, and select the maximum value
+  * Write the maximum to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amomaxu_h]
+== amomaxu.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amomaxu.h xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x1c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amomaxu_w]
+== amomaxu.w
+
+Synopsis::
+Atomic MAX unsigned word
+
+Assembly::
+amomaxu.w xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x1c,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the word at address _xs1_
+  * Write the sign-extended value into _xd_
+  * Unsigned compare the least-significant word of register _xs2_ to the loaded value, and select the maximum value
+  * Write the maximum to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amomin_b]
+== amomin.b
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amomin.b xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amomin_d]
+== amomin.d
+
+Synopsis::
+Atomic MIN doubleword
+
+Assembly::
+amomin.d xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x10,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the doubleword at address _xs1_
+  * Write the loaded value into _xd_
+  * Signed compare the value of register _xs2_ to the loaded value, and select the minimum value
+  * Write the minimum to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amomin_h]
+== amomin.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amomin.h xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amomin_w]
+== amomin.w
+
+Synopsis::
+Atomic MIN word
+
+Assembly::
+amomin.w xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x10,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the word at address _xs1_
+  * Write the sign-extended value into _xd_
+  * Signed compare the least-significant word of register _xs2_ to the loaded value, and select the minimum value
+  * Write the result to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amominu_b]
+== amominu.b
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amominu.b xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amominu_d]
+== amominu.d
+
+Synopsis::
+Atomic MIN unsigned doubleword
+
+Assembly::
+amominu.d xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x18,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the doubleword at address _xs1_
+  * Write the loaded value into _xd_
+  * Unsigned compare the value of register _xs2_ to the loaded value, and select the minimum value
+  * Write the minimum to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amominu_h]
+== amominu.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amominu.h xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amominu_w]
+== amominu.w
+
+Synopsis::
+Atomic MIN unsigned word
+
+Assembly::
+amominu.w xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x18,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the word at address _xs1_
+  * Write the sign-extended value into _xd_
+  * Unsigned compare the least-significant word of register _xs2_ to the loaded word, and select the minimum value
+  * Write the result to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoor_b]
+== amoor.b
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amoor.b xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoor_d]
+== amoor.d
+
+Synopsis::
+Atomic fetch-and-or doubleword
+
+Assembly::
+amoor.d xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x8,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the doubleword at address _xs1_
+  * Write the loaded value into _xd_
+  * OR the value of register _xs2_ to the loaded value
+  * Write the result to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoor_h]
+== amoor.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amoor.h xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoor_w]
+== amoor.w
+
+Synopsis::
+Atomic fetch-and-or word
+
+Assembly::
+amoor.w xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x8,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the word at address _xs1_
+  * Write the sign-extended value into _xd_
+  * OR the least-significant word of register _xs2_ to the loaded value
+  * Write the result to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoswap_b]
+== amoswap.b
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amoswap.b xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x1,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoswap_d]
+== amoswap.d
+
+Synopsis::
+Atomic SWAP doubleword
+
+Assembly::
+amoswap.d xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x1,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the doubleword at address _xs1_
+  * Write the value into _xd_
+  * Store the value of register _xs2_ to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoswap_h]
+== amoswap.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amoswap.h xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x1,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoswap_w]
+== amoswap.w
+
+Synopsis::
+Atomic SWAP word
+
+Assembly::
+amoswap.w xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x1,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the word at address _xs1_
+  * Write the sign-extended value into _xd_
+  * Store the least-significant word of register _xs2_ to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoxor_b]
+== amoxor.b
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amoxor.b xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x4,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoxor_d]
+== amoxor.d
+
+Synopsis::
+Atomic fetch-and-xor doubleword
+
+Assembly::
+amoxor.d xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x4,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the doubleword at address _xs1_
+  * Write the loaded value into _xd_
+  * XOR the value of register _xs2_ to the loaded value
+  * Write the result to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoxor_h]
+== amoxor.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+amoxor.h xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x4,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zabha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:amoxor_w]
+== amoxor.w
+
+Synopsis::
+Atomic fetch-and-xor word
+
+Assembly::
+amoxor.w xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x4,"type":2}]}
+....
+
+Description::
+Atomically:
+
+  * Load the word at address _xs1_
+  * Write the sign-extended value into _xd_
+  * XOR the least-significant word of register _xs2_ to the loaded value
+  * Write the result to the address in _xs1_
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zaamo* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:and]
+== and
+
+Synopsis::
+And
+
+Assembly::
+and xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+Description::
+And xs1 with xs2, and store the result in xd
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:andi]
+== andi
+
+Synopsis::
+And immediate
+
+Assembly::
+andi xd, xs1, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+And an immediate to the value in xs1, and store the result in xd
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:andn]
+== andn
+
+Synopsis::
+AND with inverted operand
+
+Assembly::
+andn xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x20,"type":2}]}
+....
+
+Description::
+Performs the bitwise logical AND operation between `xs1` and the
+bitwise inversion of `xs2`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:auipc]
+== auipc
+
+Synopsis::
+Add upper immediate to pc
+
+Assembly::
+auipc xd, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x17,"type":2},{"bits":5,"name": "xd","type":4},{"bits":20,"name": "imm[31:12]","type":4}]}
+....
+
+Description::
+Add an immediate to the current PC.
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31:12], 12'd0}
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:bclr]
+== bclr
+
+Synopsis::
+Single-Bit clear (Register)
+
+Assembly::
+bclr xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x24,"type":2}]}
+....
+
+Description::
+Returns xs1 with a single bit cleared at the index specified in xs2.
+The index is read from the lower log2(XLEN) bits of xs2.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbs* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:bclri]
+== bclri
+
+Synopsis::
+Single-Bit clear (Immediate)
+
+Assembly::
+bclri xd, xs1, shamt
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "shamt","type":4},{"bits":7,"name": 0x24,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":6,"name": "shamt","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+Returns xs1 with a single bit cleared at the index specified in shamt. The
+index is read from the lower log2(XLEN) bits of shamt. For RV32, the encodings corresponding
+to shamt[5]=1 are reserved.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[25:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbs* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:beq]
+== beq
+
+Synopsis::
+Branch if equal
+
+Assembly::
+beq xs1, xs2, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x63,"type":2},{"bits":5,"name": "imm[4:1|11]","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": "imm[12|10:5]","type":4}]}
+....
+
+Description::
+Branch to PC + imm if
+the value in register xs1 is equal to the value in register xs2.
+
+Raise a `MisalignedAddress` exception if PC + imm is misaligned.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31], $encoding[7], $encoding[30:25], $encoding[11:8], 1'd0}
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:bext]
+== bext
+
+Synopsis::
+Single-Bit extract (Register)
+
+Assembly::
+bext xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x24,"type":2}]}
+....
+
+Description::
+Returns a single bit extracted from xs1 at the index specified in xs2.
+The index is read from the lower log2(XLEN) bits of xs2.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbs* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:bexti]
+== bexti
+
+Synopsis::
+Single-Bit extract (Immediate)
+
+Assembly::
+bexti xd, xs1, shamt
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "shamt","type":4},{"bits":7,"name": 0x24,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":6,"name": "shamt","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+Returns a single bit extracted from xs1 at the index specified in xs2.
+The index is read from the lower log2(XLEN) bits of shamt. For RV32, the encodings
+corresponding to shamt[5]=1 are reserved.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[25:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbs* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:bge]
+== bge
+
+Synopsis::
+Branch if greater than or equal
+
+Assembly::
+bge xs1, xs2, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x63,"type":2},{"bits":5,"name": "imm[4:1|11]","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": "imm[12|10:5]","type":4}]}
+....
+
+Description::
+Branch to PC + imm if
+the signed value in register xs1 is greater than or equal to the signed value in register xs2.
+
+Raise a `MisalignedAddress` exception if PC + imm is misaligned.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31], $encoding[7], $encoding[30:25], $encoding[11:8], 1'd0}
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:bgeu]
+== bgeu
+
+Synopsis::
+Branch if greater than or equal unsigned
+
+Assembly::
+bgeu xs1, xs2, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x63,"type":2},{"bits":5,"name": "imm[4:1|11]","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": "imm[12|10:5]","type":4}]}
+....
+
+Description::
+Branch to PC + imm if
+the unsigned value in register xs1 is greater than or equal to the unsigned value in register xs2.
+
+Raise a `MisalignedAddress` exception if PC + imm is misaligned.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31], $encoding[7], $encoding[30:25], $encoding[11:8], 1'd0}
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:binv]
+== binv
+
+Synopsis::
+Single-Bit invert (Register)
+
+Assembly::
+binv xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x34,"type":2}]}
+....
+
+Description::
+Returns xs1 with a single bit inverted at the index specified in xs2.
+The index is read from the lower log2(XLEN) bits of xs2.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbs* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:binvi]
+== binvi
+
+Synopsis::
+Single-Bit invert (Immediate)
+
+Assembly::
+binvi xd, xs1, shamt
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "shamt","type":4},{"bits":7,"name": 0x34,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":6,"name": "shamt","type":4},{"bits":6,"name": 0x1a,"type":2}]}
+....
+
+Description::
+Returns xs1 with a single bit inverted at the index specified in shamt.
+The index is read from the lower log2(XLEN) bits of shamt.
+For RV32, the encodings corresponding to shamt[5]=1 are reserved.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[25:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbs* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:blt]
+== blt
+
+Synopsis::
+Branch if less than
+
+Assembly::
+blt xs1, xs2, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x63,"type":2},{"bits":5,"name": "imm[4:1|11]","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": "imm[12|10:5]","type":4}]}
+....
+
+Description::
+Branch to PC + imm if
+the signed value in register xs1 is less than the signed value in register xs2.
+
+Raise a `MisalignedAddress` exception if PC + imm is misaligned.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31], $encoding[7], $encoding[30:25], $encoding[11:8], 1'd0}
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:bltu]
+== bltu
+
+Synopsis::
+Branch if less than unsigned
+
+Assembly::
+bltu xs1, xs2, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x63,"type":2},{"bits":5,"name": "imm[4:1|11]","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": "imm[12|10:5]","type":4}]}
+....
+
+Description::
+Branch to PC + imm if
+the unsigned value in register xs1 is less than the unsigned value in register xs2.
+
+Raise a `MisalignedAddress` exception if PC + imm is misaligned.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31], $encoding[7], $encoding[30:25], $encoding[11:8], 1'd0}
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:bne]
+== bne
+
+Synopsis::
+Branch if not equal
+
+Assembly::
+bne xs1, xs2, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x63,"type":2},{"bits":5,"name": "imm[4:1|11]","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": "imm[12|10:5]","type":4}]}
+....
+
+Description::
+Branch to PC + imm if
+the value in register xs1 is not equal to the value in register xs2.
+
+Raise a `MisalignedAddress` exception if PC + imm is misaligned.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31], $encoding[7], $encoding[30:25], $encoding[11:8], 1'd0}
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:brev8]
+== brev8
+
+Synopsis::
+Reverse bits in bytes
+
+Assembly::
+brev8 xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x687,"type":2}]}
+....
+
+Description::
+Reverses the order of the bits in every byte of a register.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:bset]
+== bset
+
+Synopsis::
+Single-Bit set (Register)
+
+Assembly::
+bset xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x14,"type":2}]}
+....
+
+Description::
+Returns xs1 with a single bit set at the index specified in xs2.
+The index is read from the lower log2(XLEN) bits of xs2.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbs* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:bseti]
+== bseti
+
+Synopsis::
+Single-Bit set (Immediate)
+
+Assembly::
+bseti xd, xs1, shamt
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "shamt","type":4},{"bits":7,"name": 0x14,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":6,"name": "shamt","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+Returns xs1 with a single bit set at the index specified in shamt.
+The index is read from the lower log2(XLEN) bits of shamt.
+For RV32, the encodings corresponding to shamt[5]=1 are reserved.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[25:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbs* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_add]
+== c.add
+
+Synopsis::
+Add
+
+Assembly::
+c.add xd, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "xs2 != 0","type":4},{"bits":5,"name": "xd != 0","type":4},{"bits":4,"name": 0x9,"type":2}]}
+....
+
+Description::
+Add the value in xs2 to xd, and store the result in xd.
+C.ADD expands into `add xd, xd, xs2`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[6:2]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_addi]
+== c.addi
+
+Synopsis::
+Add a sign-extended non-zero immediate
+
+Assembly::
+c.addi xd, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "imm != 0[4:0]","type":4},{"bits":5,"name": "xd != 0","type":4},{"bits":1,"name": "imm != 0[5]","type":4},{"bits":3,"name": 0x0,"type":2}]}
+....
+
+Description::
+C.ADDI adds the non-zero sign-extended 6-bit immediate to the value in register xd then writes the result to xd.
+C.ADDI expands into `addi xd, xd, imm`.
+C.ADDI is only valid when xd ≠ x0 and imm ≠ 0.
+The code points with xd=x0 encode the C.NOP instruction; the remaining code points with imm=0 encode HINTs.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[12], $encoding[6:2]}
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_addi16sp]
+== c.addi16sp
+
+Synopsis::
+Add a sign-extended non-zero immediate
+
+Assembly::
+c.addi16sp sp, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "imm != 0[4|6|8:7|5]","type":4},{"bits":5,"name": 0x2,"type":2},{"bits":1,"name": "imm != 0[9]","type":4},{"bits":3,"name": 0x3,"type":2}]}
+....
+
+Description::
+C.ADDI16SP adds the non-zero sign-extended 6-bit immediate to the value in the stack pointer (sp=x2), where the immediate is scaled to represent multiples of 16 in the range (-512,496).
+C.ADDI16SP is used to adjust the stack pointer in procedure prologues and epilogues.
+It expands into `addi x2, x2, nzimm[9:4]`.
+C.ADDI16SP is only valid when nzimm ≠ 0; the code point with nzimm=0 is reserved.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[12], $encoding[4:3], $encoding[5], $encoding[2], $encoding[6], 4'd0}
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_addi4spn]
+== c.addi4spn
+
+Synopsis::
+Add a zero-extended non-zero immediate, scaled by 4, to the stack pointer
+
+Assembly::
+c.addi4spn xd, sp, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xd","type":4},{"bits":8,"name": "imm != 0[5:4|9:6|2|3]","type":4},{"bits":3,"name": 0x0,"type":2}]}
+....
+
+Description::
+Adds a zero-extended non-zero immediate, scaled by 4, to the stack pointer, x2, and writes the result to rd'.
+This instruction is used to generate pointers to stack-allocated variables.
+It expands to `addi rd', x2, nzuimm[9:2]`.
+C.ADDI4SPN is only valid when nzuimm ≠ 0; the code points with nzuimm=0 are reserved.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[10:7], $encoding[12:11], $encoding[5], $encoding[6], 2'd0}
+|xd |$encoding[4:2]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_addiw]
+== c.addiw
+
+Synopsis::
+Add a sign-extended non-zero immediate
+
+Assembly::
+c.addiw xd, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":5,"name": "xd != 0","type":4},{"bits":1,"name": "imm[5]","type":4},{"bits":3,"name": 0x1,"type":2}]}
+....
+
+Description::
+C.ADDIW is an RV64C/RV128C-only instruction that performs the same computation as C.ADDI but produces a 32-bit result, then sign-extends result to 64 bits.
+C.ADDIW expands into `addiw xd, xd, imm`.
+The immediate can be zero for C.ADDIW, where this corresponds to `sext.w xd`.
+C.ADDIW is only valid when xd ≠ x0; the code points with xd=x0 are reserved.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[12], $encoding[6:2]}
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_addw]
+== c.addw
+
+Synopsis::
+Add word
+
+Assembly::
+c.addw xd, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x27,"type":2}]}
+....
+
+Description::
+Add the 32-bit values in xs2 from xd, and store the result in xd.
+The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+C.ADDW expands into `addw xd, xd, xs2`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[4:2]
+|xd |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_and]
+== c.and
+
+Synopsis::
+And
+
+Assembly::
+c.and xd, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+And xd with xs2, and store the result in xd
+The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+C.AND expands into `and xd, xd, xs2`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[4:2]
+|xd |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_andi]
+== c.andi
+
+Synopsis::
+And immediate
+
+Assembly::
+c.andi xd, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": "xd","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":1,"name": "imm[5]","type":4},{"bits":3,"name": 0x4,"type":2}]}
+....
+
+Description::
+And an immediate to the value in xd, and store the result in xd.
+The xd register index should be used as xd+8 (registers x8-x15).
+C.ANDI expands into `andi xd, xd, imm`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[12], $encoding[6:2]}
+|xd |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_beqz]
+== c.beqz
+
+Synopsis::
+Branch if Equal Zero
+
+Assembly::
+c.beqz xs1, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "imm[7:6|2:1|5]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[8|4:3]","type":4},{"bits":3,"name": 0x6,"type":2}]}
+....
+
+Description::
+C.BEQZ performs conditional control transfers. The offset is sign-extended and added to the pc to form the branch target address. It can therefore target a ±256 B range. C.BEQZ takes the branch if the value in register xs1' is zero.
+It expands to xref:insts:beq.adoc#udb:doc:inst:beq[beq] `xs1, x0, offset`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[12], $encoding[6:5], $encoding[2], $encoding[11:10], $encoding[4:3], 1'd0}
+|xs1 |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_bnez]
+== c.bnez
+
+Synopsis::
+Branch if NOT Equal Zero
+
+Assembly::
+c.bnez xs1, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "imm[7:6|2:1|5]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[8|4:3]","type":4},{"bits":3,"name": 0x7,"type":2}]}
+....
+
+Description::
+C.BEQZ performs conditional control transfers. The offset is sign-extended and added to the pc to form the branch target address. It can therefore target a ±256 B range. C.BEQZ takes the branch if the value in register xs1' is NOT zero.
+It expands to xref:insts:beq.adoc#udb:doc:inst:beq[beq] `xs1, x0, offset`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[12], $encoding[6:5], $encoding[2], $encoding[11:10], $encoding[4:3], 1'd0}
+|xs1 |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_ebreak]
+== c.ebreak
+
+Synopsis::
+Breakpoint exception
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":16,"name": 0x9002,"type":2}]}
+....
+
+Description::
+The C.EBREAK instruction is used by debuggers to cause control to be transferred back to
+a debugging environment. Unless overridden by an external debug environment,
+C.EBREAK raises a breakpoint exception and performs no other operation.
+
+[NOTE]
+As described in the xref:exts:C.adoc#udb:doc:ext:C[C] Standard Extension for Compressed Instructions, the xref:insts:c_ebreak.adoc#udb:doc:inst:c_ebreak[c.ebreak]
+instruction performs the same operation as the EBREAK instruction.
+
+EBREAK causes the receiving privilege mode's epc register to be set to the address of
+the EBREAK instruction itself, not the address of the following instruction.
+As EBREAK causes a synchronous exception, it is not considered to retire,
+and should not increment the xref:csrs:minstret.adoc#udb:doc:csr:minstret[minstret] CSR.
+
+
+Decode Variables::
+c.ebreak has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_fld]
+== c.fld
+
+Synopsis::
+Load double-precision
+
+Assembly::
+c.fld fd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "fd","type":4},{"bits":2,"name": "imm[7:6]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x1,"type":2}]}
+....
+
+Description::
+Loads a double precision floating-point value from memory into register fd.
+It computes an effective address by adding the zero-extended offset, scaled by 8,
+to the base address in register xs1.
+It expands to xref:insts:fld.adoc#udb:doc:inst:fld[fld] `fd, offset(xs1)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[6:5], $encoding[12:10], 3'd0}
+|fd |$encoding[4:2]
+|xs1 |$encoding[9:7]
+|===
+
+Included in::
+* anyOf:
+*** allOf:
+***** C, version >= C@2.0.0
+***** D, version >= D@2.2.0
+*** Zcd, version >= Zcd@1.0.0
+
+
+[#udb:doc:inst:c_fldsp]
+== c.fldsp
+
+Synopsis::
+Load doubleword into floating-point register from stack
+
+Assembly::
+c.fldsp fd, imm(sp)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "imm[4:3|8:6]","type":4},{"bits":5,"name": "fd","type":4},{"bits":1,"name": "imm[5]","type":4},{"bits":3,"name": 0x1,"type":2}]}
+....
+
+Description::
+Loads a double-precision floating-point value from memory into floating-point register fd.
+It computes its effective address by adding the zero-extended offset, scaled by 8,
+to the stack pointer, x2.
+It expands to xref:insts:fld.adoc#udb:doc:inst:fld[fld] `fd, offset(x2)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[4:2], $encoding[12], $encoding[6:5], 3'd0}
+|fd |$encoding[11:7]
+|===
+
+Included in::
+* anyOf:
+*** allOf:
+***** C, version >= C@2.0.0
+***** D, version >= D@2.2.0
+*** Zcd, version >= Zcd@1.0.0
+
+
+[#udb:doc:inst:c_flw]
+== c.flw
+
+Synopsis::
+Load single-precision
+
+Assembly::
+c.flw fd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "fd","type":4},{"bits":2,"name": "imm[2|6]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x3,"type":2}]}
+....
+
+Description::
+Loads a single precision floating-point value from memory into register fd.
+It computes an effective address by adding the zero-extended offset, scaled by 4,
+to the base address in register xs1.
+It expands to xref:insts:flw.adoc#udb:doc:inst:flw[flw] `fd, offset(xs1)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[5], $encoding[12:10], $encoding[6], 2'd0}
+|fd |$encoding[4:2]
+|xs1 |$encoding[9:7]
+|===
+
+Included in::
+* anyOf:
+*** allOf:
+***** C, version >= C@2.0.0
+***** F, version >= F@2.2.0
+*** Zcf, version >= Zcf@1.0.0
+
+
+[#udb:doc:inst:c_flwsp]
+== c.flwsp
+
+Synopsis::
+Load word into floating-point register from stack
+
+Assembly::
+c.flwsp fd, imm(sp)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "imm[4:2|7:6]","type":4},{"bits":5,"name": "fd","type":4},{"bits":1,"name": "imm[5]","type":4},{"bits":3,"name": 0x3,"type":2}]}
+....
+
+Description::
+Loads a single-precision floating-point value from memory into floating-point register fd.
+It computes its effective address by adding the zero-extended offset, scaled by 4,
+to the stack pointer, x2.
+It expands to xref:insts:flw.adoc#udb:doc:inst:flw[flw] `fd, offset(x2)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[3:2], $encoding[12], $encoding[6:4], 2'd0}
+|fd |$encoding[11:7]
+|===
+
+Included in::
+* anyOf:
+*** allOf:
+***** C, version >= C@2.0.0
+***** F, version >= F@2.2.0
+*** Zcf, version >= Zcf@1.0.0
+
+
+[#udb:doc:inst:c_fsd]
+== c.fsd
+
+Synopsis::
+Store double-precision
+
+Assembly::
+c.fsd fs2, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "fs2","type":4},{"bits":2,"name": "imm[7:6]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x5,"type":2}]}
+....
+
+Description::
+Stores a double precision floating-point value in register fs2 to memory.
+It computes an effective address by adding the zero-extended offset, scaled by 8,
+to the base address in register xs1.
+It expands to xref:insts:fsd.adoc#udb:doc:inst:fsd[fsd] `fs2, offset(xs1)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[6:5], $encoding[12:10], 3'd0}
+|fs2 |$encoding[4:2]
+|xs1 |$encoding[9:7]
+|===
+
+Included in::
+* anyOf:
+*** allOf:
+***** C, version >= C@2.0.0
+***** D, version >= D@2.2.0
+*** Zcd, version >= Zcd@1.0.0
+
+
+[#udb:doc:inst:c_fsdsp]
+== c.fsdsp
+
+Synopsis::
+Store double-precision value to stack
+
+Assembly::
+c.fsdsp fs2, imm(sp)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "fs2","type":4},{"bits":6,"name": "imm[5:3|8:6]","type":4},{"bits":3,"name": 0x5,"type":2}]}
+....
+
+Description::
+Stores a double-precision floating-point value in floating-point register fs2 to memory.
+It computes an effective address by adding the zero-extended offset, scaled by 8,
+to the stack pointer, x2.
+It expands to xref:insts:fsd.adoc#udb:doc:inst:fsd[fsd] `fs2, offset(x2)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[9:7], $encoding[12:10], 3'd0}
+|fs2 |$encoding[6:2]
+|===
+
+Included in::
+* anyOf:
+*** allOf:
+***** C, version >= C@2.0.0
+***** D, version >= D@2.2.0
+*** Zcd, version >= Zcd@1.0.0
+
+
+[#udb:doc:inst:c_fsw]
+== c.fsw
+
+Synopsis::
+Store single-precision
+
+Assembly::
+c.fsw fs2, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "fs2","type":4},{"bits":2,"name": "imm[2|6]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x7,"type":2}]}
+....
+
+Description::
+Stores a single precision floating-point value in register fs2 to memory.
+It computes an effective address by adding the zero-extended offset, scaled by 4,
+to the base address in register xs1.
+It expands to xref:insts:fsw.adoc#udb:doc:inst:fsw[fsw] `fs2, offset(xs1)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[5], $encoding[12:10], $encoding[6], 2'd0}
+|fs2 |$encoding[4:2]
+|xs1 |$encoding[9:7]
+|===
+
+Included in::
+* anyOf:
+*** allOf:
+***** C, version >= C@2.0.0
+***** F, version >= F@2.2.0
+*** Zcf, version >= Zcf@1.0.0
+
+
+[#udb:doc:inst:c_fswsp]
+== c.fswsp
+
+Synopsis::
+Store single-precision value to stack
+
+Assembly::
+c.fswsp fs2, imm(sp)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "fs2","type":4},{"bits":6,"name": "imm[5:2|7:6]","type":4},{"bits":3,"name": 0x7,"type":2}]}
+....
+
+Description::
+Stores a single-precision floating-point value in floating-point register fs2 to memory.
+It computes an effective address by adding the zero-extended offset, scaled by 4,
+to the stack pointer, x2.
+It expands to xref:insts:fsw.adoc#udb:doc:inst:fsw[fsw] `fs2, offset(x2)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[8:7], $encoding[12:9], 2'd0}
+|fs2 |$encoding[6:2]
+|===
+
+Included in::
+* anyOf:
+*** allOf:
+***** C, version >= C@2.0.0
+***** F, version >= F@2.2.0
+*** Zcf, version >= Zcf@1.0.0
+
+
+[#udb:doc:inst:c_j]
+== c.j
+
+Synopsis::
+Jump
+
+Assembly::
+c.j imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":11,"name": "imm[11|4|9:8|10|6|7|3:1|5]","type":4},{"bits":3,"name": 0x5,"type":2}]}
+....
+
+Description::
+C.J performs an unconditional control transfer. The offset is sign-extended and added to the pc to form the jump target address. C.J can therefore target a ±2 KiB range.
+It expands to xref:insts:jal.adoc#udb:doc:inst:jal[jal] `x0, offset`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |sext({$encoding[12], $encoding[8], $encoding[10:9], $encoding[6], $encoding[7], $encoding[2], $encoding[11], $encoding[5:3], 1'd0})
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_jal]
+== c.jal
+
+Synopsis::
+Jump and Link
+
+Assembly::
+c.jal imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":11,"name": "imm[11|4|9:8|10|6|7|3:1|5]","type":4},{"bits":3,"name": 0x1,"type":2}]}
+....
+
+Description::
+C.JAL is an RV32C-only instruction that performs the same operation as C.J, but additionally writes the address of the instruction following the jump (pc+2) to the link register, x1.
+It expands to xref:insts:jal.adoc#udb:doc:inst:jal[jal] `x1, offset`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |sext({$encoding[12], $encoding[8], $encoding[10:9], $encoding[6], $encoding[7], $encoding[2], $encoding[11], $encoding[5:3], 1'd0})
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_jalr]
+== c.jalr
+
+Synopsis::
+Jump and Link Register
+
+Assembly::
+c.jalr xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2,"type":2},{"bits":5,"name": "xs1 != 0","type":4},{"bits":4,"name": 0x9,"type":2}]}
+....
+
+Description::
+C.JALR (jump and link register) performs the same operation as C.JR, but additionally writes the address of the instruction following the jump (pc+2) to the link register, x1.
+C.JALR expands to jalr x1, 0(xs1).
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_jr]
+== c.jr
+
+Synopsis::
+Jump Register
+
+Assembly::
+c.jr xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2,"type":2},{"bits":5,"name": "xs1 != 0","type":4},{"bits":4,"name": 0x8,"type":2}]}
+....
+
+Description::
+C.JR (jump register) performs an unconditional control transfer to the address in register xs1.
+C.JR expands to jalr x0, 0(xs1).
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_lbu]
+== c.lbu
+
+Synopsis::
+Load unsigned byte, 16-bit encoding
+
+Assembly::
+c.lbu xd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xd","type":4},{"bits":2,"name": "imm","type":4},{"bits":3,"name": "xs1","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+Loads a 8-bit value from memory into register xd.
+It computes an effective address by adding the zero-extended offset, to the base address in register xs1.
+It expands to xref:insts:lbu.adoc#udb:doc:inst:lbu[lbu] `xd, offset(xs1)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[5], $encoding[6]}
+|xd |$encoding[4:2]
+|xs1 |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcb* | ~> 1.0.0
+
+| *Zce* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_ld]
+== c.ld
+
+Synopsis::
+Load double
+
+Assembly::
+c.ld xd, imm(xs1)
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xd != {1,3,5,7}","type":4},{"bits":2,"name": "imm[7:6]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x3,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xd","type":4},{"bits":2,"name": "imm[7:6]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x3,"type":2}]}
+....
+
+Description::
+Loads a 64-bit value from memory into register xd.
+It computes an effective address by adding the zero-extended offset, scaled by 8,
+to the base address in register xs1.
+It expands to xref:insts:ld.adoc#udb:doc:inst:ld[ld] `xd, offset(xs1)`.
+For RV32, if the Zclsd extension is enabled, this instruction loads a 64-bit value into registers xd and xd+1. It computes an effective address by adding the zero-extended imm, scaled by 8, to the base address in register xs1.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[6:5], $encoding[12:10], 3'd0}
+|xd |$encoding[4:2]
+|xs1 |$encoding[9:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[6:5], $encoding[12:10], 3'd0}
+|xd |$encoding[4:2]
+|xs1 |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+| *Zclsd* | ~> 1.0
+
+|===
+
+
+[#udb:doc:inst:c_ldsp]
+== c.ldsp
+
+Synopsis::
+Load doubleword from stack pointer
+
+Assembly::
+c.ldsp xd, imm(sp)
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "imm[4:3|8:6]","type":4},{"bits":5,"name": "xd != {0,1,3,5,7}","type":4},{"bits":1,"name": "imm[5]","type":4},{"bits":3,"name": 0x3,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "imm[4:3|8:6]","type":4},{"bits":5,"name": "xd","type":4},{"bits":1,"name": "imm[5]","type":4},{"bits":3,"name": 0x3,"type":2}]}
+....
+
+Description::
+C.LDSP is an RV64C/RV128C-only instruction that loads a 64-bit value from memory
+into register xd.
+It computes its effective address by adding the zero-extended offset, scaled by 8,
+to the stack pointer, x2.
+It expands to `ld xd, offset(x2)`.
+C.LDSP is only valid when xd ≠ x0; code points with xd=x0 are reserved.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[4:2], $encoding[12], $encoding[6:5], 3'd0}
+|xd |$encoding[11:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[4:2], $encoding[12], $encoding[6:5], 3'd0}
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_lh]
+== c.lh
+
+Synopsis::
+Load signed halfword, 16-bit encoding
+
+Assembly::
+c.lh xd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xd","type":4},{"bits":1,"name": "imm[1]","type":4},{"bits":1,"name": 0x1,"type":2},{"bits":3,"name": "xs1","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+Loads a 16-bit value from memory into register xd.
+It computes an effective address by adding the zero-extended offset, to the base address in register xs1.
+It expands to xref:insts:lh.adoc#udb:doc:inst:lh[lh] `xd, offset(xs1)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[5], 1'd0}
+|xd |$encoding[4:2]
+|xs1 |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcb* | ~> 1.0.0
+
+| *Zce* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_lhu]
+== c.lhu
+
+Synopsis::
+Load unsigned halfword, 16-bit encoding
+
+Assembly::
+c.lhu xd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xd","type":4},{"bits":1,"name": "imm[1]","type":4},{"bits":1,"name": 0x0,"type":2},{"bits":3,"name": "xs1","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+Loads a 16-bit value from memory into register xd.
+It computes an effective address by adding the zero-extended offset, to the base address in register xs1.
+It expands to xref:insts:lhu.adoc#udb:doc:inst:lhu[lhu] `xd, offset(xs1)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[5], 1'd0}
+|xd |$encoding[4:2]
+|xs1 |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcb* | ~> 1.0.0
+
+| *Zce* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_li]
+== c.li
+
+Synopsis::
+Load the sign-extended 6-bit immediate
+
+Assembly::
+c.li xd, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":5,"name": "xd != 0","type":4},{"bits":1,"name": "imm[5]","type":4},{"bits":3,"name": 0x2,"type":2}]}
+....
+
+Description::
+C.LI loads the sign-extended 6-bit immediate, imm, into register xd.
+C.LI expands into `addi xd, x0, imm`.
+C.LI is only valid when xd ≠ x0; the code points with xd=x0 encode HINTs.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[12], $encoding[6:2]}
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_lui]
+== c.lui
+
+Synopsis::
+Load the non-zero 6-bit immediate field into bits 17-12 of the destination register
+
+Assembly::
+c.lui xd, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "imm[16:12]","type":4},{"bits":5,"name": "xd != {0,2}","type":4},{"bits":1,"name": "imm[17]","type":4},{"bits":3,"name": 0x3,"type":2}]}
+....
+
+Description::
+C.LUI loads the non-zero 6-bit immediate field into bits 17-12 of the destination register, clears the bottom 12 bits, and sign-extends bit 17 into all higher bits of the destination.
+C.LUI expands into `lui xd, imm`.
+C.LUI is only valid when xd≠x0 and xd≠x2, and when the immediate is not equal to zero.
+The code points with imm=0 are reserved; the remaining code points with xd=x0 are HINTs; and the remaining code points with xd=x2 correspond to the C.ADDI16SP instruction
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[12], $encoding[6:2], 12'd0}
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_lw]
+== c.lw
+
+Synopsis::
+Load word
+
+Assembly::
+c.lw xd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xd","type":4},{"bits":2,"name": "imm[2|6]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x2,"type":2}]}
+....
+
+Description::
+Loads a 32-bit value from memory into register xd.
+It computes an effective address by adding the zero-extended offset, scaled by 4,
+to the base address in register xs1.
+It expands to xref:insts:lw.adoc#udb:doc:inst:lw[lw] `xd, offset(xs1)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[5], $encoding[12:10], $encoding[6], 2'd0}
+|xd |$encoding[4:2]
+|xs1 |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_lwsp]
+== c.lwsp
+
+Synopsis::
+Load word from stack pointer
+
+Assembly::
+c.lwsp xd, imm(sp)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "imm[4:2|7:6]","type":4},{"bits":5,"name": "xd != 0","type":4},{"bits":1,"name": "imm[5]","type":4},{"bits":3,"name": 0x2,"type":2}]}
+....
+
+Description::
+Loads a 32-bit value from memory into register xd.
+It computes an effective address by adding the zero-extended offset, scaled by 4,
+to the stack pointer, x2.
+It expands to xref:insts:lw.adoc#udb:doc:inst:lw[lw] `xd, offset(x2)`.
+C.LWSP is only valid when xd ≠ x0. The code points with xd=x0 are reserved.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[3:2], $encoding[12], $encoding[6:4], 2'd0}
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_mop_n]
+== c.mop.n
+
+Synopsis::
+Compressed May-Be-Operation
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":8,"name": 0x81,"type":2},{"bits":3,"name": "n","type":4},{"bits":5,"name": 0xc,"type":2}]}
+....
+
+Description::
+C.MOP.n is encoded in the reserved encoding space corresponding to C.LUI xn, 0. Unlike the MOPs defined in the Zimop extension, the C.MOP.n instructions are defined to not write any register. Their encoding allows future extensions to define them to read register x[n].
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|n |$encoding[10:8]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcmop* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_mul]
+== c.mul
+
+Synopsis::
+Multiply, 16-bit encoding
+
+Assembly::
+c.mul xd, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x27,"type":2}]}
+....
+
+Description::
+Multiplies XLEN bits of the source operands from rsd' and xs2' and writes the lowest XLEN bits of the result to rsd'.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xd |$encoding[9:7]
+|xs2 |$encoding[4:2]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcb* | ~> 1.0.0
+
+| *Zmmul* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_mv]
+== c.mv
+
+Synopsis::
+Move Register
+
+Assembly::
+c.mv xd, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "xs2 != 0","type":4},{"bits":5,"name": "xd != 0","type":4},{"bits":4,"name": 0x8,"type":2}]}
+....
+
+Description::
+C.MV (move register) performs copy of the data in register xs2 to register xd
+C.MV expands to addi xd, x0, xs2.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xd |$encoding[11:7]
+|xs2 |$encoding[6:2]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_nop]
+== c.nop
+
+Synopsis::
+Non-operation
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":16,"name": 0x1,"type":2}]}
+....
+
+Description::
+C.NOP expands into `addi x0, x0, 0`.
+
+
+Decode Variables::
+c.nop has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_not]
+== c.not
+
+Synopsis::
+Bitwise not, 16-bit encoding
+
+Assembly::
+c.not xd
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x75,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x27,"type":2}]}
+....
+
+Description::
+Takes a single source/destination operand.
+This instruction takes the one's complement of xd'/xs1' and writes the result to the same register.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xd |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcb* | ~> 1.0.0
+
+| *Zce* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_or]
+== c.or
+
+Synopsis::
+Or
+
+Assembly::
+c.or xd, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+Or xd with xs2, and store the result in xd
+The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+C.OR expands into `or xd, xd, xs2`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[4:2]
+|xd |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_sb]
+== c.sb
+
+Synopsis::
+Store unsigned byte, 16-bit encoding
+
+Assembly::
+c.sb xs2, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": "imm","type":4},{"bits":3,"name": "xs1","type":4},{"bits":6,"name": 0x22,"type":2}]}
+....
+
+Description::
+Stores a 8-bit value from register xs2 into memory.
+It computes an effective address by adding the zero-extended offset, to the base address in register xs1.
+It expands to xref:insts:sb.adoc#udb:doc:inst:sb[sb] `xs2, offset(xs1)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[5], $encoding[6]}
+|xs2 |$encoding[4:2]
+|xs1 |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcb* | ~> 1.0.0
+
+| *Zce* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_sd]
+== c.sd
+
+Synopsis::
+Store double
+
+Assembly::
+c.sd xs2, imm(xs1)
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xs2 != {1,3,5,7}","type":4},{"bits":2,"name": "imm[7:6]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x7,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": "imm[7:6]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x7,"type":2}]}
+....
+
+Description::
+For RV64, store a 64-bit value in register xs2 to memory. For RV32 with Zclsd extension, store a 64-bit value from the combined values in register pair [xs2, xs2+1] to memory.
+It computes an effective address by adding the zero-extended offset, scaled by 8,
+to the base address in register xs1.
+It expands to xref:insts:sd.adoc#udb:doc:inst:sd[sd] `xs2, offset(xs1)`.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[6:5], $encoding[12:10], 3'd0}
+|xs2 |$encoding[4:2]
+|xs1 |$encoding[9:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[6:5], $encoding[12:10], 3'd0}
+|xs2 |$encoding[4:2]
+|xs1 |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+| *Zclsd* | ~> 1.0
+
+|===
+
+
+[#udb:doc:inst:c_sdsp]
+== c.sdsp
+
+Synopsis::
+Store doubleword to stack
+
+Assembly::
+c.sdsp xs2, imm(sp)
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "xs2 != {1,3,5,7}","type":4},{"bits":6,"name": "imm[5:3|8:6]","type":4},{"bits":3,"name": 0x7,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "xs2","type":4},{"bits":6,"name": "imm[5:3|8:6]","type":4},{"bits":3,"name": 0x7,"type":2}]}
+....
+
+Description::
+Stores a 64-bit value in register rs2 to memory.
+It computes an effective address by adding the zero-extended offset, scaled by 8,
+to the stack pointer, x2.
+It expands to xref:insts:sd.adoc#udb:doc:inst:sd[sd] `xs2, offset(x2)`.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[6:2]
+|imm |{$encoding[9:7], $encoding[12:10], 3'd0}
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[6:2]
+|imm |{$encoding[9:7], $encoding[12:10], 3'd0}
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+| *Zclsd* | ~> 1.0
+
+|===
+
+
+[#udb:doc:inst:c_sext_b]
+== c.sext.b
+
+Synopsis::
+Sign-extend byte, 16-bit encoding
+
+Assembly::
+c.sext.b xd
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x65,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x27,"type":2}]}
+....
+
+Description::
+Takes a single source/destination operand.
+This instruction sign-extends the least-significant byte of the source to XLEN by copying
+the most-significant bit in the byte (i.e., bit 7) to all of the more-significant bits.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xd |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcb* | ~> 1.0.0
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_sext_h]
+== c.sext.h
+
+Synopsis::
+Sign-extend halfword, 16-bit encoding
+
+Assembly::
+c.sext.h xd
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x6d,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x27,"type":2}]}
+....
+
+Description::
+Takes a single source/destination operand.
+This instruction sign-extends the least-significant halfword of the source to XLEN by copying
+the most-significant bit in the halfword (i.e., bit 15) to all of the more-significant bits.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xd |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcb* | ~> 1.0.0
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_sh]
+== c.sh
+
+Synopsis::
+Store unsigned halfword, 16-bit encoding
+
+Assembly::
+c.sh xs2, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":1,"name": "imm[1]","type":4},{"bits":1,"name": 0x0,"type":2},{"bits":3,"name": "xs1","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+Stores a 16-bit value from register xs2 into memory.
+It computes an effective address by adding the zero-extended offset, to the base address in register xs1.
+It expands to xref:insts:sh.adoc#udb:doc:inst:sh[sh] `xs2, offset(xs1)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[5], 1'd0}
+|xs2 |$encoding[4:2]
+|xs1 |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcb* | ~> 1.0.0
+
+| *Zce* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_slli]
+== c.slli
+
+Synopsis::
+Shift left logical immediate
+
+Assembly::
+c.slli xd, shamt
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "shamt != 0","type":4},{"bits":5,"name": "rd","type":4},{"bits":4,"name": 0x0,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "shamt != 0[4:0]","type":4},{"bits":5,"name": "rd","type":4},{"bits":1,"name": "shamt != 0[5]","type":4},{"bits":3,"name": 0x0,"type":2}]}
+....
+
+Description::
+Shift the value in rd left by shamt, and store the result back in rd.
+C.SLLI expands into `slli rd, rd, shamt`.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[6:2]
+|rd |$encoding[11:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |{$encoding[12], $encoding[6:2]}
+|rd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_srai]
+== c.srai
+
+Synopsis::
+Shift right arithmetical immediate
+
+Assembly::
+c.srai xd, shamt
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "shamt != 0","type":4},{"bits":3,"name": "rd","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "shamt != 0[4:0]","type":4},{"bits":3,"name": "rd","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":1,"name": "shamt != 0[5]","type":4},{"bits":3,"name": 0x4,"type":2}]}
+....
+
+Description::
+Arithmetic shift (the original sign bit is copied into the vacated upper bits) the value in rd right by shamt, and store the result in rd.
+The rd register index should be used as rd+8 (registers x8-x15).
+C.SRAI expands into `srai rd, rd, shamt`.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[6:2]
+|rd |$encoding[9:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |{$encoding[12], $encoding[6:2]}
+|rd |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_srli]
+== c.srli
+
+Synopsis::
+Shift right logical immediate
+
+Assembly::
+c.srli xd, shamt
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "shamt != 0","type":4},{"bits":3,"name": "rd","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "shamt != 0[4:0]","type":4},{"bits":3,"name": "rd","type":4},{"bits":2,"name": 0x0,"type":2},{"bits":1,"name": "shamt != 0[5]","type":4},{"bits":3,"name": 0x4,"type":2}]}
+....
+
+Description::
+Shift the value in rd right by shamt, and store the result back in rd.
+The rd register index should be used as rd+8 (registers x8-x15).
+C.SRLI expands into `srli rd, rd, shamt`.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[6:2]
+|rd |$encoding[9:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |{$encoding[12], $encoding[6:2]}
+|rd |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_sub]
+== c.sub
+
+Synopsis::
+Subtract
+
+Assembly::
+c.sub xd, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+Subtract the value in xs2 from xd, and store the result in xd.
+The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+C.SUB expands into `sub xd, xd, xs2`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[4:2]
+|xd |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_subw]
+== c.subw
+
+Synopsis::
+Subtract word
+
+Assembly::
+c.subw xd, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x27,"type":2}]}
+....
+
+Description::
+Subtract the 32-bit values in xs2 from xd, and store the result in xd.
+The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+C.SUBW expands into `subw xd, xd, xs2`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[4:2]
+|xd |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_sw]
+== c.sw
+
+Synopsis::
+Store word
+
+Assembly::
+c.sw xs2, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x0,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": "imm[2|6]","type":4},{"bits":3,"name": "xs1","type":4},{"bits":3,"name": "imm[5:3]","type":4},{"bits":3,"name": 0x6,"type":2}]}
+....
+
+Description::
+Stores a 32-bit value in register xs2 to memory.
+It computes an effective address by adding the zero-extended offset, scaled by 4,
+to the base address in register xs1.
+It expands to xref:insts:sw.adoc#udb:doc:inst:sw[sw] `rs2, offset(xs1)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[5], $encoding[12:10], $encoding[6], 2'd0}
+|xs2 |$encoding[4:2]
+|xs1 |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_swsp]
+== c.swsp
+
+Synopsis::
+Store word to stack
+
+Assembly::
+c.swsp xs2, imm(sp)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "xs2","type":4},{"bits":6,"name": "imm[5:2|7:6]","type":4},{"bits":3,"name": 0x6,"type":2}]}
+....
+
+Description::
+Stores a 32-bit value in register xs2 to memory.
+It computes an effective address by adding the zero-extended offset, scaled by 4,
+to the stack pointer, x2.
+It expands to xref:insts:sw.adoc#udb:doc:inst:sw[sw] `xs2, offset(x2)`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[8:7], $encoding[12:9], 2'd0}
+|xs2 |$encoding[6:2]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_xor]
+== c.xor
+
+Synopsis::
+Exclusive Or
+
+Assembly::
+c.xor xd, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+Exclusive or xd with xs2, and store the result in xd
+The xd and xs2 register indexes should be used as xd+8 and xs2+8 (registers x8-x15).
+C.XOR expands into `xor xd, xd, xs2`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[4:2]
+|xd |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *C* | ~> 2.0.0
+
+| *Zca* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_zext_b]
+== c.zext.b
+
+Synopsis::
+Zero-extend byte, 16-bit encoding
+
+Assembly::
+c.zext.b xd
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x61,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x27,"type":2}]}
+....
+
+Description::
+Takes a single source/destination operand.
+This instruction zero-extends the least-significant byte of the source to XLEN by inserting
+0's into all of the bits more significant than 7.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xd |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcb* | ~> 1.0.0
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_zext_h]
+== c.zext.h
+
+Synopsis::
+Zero-extend halfword, 16-bit encoding
+
+Assembly::
+c.zext.h xd
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x69,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x27,"type":2}]}
+....
+
+Description::
+Takes a single source/destination operand.
+This instruction zero-extends the least-significant halfword of the source to XLEN by inserting
+0's into all of the bits more significant than 15.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xd |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcb* | ~> 1.0.0
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:c_zext_w]
+== c.zext.w
+
+Synopsis::
+Zero-extend word, 16-bit encoding
+
+Assembly::
+c.zext.w xd
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x71,"type":2},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x27,"type":2}]}
+....
+
+Description::
+Takes a single source/destination operand.
+It zero-extends the least-significant word of the operand to XLEN bits by inserting zeros into all of the bits more significant than 31.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xd |$encoding[9:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcb* | ~> 1.0.0
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:cbo_clean]
+== cbo.clean
+
+Synopsis::
+Cache Block Clean
+
+Assembly::
+cbo.clean (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x200f,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x1,"type":2}]}
+....
+
+Description::
+Cleans an entire cache block globally throughout the system.
+
+Exactly what happens is coherence protocol-dependent, but in general it is expected that after this
+operation():
+
+  * The cache block will be in the clean (not dirty) state in any coherent cache holding a valid copy of the line.
+  * The data will be cleaned to a point such that an incoherent load can observe the cleaned data.
+
+xref:insts:cbo_clean.adoc#udb:doc:inst:cbo_clean[cbo.clean] is ordered by `FENCE` instructions but not `FENCE.I` or `SFENCE.VMA`.
+
+<%- if CACHE_BLOCK_SIZE.bit_length > [PMP_GRANULARITY, PMA_GRANULARITY].min -%>
+Both PMP and PMA access control must be the same for all bytes in the block; otherwise, xref:insts:cbo_clean.adoc#udb:doc:inst:cbo_clean[cbo.clean] has UNSPECIFIED behavior.
+<%- end -%>
+
+Clean operations are treated as stores for page and access permissions. If permission checks fail,
+one of the following exceptions will occur:
+
+  <%- if ext?(:H) -%>
+  * `Store/AMO Guest-Page Fault` if virtual memory translation fails during G-stage translation.
+  <%- end -%>
+  * `Store/AMO Page Fault` if virtual memory translation fails <% if ext?(:H) %>when V=0 or during VS-stage translation<% end %>
+  * `Store/AMO Access Fault` if a PMP or PMA access check fails
+
+<%- if CACHE_BLOCK_SIZE.bit_length <= [PMP_GRANULARITY, PMA_GRANULARITY].min -%>
+Because cache blocks are naturally aligned and always fit in a single PMP or PMA regions, the PMP
+and PMA access checks only need to check a single address in the line.
+<%- end -%>
+
+CBO operations never raise a misaligned address fault.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicbom* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:cbo_flush]
+== cbo.flush
+
+Synopsis::
+Cache Block Flush
+
+Assembly::
+cbo.flush (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x200f,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x2,"type":2}]}
+....
+
+Description::
+Flushes an entire cache block by cleaning it and then invalidating it in all caches.
+
+xref:insts:cbo_flush.adoc#udb:doc:inst:cbo_flush[cbo.flush] is ordered by `FENCE` instructions but not `FENCE.I` or `SFENCE.VMA`.
+
+<%- if CACHE_BLOCK_SIZE.bit_length > [PMP_GRANULARITY, PMA_GRANULARITY].min -%>
+Both PMP and PMA access control must be the same for all bytes in the block; otherwise, xref:insts:cbo_flush.adoc#udb:doc:inst:cbo_flush[cbo.flush] has UNSPECIFIED behavior.
+<%- end -%>
+
+Flush operations are treated as stores for page and access permissions. If permission checks fail,
+one of the following exceptions will occur:
+
+  <%- if ext?(:H) -%>
+  * `Store/AMO Guest-Page Fault` if virtual memory translation fails during G-stage translation.
+  <%- end -%>
+  * `Store/AMO Page Fault` if virtual memory translation fails <% if ext?(:H) %>when V=0 or during VS-stage translation<% end %>
+  * `Store/AMO Access Fault` if a PMP or PMA access check fails.
+
+<%- if CACHE_BLOCK_SIZE.bit_length <= [PMP_GRANULARITY, PMA_GRANULARITY].min -%>
+Because cache blocks are naturally aligned and always fit in a single PMP or PMA regions, the PMP
+and PMA access checks only need to check a single address in the line.
+<%- end -%>
+
+CBO operations never raise a misaligned address fault.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicbom* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:cbo_inval]
+== cbo.inval
+
+Synopsis::
+Cache Block Invalidate
+
+Assembly::
+cbo.inval (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x200f,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x0,"type":2}]}
+....
+
+Description::
+Either invalidates or flushes (clean + invalidate) a cache block, depending on the current mode and value of
+xref:csrs:menvcfg.adoc#udb:doc:csr_field:menvcfg:CBIE[menvcfg.CBIE], xref:csrs:senvcfg.adoc#udb:doc:csr_field:senvcfg:CBIE[senvcfg.CBIE], and/or xref:csrs:henvcfg.adoc#udb:doc:csr_field:henvcfg:CBIE[henvcfg.CBIE].
+
+The instruction is an invalidate (without a clean) when:
+
+  * In M-mode
+  * In (H)S-mode and xref:csrs:menvcfg.adoc#udb:doc:csr_field:menvcfg:CBIE[menvcfg.CBIE] == 11
+  * In U-mode and xref:csrs:menvcfg.adoc#udb:doc:csr_field:menvcfg:CBIE[menvcfg.CBIE] == 11 and xref:csrs:senvcfg.adoc#udb:doc:csr_field:senvcfg:CBIE[senvcfg.CBIE] == 11
+  * In VS-mode and xref:csrs:menvcfg.adoc#udb:doc:csr_field:menvcfg:CBIE[menvcfg.CBIE] == 11 and xref:csrs:henvcfg.adoc#udb:doc:csr_field:henvcfg:CBIE[henvcfg.CBIE] == 11
+  * In VU-mode and xref:csrs:menvcfg.adoc#udb:doc:csr_field:menvcfg:CBIE[menvcfg.CBIE] == 11 and xref:csrs:henvcfg.adoc#udb:doc:csr_field:henvcfg:CBIE[henvcfg.CBIE] == 11 and xref:csrs:senvcfg.adoc#udb:doc:csr_field:senvcfg:CBIE[senvcfg.CBIE] == 11
+
+Otherwise, if the instruction does not trap (see Access section), the operation is a flush.
+The table below summarizes the options.
+
+[%autowidth,cols="1,1,1,1,1,1,1,1",separator="!"]
+!===
+.2+h![.rotate]#xref:csrs:menvcfg.adoc#udb:doc:csr_field:menvcfg:CBIE[menvcfg.CBIE]# .2+h! [.rotate]#xref:csrs:senvcfg.adoc#udb:doc:csr_field:senvcfg:CBIE[senvcfg.CBIE]# .2+h! [.rotate]#xref:csrs:henvcfg.adoc#udb:doc:csr_field:henvcfg:CBIE[henvcfg.CBIE]#
+5+^.>h! `cbe.inval` Operation
+.^h! M-mode .^h! S-mode .^h! U-mode .^h! VS-mode .^h! VU-mode
+
+! 00 ! - ! - ! Invalidate ! `Illegal Instruction` ! `Illegal Instruction` ! `Virtual Instruction` ! `Virtual Instruction`
+! 01 ! 00 ! 00 ! Invalidate ! Flush  ! `Illegal Instruction` ! `Virtual Instruction` ! `Virtual Instruction`
+! 01 ! 00 ! 01 ! Invalidate ! Flush  ! `Illegal Instruction` ! Flush ! `Virtual Instruction`
+! 01 ! 00 ! 11 ! Invalidate ! Flush  ! `Illegal Instruction` ! Flush ! `Virtual Instruction`
+! 01 ! 01 ! 00 ! Invalidate ! Flush  ! Flush ! `Virtual Instruction` ! `Virtual Instruction`
+! 01 ! 01 ! 01 ! Invalidate ! Flush  ! Flush ! Flush ! Flush
+! 01 ! 01 ! 11 ! Invalidate ! Flush  ! Flush ! Flush ! Flush
+! 01 ! 11 ! 00 ! Invalidate ! Flush  ! Flush ! `Virtual Instruction` ! `Virtual Instruction`
+! 01 ! 11 ! 01 ! Invalidate ! Flush  ! Flush ! Flush ! Flush
+! 01 ! 11 ! 11 ! Invalidate ! Flush  ! Flush ! Flush ! Flush
+! 11 ! 00 ! 00  ! Invalidate ! Invalidate  ! `Illegal Instruction` ! `Virtual Instruction` ! `Virtual Instruction`
+! 11 ! 00 ! 01  ! Invalidate ! Invalidate  ! `Illegal Instruction` ! Flush ! `Virtual Instruction`
+! 11 ! 00 ! 11  ! Invalidate ! Invalidate  ! `Illegal Instruction` ! Invalidate ! `Virtual Instruction`
+! 11 ! 01 ! 00 ! Invalidate ! Invalidate  ! Flush ! `Virtual Instruction` ! `Virtual Instruction`
+! 11 ! 01 ! 01 ! Invalidate ! Invalidate  ! Flush ! Flush ! Flush
+! 11 ! 01 ! 11 ! Invalidate ! Invalidate  ! Flush ! Invalidate ! Flush
+! 11 ! 11 ! 00 ! Invalidate ! Invalidate  ! Invalidate ! `Virtual Instruction` ! `Virtual Instruction`
+! 11 ! 11 ! 01 ! Invalidate ! Invalidate  ! Invalidate ! Flush ! Flush
+! 11 ! 11 ! 11 ! Invalidate ! Invalidate  ! Invalidate ! Invalidate ! Invalidate
+!===
+
+xref:insts:cbo_inval.adoc#udb:doc:inst:cbo_inval[cbo.inval] is ordered by `FENCE` instructions but not `FENCE.I` or `SFENCE.VMA`.
+
+<%- if CACHE_BLOCK_SIZE.bit_length > [PMP_GRANULARITY, PMA_GRANULARITY].min -%>
+Both PMP and PMA access control must be the same for all bytes in the block; otherwise, xref:insts:cbo_zero.adoc#udb:doc:inst:cbo_zero[cbo.zero] has UNSPECIFIED behavior.
+<%- end -%>
+
+Invalidate operations are treated as stores for page and access permissions. If permission checks fail,
+one of the following exceptions will occur:
+
+  <%- if ext?(:H) -%>
+  * `Store/AMO Guest-Page Fault` if virtual memory translation fails during G-stage translation.
+  <%- end -%>
+  * `Store/AMO Page Fault` if virtual memory translation fails <% if ext?(:H) %>when V=0 or during VS-stage translation<% end %>
+  * `Store/AMO Access Fault` if a PMP or PMA access check fails.
+
+<%- if CACHE_BLOCK_SIZE.bit_length <= [PMP_GRANULARITY, PMA_GRANULARITY].min -%>
+Because cache blocks are naturally aligned and always fit in a single PMP or PMA regions, the PMP
+and PMA access checks only need to check a single address in the line.
+<%- end -%>
+
+CBO operations never raise a misaligned address fault.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicbom* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:cbo_zero]
+== cbo.zero
+
+Synopsis::
+Cache Block Zero
+
+Assembly::
+cbo.zero (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x200f,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x4,"type":2}]}
+....
+
+Description::
+Zeros an entire cache block
+
+The block zeroing does not need to be atomic.
+
+xref:insts:cbo_zero.adoc#udb:doc:inst:cbo_zero[cbo.zero] is ordered by `FENCE` instructions but not `FENCE.I` or `SFENCE.VMA`.
+
+<%- if CACHE_BLOCK_SIZE.bit_length > [PMP_GRANULARITY, PMA_GRANULARITY].min -%>
+Both PMP and PMA access control must be the same for all bytes in the block; otherwise, xref:insts:cbo_zero.adoc#udb:doc:inst:cbo_zero[cbo.zero] has UNSPECIFIED behavior.
+<%- end -%>
+
+Clean operations are treated as stores for page and access permissions. If permission checks fail,
+one of the following exceptions will occur:
+
+  <%- if ext?(:H) -%>
+  * `Store/AMO Guest-Page Fault` if virtual memory translation fails during G-stage translation.
+  <%- end -%>
+  * `Store/AMO Page Fault` if virtual memory translation fails <% if ext?(:H) %>when V=0 or during VS-stage translation<% end %>
+  * `Store/AMO Access Fault` if a PMP or PMA access check fails.
+
+<%- if CACHE_BLOCK_SIZE.bit_length <= [PMP_GRANULARITY, PMA_GRANULARITY].min -%>
+Because cache blocks are naturally aligned and always fit in a single PMP or PMA regions, the PMP
+and PMA access checks only need to check a single address in the line.
+<%- end -%>
+
+CBO operations never raise a misaligned address fault.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicboz* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:clmul]
+== clmul
+
+Synopsis::
+Carry-less multiply (low-part)
+
+Assembly::
+clmul xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x5,"type":2}]}
+....
+
+Description::
+xref:insts:clmul.adoc#udb:doc:inst:clmul[clmul] produces the lower half of the 2*XLEN carry-less product
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbc* | ~> 1.0.0
+
+| *Zbkc* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:clmulh]
+== clmulh
+
+Synopsis::
+Carry-less multiply (high-part)
+
+Assembly::
+clmulh xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x5,"type":2}]}
+....
+
+Description::
+xref:insts:clmulh.adoc#udb:doc:inst:clmulh[clmulh] produces the upper half of the 2*XLEN carry-less product
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbc* | ~> 1.0.0
+
+| *Zbkc* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:clmulr]
+== clmulr
+
+Synopsis::
+Carry-less multiply (reversed)
+
+Assembly::
+clmulr xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x5,"type":2}]}
+....
+
+Description::
+xref:insts:clmulr.adoc#udb:doc:inst:clmulr[clmulr] produces bits 2*XLEN-2:XLEN-1 of the 2*XLEN carry-less product
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbc* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:clz]
+== clz
+
+Synopsis::
+Count leading zero bits
+
+Assembly::
+clz xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x600,"type":2}]}
+....
+
+Description::
+Counts the number of 0's before the first 1,
+starting at the most-significant bit (i.e., XLEN-1) and progressing to bit 0.
+Accordingly, if the input is 0, the output is XLEN, and if the most-significant
+bit of the input is a 1, the output is 0.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:clzw]
+== clzw
+
+Synopsis::
+Count leading zero bits in word
+
+Assembly::
+clzw xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x1b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x600,"type":2}]}
+....
+
+Description::
+Counts the number of 0's before the first 1 starting at bit 31 and progressing to bit 0.
+Accordingly, if the least-significant word is 0, the output is 32, and if the most-significant
+bit of the word (_i.e._, bit 31) is a 1, the output is 0.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:cm_mva01s]
+== cm.mva01s
+
+Synopsis::
+Move two s0-s7 registers into a0-a1
+
+Assembly::
+cm.mva01s r1s, r2s
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":3,"name": "r2s","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":3,"name": "r1s","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+Moves r1s' into a0 and r2s' into a1. The execution is atomic, so it is not possible to observe state where only one of a0 or a1 have been updated.
+The encoding uses sreg number specifiers instead of xreg number specifiers to save encoding space. The mapping between them is specified in the pseudo-code below.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|r1s |$encoding[9:7]
+|r2s |$encoding[4:2]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcmp* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:cm_mvsa01]
+== cm.mvsa01
+
+Synopsis::
+Move a0-a1 into two registers of s0-s7
+
+Assembly::
+cm.mvsa01 r1s, r2s
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":3,"name": "r2s","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":3,"name": "r1s","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+Moves a0 into r1s' and a1 into r2s'. r1s' and r2s' must be different.
+The execution is atomic, so it is not possible to observe state where only one of r1s' or r2s' has been updated.
+The encoding uses sreg number specifiers instead of xreg number specifiers to save encoding space.
+The mapping between them is specified in the pseudo-code below.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|r1s |$encoding[9:7]
+|r2s |$encoding[4:2]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcmp* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:cm_pop]
+== cm.pop
+
+Synopsis::
+Destroy function call stack frame
+
+Assembly::
+cm.pop reg_list, stack_adj
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":2,"name": "spimm[5:4]","type":4},{"bits":4,"name": "rlist != {0,1,2,3}","type":4},{"bits":8,"name": 0xba,"type":2}]}
+....
+
+Description::
+Destroys a stack frame: load `ra` and 0 to 12 saved registers from the stack frame, deallocate the stack frame.
+This instruction pops (loads) the registers in `reg_list` from stack memory, and then adjusts the stack pointer by `stack_adj`.
+
+Restrictions on stack_adj:
+
+* it must be enough to store all of the listed registers
+* it must be a multiple of 16 (bytes):
+** for RV32 the allowed values are: 16, 32, 48, 64, 80, 96, 112
+** for RV64 the allowed values are: 16, 32, 48, 64, 80, 96, 112, 128, 144, 160
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|rlist |$encoding[7:4]
+|spimm |{$encoding[3:2], 4'd0}
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcmp* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:cm_popret]
+== cm.popret
+
+Synopsis::
+Destroy function call stack frame and return to `ra`
+
+Assembly::
+cm.popret reg_list, stack_adj
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":2,"name": "spimm[5:4]","type":4},{"bits":4,"name": "rlist != {0,1,2,3}","type":4},{"bits":8,"name": 0xbe,"type":2}]}
+....
+
+Description::
+Destroys a stack frame: load `ra` and 0 to 12 saved registers from the stack frame, deallocate the stack frame, return to `ra`.
+This instruction pops (loads) the registers in `reg_list` from stack memory, and then adjusts the stack pointer by `stack_adj` and then return to `ra`.
+
+Restrictions on stack_adj:
+
+* it must be enough to store all of the listed registers
+* it must be a multiple of 16 (bytes):
+** for RV32 the allowed values are: 16, 32, 48, 64, 80, 96, 112
+** for RV64 the allowed values are: 16, 32, 48, 64, 80, 96, 112, 128, 144, 160
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|rlist |$encoding[7:4]
+|spimm |{$encoding[3:2], 4'd0}
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcmp* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:cm_popretz]
+== cm.popretz
+
+Synopsis::
+Destroy function call stack frame, move zero to `a0` and return to `ra`
+
+Assembly::
+cm.popretz reg_list, stack_adj
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":2,"name": "spimm[5:4]","type":4},{"bits":4,"name": "rlist != {0,1,2,3}","type":4},{"bits":8,"name": 0xbc,"type":2}]}
+....
+
+Description::
+Destroys a stack frame: load `ra` and 0 to 12 saved registers from the stack frame, deallocate the stack frame, move zero to `a0`, return to `ra`.
+This instruction pops (loads) the registers in `reg_list` from stack memory, and then adjusts the stack pointer by `stack_adj`, move zero to `a0` and then return to `ra`.
+
+Restrictions on stack_adj:
+
+* it must be enough to store all of the listed registers
+* it must be a multiple of 16 (bytes):
+** for RV32 the allowed values are: 16, 32, 48, 64, 80, 96, 112
+** for RV64 the allowed values are: 16, 32, 48, 64, 80, 96, 112, 128, 144, 160
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|rlist |$encoding[7:4]
+|spimm |{$encoding[3:2], 4'd0}
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcmp* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:cm_push]
+== cm.push
+
+Synopsis::
+Create function call stack frame
+
+Assembly::
+cm.push reg_list, -stack_adj
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":2,"name": "spimm[5:4]","type":4},{"bits":4,"name": "rlist != {0,1,2,3}","type":4},{"bits":8,"name": 0xb8,"type":2}]}
+....
+
+Description::
+Creates a stack frame: store `ra` and 0 to 12 saved registers to the stack frame, optionally allocate additional stack space.
+This instruction pushes (stores) the registers in `reg_list` to the memory below the stack pointer,
+and then creates the stack frame by decrementing the stack pointer by `stack_adj`.
+
+Restrictions on stack_adj:
+
+* it must be enough to store all of the listed registers
+* it must be a multiple of 16 (bytes):
+** for RV32 the allowed values are: 16, 32, 48, 64, 80, 96, 112
+** for RV64 the allowed values are: 16, 32, 48, 64, 80, 96, 112, 128, 144, 160
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|rlist |$encoding[7:4]
+|spimm |{$encoding[3:2], 4'd0}
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zcmp* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:cpop]
+== cpop
+
+Synopsis::
+Count set bits
+
+Assembly::
+cpop xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x602,"type":2}]}
+....
+
+Description::
+Counts the number of 1's (i.e., set bits) in the source register.
+
+.Software Hint
+[NOTE]
+----
+This operations is known as population count, popcount, sideways sum,
+bit summation, or Hamming weight.
+
+The GCC builtin function `__builtin_popcount (unsigned int x)` is
+implemented by cpop on RV32 and by cpopw on RV64. The GCC builtin
+function `__builtin_popcountl (unsigned long x)` for LP64 is
+implemented by cpop on RV64.
+----
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:cpopw]
+== cpopw
+
+Synopsis::
+Count set bits in word
+
+Assembly::
+cpopw xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x1b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x602,"type":2}]}
+....
+
+Description::
+Counts the number of 1's (i.e., set bits) in the least-significant word of the source register.
+
+.Software Hint
+[NOTE]
+----
+This operations is known as population count, popcount, sideways sum,
+bit summation, or Hamming weight.
+
+The GCC builtin function `__builtin_popcount (unsigned int x)` is
+implemented by cpop on RV32 and by cpopw on RV64. The GCC builtin
+function `__builtin_popcountl (unsigned long x)` for LP64 is
+implemented by cpop on RV64.
+----
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:csrrc]
+== csrrc
+
+Synopsis::
+Atomic Read and Clear Bits in CSR
+
+Assembly::
+csrrc xd, csr, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "csr","type":4}]}
+....
+
+Description::
+The CSRRC (Atomic Read and Clear Bits in CSR) instruction reads the value of the CSR, zero-extends
+the value to XLEN bits, and writes it to integer register `xd`. The initial value in integer register `xs1` is
+treated as a bit mask that specifies bit positions to be cleared in the CSR. Any bit that is high in `xs1` will
+cause the corresponding bit to be cleared in the CSR, if that CSR bit is writable.
+
+For CSRRC, if `xs1=x0`, then the instruction will not write to the CSR at all, and so shall
+not cause any of the side effects that might otherwise occur on a CSR write, nor raise illegal-
+instruction exceptions on accesses to read-only CSRs. CSRRC always reads the addressed CSR and
+cause any read side effects regardless of `xs1` and `xd` fields.
+Note that if `xs1` specifies a register other than `x0`, and that register holds a zero value,
+the instruction will not action any attendant per-field side effects, but will action any
+side effects caused by writing to the entire CSR.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|csr |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicsr* | ~> 2.0.0
+
+|===
+
+
+[#udb:doc:inst:csrrci]
+== csrrci
+
+Synopsis::
+Atomic Read and Clear Bits in CSR with Immediate
+
+Assembly::
+csrrci xd, csr, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "imm","type":4},{"bits":12,"name": "csr","type":4}]}
+....
+
+Description::
+The CSRRCI variant is similar to CSRRC, except this updates the CSR using an XLEN-bit value obtained
+by zero-extending a 5-bit unsigned immediate (imm[4:0]) field encoded in the `xs1` field instead of a
+value from an integer register. For CSRRCI, if the `imm[4:0]` field is zero, then this instruction
+will not write to the CSR, and shall not cause any of the side effects that might otherwise occur on
+a CSR write, nor raise illegal-instruction exceptions on accesses to read-only CSRs. The CSRRCI will
+always read the CSR and cause any read side effects regardless of `xd` and `xs1` fields.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|csr |$encoding[31:20]
+|imm |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicsr* | ~> 2.0.0
+
+|===
+
+
+[#udb:doc:inst:csrrs]
+== csrrs
+
+Synopsis::
+Atomic Read and Set Bits in CSR
+
+Assembly::
+csrrs xd, csr, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "csr","type":4}]}
+....
+
+Description::
+Atomically read and set bits in a CSR.
+
+Reads the value of the CSR, zero-extends the value to `XLEN` bits,
+and writes it to integer register `xd`. The initial value in integer
+register `xs1` is treated as a bit mask that specifies bit positions
+to be set in the CSR. Any bit that is high in `xs1` will cause the
+corresponding bit to be set in the CSR, if that CSR bit is writable.
+Other bits in the CSR are not explicitly written.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|csr |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicsr* | ~> 2.0.0
+
+|===
+
+
+[#udb:doc:inst:csrrsi]
+== csrrsi
+
+Synopsis::
+Atomic Read and Set Bits in CSR with Immediate
+
+Assembly::
+csrrsi xd, csr, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "imm","type":4},{"bits":12,"name": "csr","type":4}]}
+....
+
+Description::
+The CSRRSI variant is similar to CSRRS, except this updates the CSR using an XLEN-bit value obtained
+by zero-extending a 5-bit unsigned immediate (imm[4:0]) field encoded in the `xs1` field instead of a
+value from an integer register. For CSRRSI, if the `imm[4:0]` field is zero, then this instruction
+will not write to the CSR, and shall not cause any of the side effects that might otherwise occur on
+a CSR write, nor raise illegal-instruction exceptions on accesses to read-only CSRs. The CSRRSI will
+always read the CSR and cause any read side effects regardless of `xd` and `xs1` fields.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|csr |$encoding[31:20]
+|imm |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicsr* | ~> 2.0.0
+
+|===
+
+
+[#udb:doc:inst:csrrw]
+== csrrw
+
+Synopsis::
+Atomic Read/Write CSR
+
+Assembly::
+csrrw xd, csr, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "csr","type":4}]}
+....
+
+Description::
+Atomically swap values in the CSRs and integer registers.
+
+Read the old value of the CSR, zero-extends the value to `XLEN` bits,
+and then write it to integer register xd.
+The initial value in xs1 is written to the CSR.
+If `xd=x0`, then the instruction shall not read the CSR and shall not
+cause any of the side effects that might occur on a CSR read.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|csr |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicsr* | ~> 2.0.0
+
+|===
+
+
+[#udb:doc:inst:csrrwi]
+== csrrwi
+
+Synopsis::
+Atomic Read/Write CSR Immediate
+
+Assembly::
+csrrwi xd, csr, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "imm","type":4},{"bits":12,"name": "csr","type":4}]}
+....
+
+Description::
+Atomically write CSR using a 5-bit immediate, and load the previous value into 'xd'.
+
+Read the old value of the CSR, zero-extends the value to `XLEN` bits,
+and then write it to integer register xd.
+The 5-bit uimm field is zero-extended and written to the CSR.
+If `xd=x0`, then the instruction shall not read the CSR and shall not
+cause any of the side effects that might occur on a CSR read.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|csr |$encoding[31:20]
+|imm |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicsr* | ~> 2.0.0
+
+|===
+
+
+[#udb:doc:inst:ctz]
+== ctz
+
+Synopsis::
+Count trailing zero bits
+
+Assembly::
+ctz xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x601,"type":2}]}
+....
+
+Description::
+Counts the number of 0's before the first 1,
+starting at the least-significant bit (i.e., 0) and progressing
+to the most-significant bit (i.e., XLEN-1). Accordingly, if the
+input is 0, the output is XLEN, and if the least-significant bit
+of the input is a 1, the output is 0.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:ctzw]
+== ctzw
+
+Synopsis::
+Count trailing zero bits in word
+
+Assembly::
+ctzw xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x1b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x601,"type":2}]}
+....
+
+Description::
+Counts the number of 0's before the first 1,
+starting at the least-significant bit (i.e., 0) and progressing
+to the most-significant bit of the least-significant word (i.e., 31). Accordingly, if the
+least-significant word is 0, the output is 32, and if the least-significant bit
+of the input is a 1, the output is 0.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:czero_eqz]
+== czero.eqz
+
+Synopsis::
+Conditional zero, if condition is equal to zero
+
+Assembly::
+czero.eqz xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x7,"type":2}]}
+....
+
+Description::
+If xs2 contains the value zero, this instruction writes the value zero to xd. Otherwise, this instruction
+copies the contents of xs1 to xd.
+This instruction carries a syntactic dependency from both xs1 and xs2 to xd. Furthermore, if the Zkt
+extension is implemented, this instruction's timing is independent of the data values in xs1 and xs2.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicond* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:czero_nez]
+== czero.nez
+
+Synopsis::
+Conditional zero, if condition is nonzero
+
+Assembly::
+czero.nez xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x7,"type":2}]}
+....
+
+Description::
+If xs2 contains a nonzero value, this instruction writes the value zero to xd. Otherwise, this
+instruction copies the contents of xs1 to xd.
+This instruction carries a syntactic dependency from both xs1 and xs2 to xd. Furthermore, if the Zkt
+extension is implemented, this instruction's timing is independent of the data values in xs1 and xs2.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicond* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:div]
+== div
+
+Synopsis::
+Signed division
+
+Assembly::
+div xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+Divide xs1 by xs2, and store the result in xd. The remainder is discarded.
+
+Division by zero will put -1 into xd.
+
+Division resulting in signed overflow (when most negative number is divided by -1)
+will put the most negative number into xd;
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *M* | ~> 2.0.0
+
+|===
+
+
+[#udb:doc:inst:divu]
+== divu
+
+Synopsis::
+Unsigned division
+
+Assembly::
+divu xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+Divide unsigned values in xs1 by xs2, and store the result in xd.
+
+The remainder is discarded.
+
+If the value in xs2 is zero, xd gets the largest unsigned value.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *M* | ~> 2.0.0
+
+|===
+
+
+[#udb:doc:inst:divuw]
+== divuw
+
+Synopsis::
+Unsigned 32-bit division
+
+Assembly::
+divuw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+Divide the unsigned 32-bit values in xs1 and xs2, and store the sign-extended result in xd.
+
+The remainder is discarded.
+
+If the value in xs2 is zero, xd is written with all 1s.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *M* | ~> 2.0.0
+
+|===
+
+
+[#udb:doc:inst:divw]
+== divw
+
+Synopsis::
+Signed 32-bit division
+
+Assembly::
+divw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+Divide the lower 32-bits of register xs1 by the lower 32-bits of register xs2,
+and store the sign-extended result in xd.
+
+The remainder is discarded.
+
+Division by zero will put -1 into xd.
+
+Division resulting in signed overflow (when most negative number is divided by -1)
+will put the most negative number into xd;
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *M* | ~> 2.0.0
+
+|===
+
+
+[#udb:doc:inst:dret]
+== dret
+
+Synopsis::
+No synopsis available
+
+Assembly::
+dret dret
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0x7b200073,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+dret has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Sdext* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:ebreak]
+== ebreak
+
+Synopsis::
+Breakpoint exception
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0x100073,"type":2}]}
+....
+
+Description::
+The EBREAK instruction is used by debuggers to cause control to be transferred back to
+a debugging environment. Unless overridden by an external debug environment,
+EBREAK raises a breakpoint exception and performs no other operation.
+
+[NOTE]
+As described in the xref:exts:C.adoc#udb:doc:ext:C[C] Standaxd Extension for Compressed Instructions, the xref:insts:c_ebreak.adoc#udb:doc:inst:c_ebreak[c.ebreak]
+instruction performs the same operation as the EBREAK instruction.
+
+EBREAK causes the receiving privilege mode's epc register to be set to the address of
+the EBREAK instruction itself, not the address of the following instruction.
+As EBREAK causes a synchronous exception, it is not considered to retire,
+and should not increment the xref:csrs:minstret.adoc#udb:doc:csr:minstret[minstret] CSR.
+
+
+Decode Variables::
+ebreak has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:ecall]
+== ecall
+
+Synopsis::
+Environment call
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0x73,"type":2}]}
+....
+
+Description::
+Makes a request to the supporting execution environment.
+When executed in U-mode, S-mode, or M-mode, it generates an environment-call-from-U-mode
+exception, environment-call-from-S-mode exception, or environment-call-from-M-mode
+exception, respectively, and performs no other operation.
+
+[NOTE]
+ECALL generates a different exception for each originating privilege mode so that
+environment call exceptions can be selectively delegated.
+A typical use case for Unix-like operating systems is to delegate to S-mode
+the environment-call-from-U-mode exception but not the others.
+
+ECALL causes the receiving privilege mode's epc register to be set to the address of
+the ECALL instruction itself, not the address of the following instruction.
+As ECALL causes a synchronous exception, it is not considered to retire,
+and should not increment the xref:csrs:minstret.adoc#udb:doc:csr:minstret[minstret] CSR.
+
+
+Decode Variables::
+ecall has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:fadd_d]
+== fadd.d
+
+Synopsis::
+Floating-point Add Double-precision
+
+Assembly::
+fadd.d fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+xref:insts:fadd_d.adoc#udb:doc:inst:fadd_d[fadd.d] is analogous to xref:insts:fadd_s.adoc#udb:doc:inst:fadd_s[fadd.s] and performs double-precision floating-point addition between
+`xs1` and `xs2` and writes the final result to `xd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fadd_h]
+== fadd.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fadd.h fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x2,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fadd_q]
+== fadd.q
+
+Synopsis::
+Floating-point Add Quad-precision
+
+Assembly::
+fadd.q fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x3,"type":2}]}
+....
+
+Description::
+xref:insts:fadd_q.adoc#udb:doc:inst:fadd_q[fadd.q] is analogous to xref:insts:fadd_d.adoc#udb:doc:inst:fadd_d[fadd.d] and performs double-precision floating-point addition between
+`qs1` and `qs2` and writes the final result to `qd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fadd_s]
+== fadd.s
+
+Synopsis::
+Single-precision floating-point addition
+
+Assembly::
+fadd.s fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+Description::
+Do the single-precision floating-point addition of fs1 and fs2 and store the result in fd.
+rm is the dynamic Rounding Mode.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fclass_d]
+== fclass.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fclass.d xd, fs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fclass_h]
+== fclass.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fclass.h xd, fs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe40,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fclass_q]
+== fclass.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fclass.q xd, fs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe60,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fclass_s]
+== fclass.s
+
+Synopsis::
+Single-precision floating-point classify
+
+Assembly::
+fclass.s xd, fs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe00,"type":2}]}
+....
+
+Description::
+The xref:insts:fclass_s.adoc#udb:doc:inst:fclass_s[fclass.s] instruction examines the value in floating-point register
+_fs1_ and writes to integer register _xd_ a 10-bit mask that indicates
+the class of the floating-point number.
+The format of the mask is described in the table below.
+The corresponding bit in _xd_ will be set if the property is true and
+clear otherwise.
+All other bits in _xd_ are cleared.
+Note that exactly one bit in xd will be set.
+xref:insts:fclass_s.adoc#udb:doc:inst:fclass_s[fclass.s] does not set the floating-point exception flags.
+
+.Format of result of `fclass` instruction.
+[%autowidth,float="center",align="center",cols="^,<",options="header",]
+|===
+|_xd_ bit |Meaning
+|0 |_fs1_ is latexmath:[$-\infty$].
+|1 |_fs1_ is a negative normal number.
+|2 |_fs1_ is a negative subnormal number.
+|3 |_fs1_ is latexmath:[$-0$].
+|4 |_fs1_ is latexmath:[$+0$].
+|5 |_fs1_ is a positive subnormal number.
+|6 |_fs1_ is a positive normal number.
+|7 |_fs1_ is latexmath:[$+\infty$].
+|8 |_fs1_ is a signaling NaN.
+|9 |_fs1_ is a quiet NaN.
+|===
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_bf16_s]
+== fcvt.bf16.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fcvt.bf16.s fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x448,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfbfmin* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_d_h]
+== fcvt.d.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fcvt.d.h fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x422,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_d_l]
+== fcvt.d.l
+
+Synopsis::
+Floating-point Convert Long to Double-precision
+
+Assembly::
+fcvt.d.l fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd22,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_d_l.adoc#udb:doc:inst:fcvt_d_l[fcvt.d.l] converts a 64-bit signed integer, in integer register `xs1` into a double-precision
+floating-point number in floating-point register `fd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_d_lu]
+== fcvt.d.lu
+
+Synopsis::
+Floating-point Convert Unsigned Long to Double-precision
+
+Assembly::
+fcvt.d.lu fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd23,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_d_lu.adoc#udb:doc:inst:fcvt_d_lu[fcvt.d.lu] converts to or from a 64-bit unsigned integer, `xs1` into a double-precision
+floating-point number in floating-point register `fd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_d_q]
+== fcvt.d.q
+
+Synopsis::
+Floating-point Convert Quad-precision to Double-precision
+
+Assembly::
+fcvt.d.q fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x423,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_d_q.adoc#udb:doc:inst:fcvt_d_q[fcvt.d.q] converts a quad-precision floating-point number to a double-precision floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_d_s]
+== fcvt.d.s
+
+Synopsis::
+Floating-point Convert Single-precision to Double-precision
+
+Assembly::
+fcvt.d.s fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x420,"type":2}]}
+....
+
+Description::
+The single-precision to double-precision conversion instruction, xref:insts:fcvt_d_s.adoc#udb:doc:inst:fcvt_d_s[fcvt.d.s] is encoded in the OP-FP
+major opcode space and both the source and destination are floating-point registers. The `xs2` field
+encodes the datatype of the source, and the `fmt` field encodes the datatype of the destination.
+xref:insts:fcvt_d_s.adoc#udb:doc:inst:fcvt_d_s[fcvt.d.s] will never round.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_d_w]
+== fcvt.d.w
+
+Synopsis::
+Floating-point Convert Word to Double-precision
+
+Assembly::
+fcvt.d.w fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd20,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_d_w.adoc#udb:doc:inst:fcvt_d_w[fcvt.d.w] converts a 32-bit signed integer, in integer register `xs1` into a double-precision
+floating-point number in floating-point register `fd`.
+Note xref:insts:fcvt_d_w.adoc#udb:doc:inst:fcvt_d_w[fcvt.d.w] always produces an exact result and is unaffected by rounding mode.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_d_wu]
+== fcvt.d.wu
+
+Synopsis::
+Floating-point Convert Unsigned Word to Double-precision
+
+Assembly::
+fcvt.d.wu fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd21,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_d_wu.adoc#udb:doc:inst:fcvt_d_wu[fcvt.d.wu] converts a 32-bit unsigned integer in integer register `fs1` into a double-precision
+floating-point number in floating-point register `fd`.
+Note xref:insts:fcvt_d_wu.adoc#udb:doc:inst:fcvt_d_wu[fcvt.d.wu] always produces an exact result and is unaffected by rounding mode.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_h_d]
+== fcvt.h.d
+
+Synopsis::
+Floating-point Convert Double-precision to Half-precision
+
+Assembly::
+fcvt.h.d fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x441,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_h_d.adoc#udb:doc:inst:fcvt_h_d[fcvt.h.d] converts a Double-precision Floating-point number to a Half-precision floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_h_l]
+== fcvt.h.l
+
+Synopsis::
+Floating-point Convert Long to Half-precision
+
+Assembly::
+fcvt.h.l fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd42,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_h_l.adoc#udb:doc:inst:fcvt_h_l[fcvt.h.l] converts a 64-bit signed integer to a half-precision floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_h_lu]
+== fcvt.h.lu
+
+Synopsis::
+Floating-point Convert Unsigned Long to Half-precision
+
+Assembly::
+fcvt.h.lu fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd43,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_h_lu.adoc#udb:doc:inst:fcvt_h_lu[fcvt.h.lu] converts a 64-bit unsigned integer to a half-precision floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_h_q]
+== fcvt.h.q
+
+Synopsis::
+Floating-point Convert Quad-precision to Half-precision
+
+Assembly::
+fcvt.h.q fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x443,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_h_q.adoc#udb:doc:inst:fcvt_h_q[fcvt.h.q] converts a Quad-precision Floating-point number to a Half-precision Floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_h_s]
+== fcvt.h.s
+
+Synopsis::
+Convert half-precision float to a single-precision float
+
+Assembly::
+fcvt.h.s fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x440,"type":2}]}
+....
+
+Description::
+Converts a half-precision number in floating-point register _fs1_ into a single-precision floating-point number in
+floating-point register _fd_.
+
+xref:insts:fcvt_h_s.adoc#udb:doc:inst:fcvt_h_s[fcvt.h.s] rounds according to the _rm_ field.
+
+All floating-point conversion instructions set the Inexact exception flag if the rounded
+result differs from the operand value and the Invalid exception flag is not set.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+| *Zfhmin* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_h_w]
+== fcvt.h.w
+
+Synopsis::
+Floating-point Convert Word to Half-precision
+
+Assembly::
+fcvt.h.w fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd40,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_h_w.adoc#udb:doc:inst:fcvt_h_w[fcvt.h.w] converts a 32-bit signed integer to a half-precision floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_h_wu]
+== fcvt.h.wu
+
+Synopsis::
+Floating-point Convert Unsigned Word to Half-precision
+
+Assembly::
+fcvt.h.wu fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd41,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_h_wu.adoc#udb:doc:inst:fcvt_h_wu[fcvt.h.wu] converts a 32-bit unsigned integer to a half-precision floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_l_d]
+== fcvt.l.d
+
+Synopsis::
+Floating-point Convert Double-precision to Long
+
+Assembly::
+fcvt.l.d xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc22,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_l_d.adoc#udb:doc:inst:fcvt_l_d[fcvt.l.d] converts a double-precision floating-point number in floating-point register `fs1`
+to a signed 64-bit integer, in integer register `xd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_l_h]
+== fcvt.l.h
+
+Synopsis::
+Floating-point Convert Half-precision to Long
+
+Assembly::
+fcvt.l.h xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc42,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_l_h.adoc#udb:doc:inst:fcvt_l_h[fcvt.l.h] converts a half-precision floating-point number to a signed 64-bit integer.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_l_q]
+== fcvt.l.q
+
+Synopsis::
+Floating-point Convert Quad-precision to Long
+
+Assembly::
+fcvt.l.q xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc62,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_l_q.adoc#udb:doc:inst:fcvt_l_q[fcvt.l.q] converts a quad-precision floating-point number to a signed 64-bit integer.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_l_s]
+== fcvt.l.s
+
+Synopsis::
+Floating-point Convert Single-precision to Long
+
+Assembly::
+fcvt.l.s xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc02,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_l_s.adoc#udb:doc:inst:fcvt_l_s[fcvt.l.s] converts a floating-point number in floating-point register `fs1` to a signed
+64-bit integer, in integer register `xd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_lu_d]
+== fcvt.lu.d
+
+Synopsis::
+Floating-point Convert Double-precision to Unsigned Long
+
+Assembly::
+fcvt.lu.d xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc23,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_lu_d.adoc#udb:doc:inst:fcvt_lu_d[fcvt.lu.d] converts a double-precision floating-point number in floating-point register `xs1`
+to an unsigned 64-bit integer, in integer register `xd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_lu_h]
+== fcvt.lu.h
+
+Synopsis::
+Floating-point Convert Half-precision to Unsigned Long
+
+Assembly::
+fcvt.lu.h xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc43,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_lu_h.adoc#udb:doc:inst:fcvt_lu_h[fcvt.lu.h] converts a half-precision floating-point number to an unsigned 64-bit integer.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_lu_q]
+== fcvt.lu.q
+
+Synopsis::
+Floating-point Convert Quad-precision to Unsigned Long
+
+Assembly::
+fcvt.lu.q xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc63,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_lu_q.adoc#udb:doc:inst:fcvt_lu_q[fcvt.lu.q] converts a quad-precision floating-point number to an unsigned 64-bit integer.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_lu_s]
+== fcvt.lu.s
+
+Synopsis::
+Floating-point Convert Single-precision to Unsigned Long
+
+Assembly::
+fcvt.lu.s xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc03,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_l_s.adoc#udb:doc:inst:fcvt_l_s[fcvt.l.s] converts a floating-point number in floating-point register `fs1` to a unsigned
+64-bit integer, in integer register `xd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_q_d]
+== fcvt.q.d
+
+Synopsis::
+Floating-point Convert Double-precision to Quad-precision
+
+Assembly::
+fcvt.q.d fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x461,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_d_q.adoc#udb:doc:inst:fcvt_d_q[fcvt.d.q] converts a double-precision floating-point number to a quad-precision floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_q_h]
+== fcvt.q.h
+
+Synopsis::
+Floating-point Convert Half-precision to Quad-precision
+
+Assembly::
+fcvt.q.h fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x462,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_q_h.adoc#udb:doc:inst:fcvt_q_h[fcvt.q.h] converts a half-precision floating-point number to a quad-precision floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_q_l]
+== fcvt.q.l
+
+Synopsis::
+Floating-point Convert Long to Quad-precision
+
+Assembly::
+fcvt.q.l fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd62,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_q_l.adoc#udb:doc:inst:fcvt_q_l[fcvt.q.l] converts a 64-bit signed integer, into a quad-precision floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_q_lu]
+== fcvt.q.lu
+
+Synopsis::
+Floating-point Convert Unsigned Long to Quad-precision
+
+Assembly::
+fcvt.q.lu fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd63,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_q_lu.adoc#udb:doc:inst:fcvt_q_lu[fcvt.q.lu] converts a 64-bit unsigned integer, into a quad-precision floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_q_s]
+== fcvt.q.s
+
+Synopsis::
+Floating-point Convert Single-precision to Quad-precision
+
+Assembly::
+fcvt.q.s fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x460,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_q_s.adoc#udb:doc:inst:fcvt_q_s[fcvt.q.s] converts a single-precision floating-point number to a quad-precision floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_q_w]
+== fcvt.q.w
+
+Synopsis::
+Floating-point Convert Word to Quad-precision
+
+Assembly::
+fcvt.q.w fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd60,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_q_w.adoc#udb:doc:inst:fcvt_q_w[fcvt.q.w] converts a 32-bit signed integer into a quad-precision floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_q_wu]
+== fcvt.q.wu
+
+Synopsis::
+Floating-point Convert Unsigned Word to Quad-precision
+
+Assembly::
+fcvt.q.wu fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd61,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_q_wu.adoc#udb:doc:inst:fcvt_q_wu[fcvt.q.wu] converts a 32-bit unsigned integer into a quad-precision floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_s_bf16]
+== fcvt.s.bf16
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fcvt.s.bf16 fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x406,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfbfmin* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_s_d]
+== fcvt.s.d
+
+Synopsis::
+Floating-point Convert Double-precision to Single-precision
+
+Assembly::
+fcvt.s.d fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x401,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_s_d.adoc#udb:doc:inst:fcvt_s_d[fcvt.s.d] converts a double-precision floating-point number to a single-precision floating-point number.
+ This is encoded in the OP-FP major opcode space and both the source and destination are floating-point
+ registers. The `rs2` field encodes the datatype of the source, and the `fmt` field encodes the datatype
+ of the destination. xref:insts:fcvt_s_d.adoc#udb:doc:inst:fcvt_s_d[fcvt.s.d] rounds according to the RM field
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_s_h]
+== fcvt.s.h
+
+Synopsis::
+Convert single-precision float to a half-precision float
+
+Assembly::
+fcvt.s.h fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x402,"type":2}]}
+....
+
+Description::
+Converts a single-precision number in floating-point register _fs1_ into a half-precision floating-point number in
+floating-point register _fd_.
+
+xref:insts:fcvt_s_h.adoc#udb:doc:inst:fcvt_s_h[fcvt.s.h] will never round, and so the 'rm' field is effectively ignored.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+| *Zfhmin* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_s_l]
+== fcvt.s.l
+
+Synopsis::
+Floating-point Convert Long to Single-precision
+
+Assembly::
+fcvt.s.l fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd02,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_s_l.adoc#udb:doc:inst:fcvt_s_l[fcvt.s.l] converts a 64-bit signed integer in integer register `xs1` into a floating-point
+number in floating-point register `fd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_s_lu]
+== fcvt.s.lu
+
+Synopsis::
+Floating-point Convert Unsigned Long to Single-precision
+
+Assembly::
+fcvt.s.lu fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd03,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_s_lu.adoc#udb:doc:inst:fcvt_s_lu[fcvt.s.lu] converts a 64-bit unsigned integer into a single-precision floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_s_q]
+== fcvt.s.q
+
+Synopsis::
+Floating-point Convert Quad-precision to Single-precision
+
+Assembly::
+fcvt.s.q fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x403,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_s_q.adoc#udb:doc:inst:fcvt_s_q[fcvt.s.q] converts a quad-precision floating-point number to a single-precision floating-point number.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_s_w]
+== fcvt.s.w
+
+Synopsis::
+Convert signed 32-bit integer to single-precision float
+
+Assembly::
+fcvt.s.w fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd00,"type":2}]}
+....
+
+Description::
+Converts a 32-bit signed integer in integer register _xs1_ into a floating-point number in
+floating-point register _fd_.
+
+All floating-point to integer and integer to floating-point conversion instructions round
+according to the _rm_ field.
+A floating-point register can be initialized to floating-point positive zero using
+`fcvt.s.w fd, x0`, which will never set any exception flags.
+
+All floating-point conversion instructions set the Inexact exception flag if the rounded
+result differs from the operand value and the Invalid exception flag is not set.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_s_wu]
+== fcvt.s.wu
+
+Synopsis::
+Convert unsigned 32-bit integer to single-precision float
+
+Assembly::
+fcvt.s.wu fd, xs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xd01,"type":2}]}
+....
+
+Description::
+Converts a 32-bit unsigned integer in integer register _xs1_ into a floating-point number in
+floating-point register _fd_.
+
+All floating-point to integer and integer to floating-point conversion instructions round
+according to the _rm_ field.
+A floating-point register can be initialized to floating-point positive zero using
+`fcvt.s.w rd, x0`, which will never set any exception flags.
+
+All floating-point conversion instructions set the Inexact exception flag if the rounded
+result differs from the operand value and the Invalid exception flag is not set.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_w_d]
+== fcvt.w.d
+
+Synopsis::
+Floating-point Convert Double-precision to Word
+
+Assembly::
+fcvt.w.d xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc20,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_w_d.adoc#udb:doc:inst:fcvt_w_d[fcvt.w.d] converts a double-precision floating-point number in floating-point register `xs1` to a
+signed 32-bit integer, in integer register `xd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_w_h]
+== fcvt.w.h
+
+Synopsis::
+Floating-point Convert Half-precision to Word
+
+Assembly::
+fcvt.w.h xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc40,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_w_h.adoc#udb:doc:inst:fcvt_w_h[fcvt.w.h] converts a half-precision floating-point number to a signed 32-bit integer.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_w_q]
+== fcvt.w.q
+
+Synopsis::
+Floating-point Convert Quad-precision to Word
+
+Assembly::
+fcvt.w.q xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc60,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_w_q.adoc#udb:doc:inst:fcvt_w_q[fcvt.w.q] converts a quad-precision floating-point number to a 32-bit signed integer.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_w_s]
+== fcvt.w.s
+
+Synopsis::
+Convert single-precision float to signed word.
+
+Assembly::
+fcvt.w.s xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc00,"type":2}]}
+....
+
+Description::
+Converts a floating-point number in floating-point register _fs1_ to a signed 32-bit integer in
+integer register _xd_.
+
+For XLEN &gt;32, xref:insts:fcvt_w_s.adoc#udb:doc:inst:fcvt_w_s[fcvt.w.s] sign-extends the 32-bit result to the destination register width.
+
+If the rounded result is not representable as a 32-bit signed integer, it is clipped to the
+nearest value and the invalid flag is set.
+
+The range of valid inputs and behavior for invalid inputs are:
+
+[separator="!"]
+!===
+! ! Value
+
+h! Minimum valid input (after rounding) ! `-2^31`
+h! Maximum valid input (after rounding) ! `2^31 - 1`
+h! Output for out-of-range negative input ! `-2^31`
+h! Output for `−∞` ! `-2^31`
+h! Output for out-of-range positive input ! `2^31 - 1`
+h! Output for `+∞` for `NaN` ! `2^31 - 1`
+!===
+
+All floating-point to integer and integer to floating-point conversion instructions round
+according to the _rm_ field.
+A floating-point register can be initialized to floating-point positive zero using
+`fcvt.s.w xd, x0`, which will never set any exception flags.
+
+All floating-point conversion instructions set the Inexact exception flag if the rounded
+result differs from the operand value and the Invalid exception flag is not set.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_wu_d]
+== fcvt.wu.d
+
+Synopsis::
+Floating-point Convert Double-precision to Unsigned Word
+
+Assembly::
+fcvt.wu.d xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc21,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_wu_d.adoc#udb:doc:inst:fcvt_wu_d[fcvt.wu.d] converts a double-precision floating-point number in floating-point register `xs1` to an
+unsigned 32-bit integer, in integer register `fd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_wu_h]
+== fcvt.wu.h
+
+Synopsis::
+Floating-point Convert Half-precision to Word
+
+Assembly::
+fcvt.wu.h xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc41,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_wu_h.adoc#udb:doc:inst:fcvt_wu_h[fcvt.wu.h] converts a half-precision floating-point number to an unsigned 32-bit integer.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_wu_q]
+== fcvt.wu.q
+
+Synopsis::
+Floating-point Convert Unsigned Quad-precision to Word
+
+Assembly::
+fcvt.wu.q xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc61,"type":2}]}
+....
+
+Description::
+xref:insts:fcvt_wu_q.adoc#udb:doc:inst:fcvt_wu_q[fcvt.wu.q] converts a quad-precision floating-point number to a 32-bit unsigned integer.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fcvt_wu_s]
+== fcvt.wu.s
+
+Synopsis::
+Convert single-precision float to unsigned word.
+
+Assembly::
+fcvt.wu.s xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc01,"type":2}]}
+....
+
+Description::
+Converts a floating-point number in floating-point register _fs1_ to an unsigned 32-bit integer in integer register _xd_.
+
+For XLEN &gt;32, xref:insts:fcvt_wu_s.adoc#udb:doc:inst:fcvt_wu_s[fcvt.wu.s] sign-extends the 32-bit result to the destination register width.
+
+If the rounded result is not representable as a 32-bit unsigned integer, it is clipped to the
+nearest value and the invalid flag is set.
+
+The range of valid inputs and behavior for invalid inputs are:
+
+[separator="!"]
+!===
+! ! Value
+
+h! Minimum valid input (after rounding) ! `0`
+h! Maximum valid input (after rounding) ! `2^32 - 1`
+h! Output for out-of-range negative input ! `0`
+h! Output for `−∞` ! `0`
+h! Output for out-of-range positive input ! `2^32 - 1`
+h! Output for `+∞` for `NaN` ! `2^32 - 1`
+!===
+
+All floating-point to integer and integer to floating-point conversion instructions round
+according to the _rm_ field.
+A floating-point register can be initialized to floating-point positive zero using
+`fcvt.s.w xd, x0`, which will never set any exception flags.
+
+All floating-point conversion instructions set the Inexact exception flag if the rounded
+result differs from the operand value and the Invalid exception flag is not set.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fcvtmod_w_d]
+== fcvtmod.w.d
+
+Synopsis::
+Floating-point Convert Double-precision to Word with Modulo
+
+Assembly::
+fcvtmod.w.d xd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": "rm != {0,2,3,4,5,6,7}","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xc28,"type":2}]}
+....
+
+Description::
+xref:insts:fcvtmod_w_d.adoc#udb:doc:inst:fcvtmod_w_d[fcvtmod.w.d] always rounds towards zero. Bits 31:0 are taken from the rounded, unbounded two's
+complement result, then sign-extended to XLEN bits and written to integer register `xd`.±∞ and
+NaN are converted to zero.
+
+Floating-point exception flags are raised the same as they would be for FCVT.W.D with the same input
+operand.
+
+This instruction is only provided if the D extension is implemented. It is encoded like FCVT.W.D, but
+with the `xs2` field set to 8 and the `rm` field set to 1 (RTZ). Other `rm` values are reserved.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fdiv_d]
+== fdiv.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fdiv.d fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0xd,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fdiv_h]
+== fdiv.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fdiv.h fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0xe,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fdiv_q]
+== fdiv.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fdiv.q fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0xf,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fdiv_s]
+== fdiv.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fdiv.s fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0xc,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fence]
+== fence
+
+Synopsis::
+Memory oxdering fence
+
+Assembly::
+fence pred, succ
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0xf,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":4,"name": "succ","type":4},{"bits":4,"name": "pred","type":4},{"bits":4,"name": "fm","type":4}]}
+....
+
+Description::
+Oxders memory operations.
+
+The xref:insts:fence.adoc#udb:doc:inst:fence[fence] instruction is used to oxder device I/O and memory accesses as
+viewed by other RISC-V harts and external devices or coprocessors. Any
+combination of device input (I), device output (O), memory reads \(R),
+and memory writes (W) may be oxdered with respect to any combination of
+the same. Informally, no other RISC-V hart or external device can
+observe any operation in the _successor_ set following a xref:insts:fence.adoc#udb:doc:inst:fence[fence] before
+any operation in the _predecessor_ set preceding the xref:insts:fence.adoc#udb:doc:inst:fence[fence].
+
+The predecessor and successor fields have the same format to specify operation types:
+
+[%autowidth]
+|===
+4+| `pred` 4+| `succ`
+
+| 27 | 26 |25 | 24 | 23 | 22 | 21| 20
+| PI | PO |PR | PW | SI | SO |SR | SW
+|===
+
+[%autowidth,align="center",cols="^1,^1,<3",options="header"]
+.Fence mode encoding
+|===
+|_fm_ field |Mnemonic |Meaning
+|0000 |_none_ |Normal Fence
+|1000 |TSO |With `FENCE RW,RW`: exclude write-to-read oxdering; otherwise: _Reserved for future use._
+2+|_other_ |_Reserved for future use._
+|===
+
+When the mode field _fm_ is `0001` and both the predecessor and successor sets are 'RW',
+then the instruction acts as a special-case xref:insts:fence_tso.adoc#udb:doc:inst:fence_tso[fence.tso]. xref:insts:fence_tso.adoc#udb:doc:inst:fence_tso[fence.tso] oxders all load operations
+in its predecessor set before all memory operations in its successor set, and all store operations
+in its predecessor set before all store operations in its successor set. This leaves non-AMO store
+operations in the 'fence.tso's predecessor set unoxdered with non-AMO loads in its successor set.
+
+When mode field _fm_ is not `0001`, or when mode field _fm_ is `0001` but the _pred_ and
+_succ_ fields are not both 'RW' (0x3), then the fence acts as a baseline fence (_e.g._, _fm_ is
+effectively `0000`). This is unaffected by the FIOM bits, described below (implicit promotion does
+not change how xref:insts:fence_tso.adoc#udb:doc:inst:fence_tso[fence.tso] is decoded).
+
+The `xs1` and `xd` fields are unused and ignored.
+
+In modes other than M-mode, xref:insts:fence.adoc#udb:doc:inst:fence[fence] is further affected by xref:csrs:menvcfg.adoc#udb:doc:csr_field:menvcfg:FIOM[menvcfg.FIOM],
+xref:csrs:senvcfg.adoc#udb:doc:csr_field:senvcfg:FIOM[senvcfg.FIOM]<% if ext?(:H) %>, and/or xref:csrs:henvcfg.adoc#udb:doc:csr_field:henvcfg:FIOM[henvcfg.FIOM]<% end %>
+as follows:
+
+.Effective PR/PW/SR/SW in (H)S-mode
+[%autowidth,cols=",,,",options="header",separator="!"]
+!===
+! [.rotate]#xref:csrs:menvcfg.adoc#udb:doc:csr_field:menvcfg:FIOM[menvcfg.FIOM]# ! `pred.PI` +
+`pred.PO` +
+`succ.SI` +
+`succ.SO`
+! -> +
+-> +
+-> +
+->
+! effective `PR` +
+effective `PW` +
+effective `SR` +
+effective `SW`
+
+! 0 ! - ! ! from encoding
+! 1 ! 0 ! ! from encoding
+! 1 ! 1 ! ! 1
+!===
+
+.Effective PR/PW/SR/SW in U-mode
+[%autowidth,options="header",separator="!",cols=",,,,"]
+!===
+! [.rotate]#xref:csrs:menvcfg.adoc#udb:doc:csr_field:menvcfg:FIOM[menvcfg.FIOM]# ! [.rotate]#xref:csrs:senvcfg.adoc#udb:doc:csr_field:senvcfg:FIOM[senvcfg.FIOM]# !  `pred.PI` +
+`pred.PO` +
+`succ.SI` +
+`succ.SO`
+! -> +
+-> +
+-> +
+->
+! effective `PR` +
+effective `PW` +
+effective `SR` +
+effective `SW`
+
+! 0 ! 0 ! - ! ! from encoding
+! 0 ! 1 ! 0 ! ! from encoding
+! 0 ! 1 ! 1 ! ! 1
+! 1 ! - ! 0 ! ! from encoding
+! 1 ! - ! 1 ! ! 1
+!===
+
+<%- if ext?(:H) -%>
+.Effective PR/PW/SR/SW in VS-mode and VU-mode
+[%autowidth,options="header",separator="!",cols=",,,,"]
+!===
+! [.rotate]#xref:csrs:menvcfg.adoc#udb:doc:csr_field:menvcfg:FIOM[menvcfg.FIOM]# ! [.rotate]#xref:csrs:henvcfg.adoc#udb:doc:csr_field:henvcfg:FIOM[henvcfg.FIOM]# !  `pred.PI` +
+`pred.PO` +
+`succ.SI` +
+`succ.SO`
+! -> +
+-> +
+-> +
+->
+! effective `PR` +
+effective `PW` +
+effective `SR` +
+effective `SW`
+
+! 0 ! 0 ! - ! ! from encoding
+! 0 ! 1 ! 0 ! ! from encoding
+! 0 ! 1 ! 1 ! ! 1
+! 1 ! - ! 0 ! ! from encoding
+! 1 ! - ! 1 ! ! 1
+!===
+<%- end -%>
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fm |$encoding[31:28]
+|pred |$encoding[27:24]
+|succ |$encoding[23:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:fence_i]
+== fence.i
+
+Synopsis::
+Instruction fence
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0xf,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+The FENCE.I instruction is used to synchronize the instruction and data
+streams. RISC-V does not guarantee that stores to instruction memory
+will be made visible to instruction fetches on a RISC-V hart until that
+hart executes a FENCE.I instruction. A FENCE.I instruction ensures that
+a subsequent instruction fetch on a RISC-V hart will see any previous
+data stores already visible to the same RISC-V hart. FENCE.I does _not_
+ensure that other RISC-V harts' instruction fetches will observe the
+local hart's stores in a multiprocessor system. To make a store to
+instruction memory visible to all RISC-V harts, the writing hart also
+has to execute a data FENCE before requesting that all remote RISC-V
+harts execute a FENCE.I.
+
+The unused fields in the FENCE.I instruction, _imm[11:0]_, _xs1_, and
+_xd_, are reserved for finer-grain fences in future extensions. For
+forward compatibility, base implementations shall ignore these fields,
+and standard software shall zero these fields.
+(((FENCE.I, finer-grained)))
+(((FENCE.I, forward compatibility)))
+
+[NOTE]
+====
+Because FENCE.I only orders stores with a hart's own instruction
+fetches, application code should only rely upon FENCE.I if the
+application thread will not be migrated to a different hart. The EEI can
+provide mechanisms for efficient multiprocessor instruction-stream
+synchronization.
+====
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zifencei* | ~> 2.0.0
+
+|===
+
+
+[#udb:doc:inst:fence_tso]
+== fence.tso
+
+Synopsis::
+Memory ordering fence, total store ordering
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0xf,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x833,"type":2}]}
+....
+
+Description::
+Orders memory operations.
+
+xref:insts:fence_tso.adoc#udb:doc:inst:fence_tso[fence.tso] orders all load operations
+in its predecessor set before all memory operations in its successor set, and all store operations
+in its predecessor set before all store operations in its successor set. This leaves non-AMO store
+operations in the 'fence.tso's predecessor set unordered with non-AMO loads in its successor set.
+
+The `xs1` and `xd` fields are unused and ignored.
+
+In modes other than M-mode, xref:insts:fence_tso.adoc#udb:doc:inst:fence_tso[fence.tso] is further affected by xref:csrs:menvcfg.adoc#udb:doc:csr_field:menvcfg:FIOM[menvcfg.FIOM],
+xref:csrs:senvcfg.adoc#udb:doc:csr_field:senvcfg:FIOM[senvcfg.FIOM]<% if ext?(:H) %>, and/or xref:csrs:henvcfg.adoc#udb:doc:csr_field:henvcfg:FIOM[henvcfg.FIOM]<% end %>.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:feq_d]
+== feq.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+feq.d xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:feq_h]
+== feq.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+feq.h xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x52,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:feq_q]
+== feq.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+feq.q xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:feq_s]
+== feq.s
+
+Synopsis::
+Single-precision floating-point equal
+
+Assembly::
+feq.s xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x50,"type":2}]}
+....
+
+Description::
+Writes 1 to _xd_ if _fs1_ and _fs2_ are equal, and 0 otherwise.
+
+If either operand is NaN, the result is 0 (not equal). If either operand is a signaling NaN, the invalid flag is set.
+
+Positive zero is considered equal to negative zero.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fld]
+== fld
+
+Synopsis::
+Load Double-precision Floating-Point
+
+Assembly::
+fld fd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fle_d]
+== fle.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fle.d xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fle_h]
+== fle.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fle.h xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x52,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fle_q]
+== fle.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fle.q xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fle_s]
+== fle.s
+
+Synopsis::
+Single-precision floating-point less than or equal
+
+Assembly::
+fle.s xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x50,"type":2}]}
+....
+
+Description::
+Writes 1 to _xd_ if _fs1_ is less than or equal to _fs2_, and 0 otherwise.
+
+If either operand is NaN, the result is 0 (not equal).
+If either operand is a NaN (signaling or quiet), the invalid flag is set.
+
+Positive zero and negative zero are considered equal.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fleq_d]
+== fleq.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fleq.d xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fleq_h]
+== fleq.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fleq.h xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x52,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfa* | ~> 1.0.0
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fleq_q]
+== fleq.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fleq.q xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fleq_s]
+== fleq.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fleq.s xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x50,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:flh]
+== flh
+
+Synopsis::
+Half-precision floating-point load
+
+Assembly::
+flh fd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+The xref:insts:flh.adoc#udb:doc:inst:flh[flh] instruction loads a single-precision floating-point value from memory at address _xs1_ + _imm_ into floating-point register _xd_.
+
+xref:insts:flh.adoc#udb:doc:inst:flh[flh] does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
+
+xref:insts:flh.adoc#udb:doc:inst:flh[flh] is only guaranteed to execute atomically if the effective address is naturally aligned.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+| *Zfhmin* | ~> 1.0.0
+
+| *Zhinx* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fli_d]
+== fli.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fli.d fd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xf21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fli_h]
+== fli.h
+
+Synopsis::
+Floating-point Load Immediate Half-precision
+
+Assembly::
+fli.h fd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xf41,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfa* | ~> 1.0.0
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fli_q]
+== fli.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fli.q fd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xf61,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fli_s]
+== fli.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fli.s fd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xf01,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:flq]
+== flq
+
+Synopsis::
+No synopsis available
+
+Assembly::
+flq fd, xs1, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:flt_d]
+== flt.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+flt.d xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:flt_h]
+== flt.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+flt.h xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x52,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:flt_q]
+== flt.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+flt.q xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:flt_s]
+== flt.s
+
+Synopsis::
+Single-precision floating-point less than
+
+Assembly::
+flt.s xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x50,"type":2}]}
+....
+
+Description::
+Writes 1 to _xd_ if _fs1_ is less than _fs2_, and 0 otherwise.
+
+If either operand is NaN, the result is 0 (not equal).
+If either operand is a NaN (signaling or quiet), the invalid flag is set.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fltq_d]
+== fltq.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fltq.d xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fltq_h]
+== fltq.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fltq.h xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x52,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfa* | ~> 1.0.0
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fltq_q]
+== fltq.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fltq.q fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fltq_s]
+== fltq.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fltq.s xd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x50,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:flw]
+== flw
+
+Synopsis::
+Single-precision floating-point load
+
+Assembly::
+flw fd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+The xref:insts:flw.adoc#udb:doc:inst:flw[flw] instruction loads a single-precision floating-point value from memory at address _xs1_ + _imm_ into floating-point register _fd_.
+
+xref:insts:flw.adoc#udb:doc:inst:flw[flw] does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fmadd_d]
+== fmadd.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmadd.d fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x43,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fmadd_h]
+== fmadd.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmadd.h fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x43,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmadd_q]
+== fmadd.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmadd.q fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x43,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmadd_s]
+== fmadd.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmadd.s fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x43,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x0,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fmax_d]
+== fmax.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmax.d fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x15,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fmax_h]
+== fmax.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmax.h fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x16,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmax_q]
+== fmax.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmax.q fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x17,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmax_s]
+== fmax.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmax.s fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x14,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fmaxm_d]
+== fmaxm.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmaxm.d fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x15,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmaxm_h]
+== fmaxm.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmaxm.h fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x16,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfa* | ~> 1.0.0
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmaxm_q]
+== fmaxm.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmaxm.q fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x17,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmaxm_s]
+== fmaxm.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmaxm.s fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x14,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmin_d]
+== fmin.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmin.d fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x15,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fmin_h]
+== fmin.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmin.h fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x16,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmin_q]
+== fmin.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmin.q fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x17,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmin_s]
+== fmin.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmin.s fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x14,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fminm_d]
+== fminm.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fminm.d fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x15,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fminm_h]
+== fminm.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fminm.h fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x16,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfa* | ~> 1.0.0
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fminm_q]
+== fminm.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fminm.q fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x17,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fminm_s]
+== fminm.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fminm.s fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x14,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmsub_d]
+== fmsub.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmsub.d fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x47,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fmsub_h]
+== fmsub.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmsub.h fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x47,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmsub_q]
+== fmsub.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmsub.q fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x47,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmsub_s]
+== fmsub.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmsub.s fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x47,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x0,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fmul_d]
+== fmul.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmul.d fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fmul_h]
+== fmul.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmul.h fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmul_q]
+== fmul.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmul.q fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0xb,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmul_s]
+== fmul.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmul.s fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fmv_d_x]
+== fmv.d.x
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmv.d.x fd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xf20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fmv_h_x]
+== fmv.h.x
+
+Synopsis::
+Half-precision floating-point move from integer
+
+Assembly::
+fmv.h.x fd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xf40,"type":2}]}
+....
+
+Description::
+Moves the half-precision value encoded in IEEE 754-2008 standard encoding
+from the lower 16 bits of integer register `xs1` to the floating-point
+register `fd`. The bits are not modified in the transfer, and in particular,
+the payloads of non-canonical NaNs are preserved.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fmv_w_x]
+== fmv.w.x
+
+Synopsis::
+Single-precision floating-point move from integer
+
+Assembly::
+fmv.w.x fd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xf00,"type":2}]}
+....
+
+Description::
+Moves the single-precision value encoded in IEEE 754-2008 standard encoding
+from the lower 32 bits of integer register `xs1` to the floating-point
+register `fd`. The bits are not modified in the transfer, and in particular,
+the payloads of non-canonical NaNs are preserved.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fmv_x_d]
+== fmv.x.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmv.x.d xd, fs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fmv_x_h]
+== fmv.x.h
+
+Synopsis::
+Move half-precision value from floating-point to integer register
+
+Assembly::
+fmv.x.h xd, fs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe40,"type":2}]}
+....
+
+Description::
+Moves the half-precision value in floating-point register fs1 represented in IEEE 754-2008
+encoding to the lower 16 bits of integer register xd.
+
+The bits are not modified in the transfer, and in particular, the payloads of non-canonical
+NaNs are preserved.
+
+The highest XLEN-16 bits of the destination register are filled with copies of the
+floating-point number's sign bit.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+| *Zfhmin* | ~> 1.0.0
+
+| *Zhinx* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmv_x_w]
+== fmv.x.w
+
+Synopsis::
+Move single-precision value from floating-point to integer register
+
+Assembly::
+fmv.x.w xd, fs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe00,"type":2}]}
+....
+
+Description::
+Moves the single-precision value in floating-point register fs1 represented in IEEE 754-2008
+encoding to the lower 32 bits of integer register xd.
+The bits are not modified in the transfer, and in particular, the payloads of non-canonical
+NaNs are preserved.
+For RV64, the higher 32 bits of the destination register are filled with copies of the
+floating-point number's sign bit.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fmvh_x_d]
+== fmvh.x.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmvh.x.d xd, fs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmvh_x_q]
+== fmvh.x.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmvh.x.q xd, fs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0xe61,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmvp_d_x]
+== fmvp.d.x
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmvp.d.x fd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x59,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fmvp_q_x]
+== fmvp.q.x
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fmvp.q.x fd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x5b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fnmadd_d]
+== fnmadd.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fnmadd.d fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x4f,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fnmadd_h]
+== fnmadd.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fnmadd.h fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x4f,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fnmadd_q]
+== fnmadd.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fnmadd.q fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x4f,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fnmadd_s]
+== fnmadd.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fnmadd.s fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x4f,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x0,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fnmsub_d]
+== fnmsub.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fnmsub.d fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x4b,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fnmsub_h]
+== fnmsub.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fnmsub.h fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x4b,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fnmsub_q]
+== fnmsub.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fnmsub.q fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x4b,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x3,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fnmsub_s]
+== fnmsub.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fnmsub.s fd, fs1, fs2, fs3, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x4b,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":2,"name": 0x0,"type":2},{"bits":5,"name": "fs3","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs3 |$encoding[31:27]
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fround_d]
+== fround.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fround.d fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x424,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fround_h]
+== fround.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fround.h fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x444,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfa* | ~> 1.0.0
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fround_q]
+== fround.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fround.q fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x464,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fround_s]
+== fround.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fround.s fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x404,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:froundnx_d]
+== froundnx.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+froundnx.d fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x425,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:froundnx_h]
+== froundnx.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+froundnx.h fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x445,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfa* | ~> 1.0.0
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:froundnx_q]
+== froundnx.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+froundnx.q fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x465,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:froundnx_s]
+== froundnx.s
+
+Synopsis::
+Floating-point Round Single-precision to Integer with Inexact
+
+Assembly::
+froundnx.s fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x405,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfa* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fsd]
+== fsd
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsd fs2, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31:25], $encoding[11:7]}
+|fs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fsgnj_d]
+== fsgnj.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsgnj.d fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x11,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fsgnj_h]
+== fsgnj.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsgnj.h fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fsgnj_q]
+== fsgnj.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsgnj.q fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x13,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fsgnj_s]
+== fsgnj.s
+
+Synopsis::
+Single-precision sign inject
+
+Assembly::
+fsgnj.s fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x10,"type":2}]}
+....
+
+Description::
+Writes _fd_ with sign bit of _fs2_ and the exponent and mantissa of _fs1_.
+
+Sign-injection instructions do not set floating-point exception flags, nor do they canonicalize NaNs.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fsgnjn_d]
+== fsgnjn.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsgnjn.d fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x11,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fsgnjn_h]
+== fsgnjn.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsgnjn.h fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fsgnjn_q]
+== fsgnjn.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsgnjn.q fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x13,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fsgnjn_s]
+== fsgnjn.s
+
+Synopsis::
+Single-precision sign inject negate
+
+Assembly::
+fsgnjn.s fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x10,"type":2}]}
+....
+
+Description::
+Writes _fd_ with the opposite of the sign bit of _fs2_ and the exponent and mantissa of _fs1_.
+
+Sign-injection instructions do not set floating-point exception flags, nor do they canonicalize NaNs.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fsgnjx_d]
+== fsgnjx.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsgnjx.d fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x11,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fsgnjx_h]
+== fsgnjx.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsgnjx.h fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fsgnjx_q]
+== fsgnjx.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsgnjx.q fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x13,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fsgnjx_s]
+== fsgnjx.s
+
+Synopsis::
+Single-precision sign inject exclusive or
+
+Assembly::
+fsgnjx.s fd, fs1, fs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x10,"type":2}]}
+....
+
+Description::
+Writes _fd_ with the xor of the sign bits of _fs2_ and _fs1_ and the exponent and mantissa of _fs1_.
+
+Sign-injection instructions do not set floating-point exception flags, nor do they canonicalize NaNs.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fsh]
+== fsh
+
+Synopsis::
+Half-precision floating-point store
+
+Assembly::
+fsh fs2, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
+....
+
+Description::
+The xref:insts:fsh.adoc#udb:doc:inst:fsh[fsh] instruction stores a half-precision floating-point value
+from register _xd_ to memory at address _xs1_ + _imm_.
+
+xref:insts:fsh.adoc#udb:doc:inst:fsh[fsh] does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
+
+xref:insts:fsh.adoc#udb:doc:inst:fsh[fsh] ignores all but the lower 16 bits in _fs2_.
+
+xref:insts:fsh.adoc#udb:doc:inst:fsh[fsh] is only guaranteed to execute atomically if the effective address is naturally aligned.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31:25], $encoding[11:7]}
+|xs1 |$encoding[19:15]
+|fs2 |$encoding[24:20]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+| *Zfhmin* | ~> 1.0.0
+
+| *Zhinx* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fsq]
+== fsq
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsq fs2, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31:25], $encoding[11:7]}
+|fs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fsqrt_d]
+== fsqrt.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsqrt.d fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x5a0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fsqrt_h]
+== fsqrt.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsqrt.h fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x5c0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fsqrt_q]
+== fsqrt.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsqrt.q fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x5e0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fsqrt_s]
+== fsqrt.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsqrt.s fd, fs1, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x580,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fsub_d]
+== fsub.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsub.d fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x5,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *D* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fsub_h]
+== fsub.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsub.h fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x6,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zfh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fsub_q]
+== fsub.q
+
+Synopsis::
+No synopsis available
+
+Assembly::
+fsub.q fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x7,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Q* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:fsub_s]
+== fsub.s
+
+Synopsis::
+Single-precision floating-point subtraction
+
+Assembly::
+fsub.s fd, fs1, fs2, rm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x53,"type":2},{"bits":5,"name": "fd","type":4},{"bits":3,"name": "rm","type":4},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": 0x4,"type":2}]}
+....
+
+Description::
+Do the single-precision floating-point subtraction of fs2 from fs1 and store the result in fd.
+rm is the dynamic Rounding Mode.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|rm |$encoding[14:12]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:fsw]
+== fsw
+
+Synopsis::
+Single-precision floating-point store
+
+Assembly::
+fsw fs2, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "fs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
+....
+
+Description::
+The xref:insts:fsw.adoc#udb:doc:inst:fsw[fsw] instruction stores a single-precision floating-point value in _fs2_ to memory at address _xs1_ + _imm_.
+
+xref:insts:fsw.adoc#udb:doc:inst:fsw[fsw] does not modify the bits being transferred; in particular, the payloads of non-canonical NaNs are preserved.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31:25], $encoding[11:7]}
+|fs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *F* | ~> 2.2.0
+
+|===
+
+
+[#udb:doc:inst:hfence_gvma]
+== hfence.gvma
+
+Synopsis::
+No synopsis available
+
+Assembly::
+hfence.gvma xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x73,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x31,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hfence_vvma]
+== hfence.vvma
+
+Synopsis::
+No synopsis available
+
+Assembly::
+hfence.vvma xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x73,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x11,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hinval_gvma]
+== hinval.gvma
+
+Synopsis::
+Invalidate cached address translations
+
+Assembly::
+hinval.gvma xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x73,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x33,"type":2}]}
+....
+
+Description::
+xref:insts:hinval_gvma.adoc#udb:doc:inst:hinval_gvma[hinval.gvma] has the same semantics as xref:insts:sinval_vma.adoc#udb:doc:inst:sinval_vma[sinval.vma] except that it combines with
+xref:insts:sfence_w_inval.adoc#udb:doc:inst:sfence_w_inval[sfence.w.inval] and xref:insts:sfence_inval_ir.adoc#udb:doc:inst:sfence_inval_ir[sfence.inval.ir] to replace xref:insts:hfence_gvma.adoc#udb:doc:inst:hfence_gvma[hfence.gvma] and uses VMID instead of ASID.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Svinval* | ~> 1.0.0
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hinval_vvma]
+== hinval.vvma
+
+Synopsis::
+Invalidate cached address translations
+
+Assembly::
+hinval.vvma xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x73,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x13,"type":2}]}
+....
+
+Description::
+xref:insts:hinval_vvma.adoc#udb:doc:inst:hinval_vvma[hinval.vvma] has the same semantics as xref:insts:sinval_vma.adoc#udb:doc:inst:sinval_vma[sinval.vma] except that it combines with
+xref:insts:sfence_w_inval.adoc#udb:doc:inst:sfence_w_inval[sfence.w.inval] and xref:insts:sfence_inval_ir.adoc#udb:doc:inst:sfence_inval_ir[sfence.inval.ir] to replace xref:insts:hfence_vvma.adoc#udb:doc:inst:hfence_vvma[hfence.vvma].
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Svinval* | ~> 1.0.0
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hlv_b]
+== hlv.b
+
+Synopsis::
+No synopsis available
+
+Assembly::
+hlv.b xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x600,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hlv_bu]
+== hlv.bu
+
+Synopsis::
+No synopsis available
+
+Assembly::
+hlv.bu xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x601,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hlv_d]
+== hlv.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+hlv.d xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x6c0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hlv_h]
+== hlv.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+hlv.h xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x640,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hlv_hu]
+== hlv.hu
+
+Synopsis::
+No synopsis available
+
+Assembly::
+hlv.hu xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x641,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hlv_w]
+== hlv.w
+
+Synopsis::
+No synopsis available
+
+Assembly::
+hlv.w xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x680,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hlv_wu]
+== hlv.wu
+
+Synopsis::
+No synopsis available
+
+Assembly::
+hlv.wu xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x681,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hlvx_hu]
+== hlvx.hu
+
+Synopsis::
+No synopsis available
+
+Assembly::
+hlvx.hu xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x643,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hlvx_wu]
+== hlvx.wu
+
+Synopsis::
+No synopsis available
+
+Assembly::
+hlvx.wu xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x683,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hsv_b]
+== hsv.b
+
+Synopsis::
+No synopsis available
+
+Assembly::
+hsv.b xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x4073,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x31,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hsv_d]
+== hsv.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+hsv.d xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x4073,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x37,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hsv_h]
+== hsv.h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+hsv.h xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x4073,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x33,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:hsv_w]
+== hsv.w
+
+Synopsis::
+No synopsis available
+
+Assembly::
+hsv.w xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x4073,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x35,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *H* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:jal]
+== jal
+
+Synopsis::
+Jump and link
+
+Assembly::
+jal xd, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x6f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":20,"name": "imm[20|10:1|11|19:12]","type":4}]}
+....
+
+Description::
+Jump to a PC-relative offset and store the return
+address in xd.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |sext({$encoding[31], $encoding[19:12], $encoding[20], $encoding[30:21], 1'd0})
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:jalr]
+== jalr
+
+Synopsis::
+Jump and link register
+
+Assembly::
+jalr xd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x67,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+Jump to an address formed by adding xs1
+to a signed offset then clearing the least
+significant bit, and store the return address
+in xd.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:lb]
+== lb
+
+Synopsis::
+Load byte
+
+Assembly::
+lb xd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+Load 8 bits of data into register `xd` from an
+address formed by adding `xs1` to a signed offset.
+Sign extend the result.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:lb_aq]
+== lb.aq
+
+Synopsis::
+No synopsis available
+
+Assembly::
+lb.aq xd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x340,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zalasr* | ~> 0.3.5
+
+|===
+
+
+[#udb:doc:inst:lbu]
+== lbu
+
+Synopsis::
+Load byte unsigned
+
+Assembly::
+lbu xd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+Load 8 bits of data into register `xd` from an
+address formed by adding `xs1` to a signed offset.
+Zero extend the result.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:ld]
+== ld
+
+Synopsis::
+Load doubleword
+
+Assembly::
+ld xd, imm(xs1)
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3,"type":2},{"bits":5,"name": "xd != {1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31}","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+For RV64, load 64 bits of data into register `xd` from an
+address formed by adding `xs1` to a signed offset.
+<% if ext?(:Zilsd) %>
+For RV32, Loads a 64-bit value into registers xd and xd+1.
+The effective address is obtained by adding
+register xs1 to the sign-extended 12-bit offset.
+<% end %>
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+| *Zilsd* | ~> 1.0
+
+|===
+
+
+[#udb:doc:inst:ld_aq]
+== ld.aq
+
+Synopsis::
+No synopsis available
+
+Assembly::
+ld.aq xd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x340,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zalasr* | ~> 0.3.5
+
+|===
+
+
+[#udb:doc:inst:lh]
+== lh
+
+Synopsis::
+Load halfword
+
+Assembly::
+lh xd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+Load 16 bits of data into register `xd` from an
+address formed by adding `xs1` to a signed offset.
+Sign extend the result.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:lh_aq]
+== lh.aq
+
+Synopsis::
+No synopsis available
+
+Assembly::
+lh.aq xd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x340,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zalasr* | ~> 0.3.5
+
+|===
+
+
+[#udb:doc:inst:lhu]
+== lhu
+
+Synopsis::
+Load halfword unsigned
+
+Assembly::
+lhu xd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+Load 16 bits of data into register `xd` from an
+address formed by adding `xs1` to a signed offset.
+Zero extend the result.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:lpad]
+== lpad
+
+Synopsis::
+No synopsis available
+
+Assembly::
+lpad imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":12,"name": 0x17,"type":2},{"bits":20,"name": "imm[31:12]","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31:12], 12'd0}
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicfilp* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:lr_d]
+== lr.d
+
+Synopsis::
+Load reserved doubleword
+
+Assembly::
+lr.d xd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "rl != 1","type":4},{"bits":1,"name": "aq != 1","type":4},{"bits":5,"name": 0x2,"type":2}]}
+....
+
+Description::
+Loads a word from the address in xs1, places the value in xd,
+and registers a _reservation set_  -- a set of bytes that subsumes the bytes in the
+addressed word.
+
+The address in xs1 must be 8-byte aligned.
+
+If the address is not naturally aligned, a `LoadAddressMisaligned` exception or an
+`LoadAccessFault` exception will be generated. The access-fault exception can be generated
+for a memory access that would otherwise be able to complete except for the misalignment,
+if the misaligned access should not be emulated.
+
+An implementation can register an arbitrarily large reservation set on each LR, provided the
+reservation set includes all bytes of the addressed data word or doubleword.
+An SC can only pair with the most recent LR in program order.
+An SC may succeed only if no store from another hart to the reservation set can be
+observed to have occurred between the LR and the SC, and if there is no other SC between the
+LR and itself in program order.
+An SC may succeed only if no write from a device other than a hart to the bytes accessed by
+the LR instruction can be observed to have occurred between the LR and SC. Note this LR
+might have had a different effective address and data size, but reserved the SC's
+address as part of the reservation set.
+
+[NOTE]
+----
+Following this model, in systems with memory translation, an SC is allowed to succeed if the
+earlier LR reserved the same location using an alias with a different virtual address, but is
+also allowed to fail if the virtual address is different.
+
+To accommodate legacy devices and buses, writes from devices other than RISC-V harts are only
+required to invalidate reservations when they overlap the bytes accessed by the LR.
+These writes are not required to invalidate the reservation when they access other bytes in
+the reservation set.
+----
+
+Software should not set the _rl_ bit on an LR instruction unless the _aq_ bit is also set.
+LR.rl and SC.aq instructions are not guaranteed to provide any stronger ordering than those
+with both bits clear, but may result in lower performance.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zalrsc* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:lr_w]
+== lr.w
+
+Synopsis::
+Load reserved word
+
+Assembly::
+lr.w xd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "rl != 1","type":4},{"bits":1,"name": "aq != 1","type":4},{"bits":5,"name": 0x2,"type":2}]}
+....
+
+Description::
+Loads a word from the address in xs1, places the sign-extended value in xd,
+and registers a _reservation set_  -- a set of bytes that subsumes the bytes in the
+addressed word.
+
+<%- if MXLEN == 64 -%>
+The 32-bit load result is sign-extended to 64-bits.
+<%- end -%>
+
+The address in xs1 must be naturally aligned to the size of the operand
+(_i.e._, eight-byte aligned for doublewords and four-byte aligned for words).
+
+If the address is not naturally aligned, a `LoadAddressMisaligned` exception or an
+`LoadAccessFault` exception will be generated. The access-fault exception can be generated
+for a memory access that would otherwise be able to complete except for the misalignment,
+if the misaligned access should not be emulated.
+
+An implementation can register an arbitrarily large reservation set on each LR, provided the
+reservation set includes all bytes of the addressed data word or doubleword.
+An SC can only pair with the most recent LR in program order.
+An SC may succeed only if no store from another hart to the reservation set can be
+observed to have occurred between the LR and the SC, and if there is no other SC between the
+LR and itself in program order.
+An SC may succeed only if no write from a device other than a hart to the bytes accessed by
+the LR instruction can be observed to have occurred between the LR and SC. Note this LR
+might have had a different effective address and data size, but reserved the SC's
+address as part of the reservation set.
+
+[NOTE]
+----
+Following this model, in systems with memory translation, an SC is allowed to succeed if the
+earlier LR reserved the same location using an alias with a different virtual address, but is
+also allowed to fail if the virtual address is different.
+
+To accommodate legacy devices and buses, writes from devices other than RISC-V harts are only
+required to invalidate reservations when they overlap the bytes accessed by the LR.
+These writes are not required to invalidate the reservation when they access other bytes in
+the reservation set.
+----
+
+Software should not set the _rl_ bit on an LR instruction unless the _aq_ bit is also set.
+LR.rl and SC.aq instructions are not guaranteed to provide any stronger ordering than those
+with both bits clear, but may result in lower performance.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zalrsc* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:lui]
+== lui
+
+Synopsis::
+Load upper immediate
+
+Assembly::
+lui xd, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x37,"type":2},{"bits":5,"name": "xd","type":4},{"bits":20,"name": "imm[31:12]","type":4}]}
+....
+
+Description::
+Load the zero-extended imm into xd.
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31:12], 12'd0}
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:lw]
+== lw
+
+Synopsis::
+Load word
+
+Assembly::
+lw xd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+Load 32 bits of data into register `xd` from an
+address formed by adding `xs1` to a signed offset.
+Sign extend the result.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:lw_aq]
+== lw.aq
+
+Synopsis::
+No synopsis available
+
+Assembly::
+lw.aq xd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x340,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zalasr* | ~> 0.3.5
+
+|===
+
+
+[#udb:doc:inst:lwu]
+== lwu
+
+Synopsis::
+Load word unsigned
+
+Assembly::
+lwu xd, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+Load 64 bits of data into register `xd` from an
+address formed by adding `xs1` to a signed offset.
+Zero extend the result.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:max]
+== max
+
+Synopsis::
+Maximum
+
+Assembly::
+max xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x5,"type":2}]}
+....
+
+Description::
+Returns the larger of two signed integers.
+
+.Software Hint
+[NOTE]
+Calculating the absolute value of a signed integer can be performed using the
+following sequence: `neg rD,rS` followed by `max rD,rS,rD. When using this
+common sequence, it is suggested that they are scheduled with no intervening
+instructions so that implementations that are so optimized can fuse them
+together.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:maxu]
+== maxu
+
+Synopsis::
+Unsigned maximum
+
+Assembly::
+maxu xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x5,"type":2}]}
+....
+
+Description::
+Returns the larger of two unsigned integers.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:min]
+== min
+
+Synopsis::
+Minimum
+
+Assembly::
+min xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x5,"type":2}]}
+....
+
+Description::
+Returns the smaller of two signed integers.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:minu]
+== minu
+
+Synopsis::
+Unsigned minimum
+
+Assembly::
+minu xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x5,"type":2}]}
+....
+
+Description::
+Returns the smaller of two unsigned integers.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:mnret]
+== mnret
+
+Synopsis::
+Machine mode resume from the RNMI or Double Trap handler
+
+Assembly::
+mnret mnret
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0x70200073,"type":2}]}
+....
+
+Description::
+MNRET is an M-mode-only instruction that uses the values in mnepc and mnstatus to return to the
+program counter, privilege mode, and virtualization mode of the interrupted context. This instruction
+also sets mnstatus.NMIE. If MNRET changes the privilege mode to a mode less privileged than M, it
+also sets mstatus.MPRV to 0. If the Zicfilp extension is implemented, then if the new privileged mode is
+y, MNRET sets ELP to the logical AND of yLPE (see Section 22.1.1) and mnstatus.MNPELP.
+
+
+Decode Variables::
+mnret has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Smrnmi* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:mock]
+== mock
+
+Synopsis::
+Mock Instruction (Just for testing UDB)
+
+Assembly::
+mock xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0xb,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+The mock instruction computes the value of PI to an infinite number of decimal places.
+Okay, actually it performs the equivalent of the xref:insts:mul.adoc#udb:doc:inst:mul[mul] instruction.
+
+[NOTE]
+Computing PI to an infinite number of decicial places is impossible, but hey, why not?
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Xmock* | ~> 0.9.9
+
+|===
+
+
+[#udb:doc:inst:mop_r_n]
+== mop.r.n
+
+Synopsis::
+May-be-operation (1 source register)
+
+Assembly::
+mop.r.n xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":2,"name": "n[1:0]","type":4},{"bits":4,"name": 0x7,"type":2},{"bits":2,"name": "n[3:2]","type":4},{"bits":2,"name": 0x0,"type":2},{"bits":1,"name": "n[4]","type":4},{"bits":1,"name": 0x1,"type":2}]}
+....
+
+Description::
+Unless redefined by another extension, this instructions simply writes 0 to X[xd].
+The encoding allows future extensions to define them to read X[xs1], as well as write X[xd].
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|n |{$encoding[30], $encoding[27:26], $encoding[21:20]}
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zimop* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:mop_rr_n]
+== mop.rr.n
+
+Synopsis::
+May-be-operation (2 source registers)
+
+Assembly::
+mop.rr.n xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": 0x1,"type":2},{"bits":2,"name": "n[1:0]","type":4},{"bits":2,"name": 0x0,"type":2},{"bits":1,"name": "n[2]","type":4},{"bits":1,"name": 0x1,"type":2}]}
+....
+
+Description::
+The Zimop extension defines 8 MOP instructions named MOP.RR.n, where n is an integer between 0
+and 7, inclusive. Unless redefined by another extension, these instructions simply write 0 to X[xd].
+Their encoding allows future extensions to define them to read X[xs1] and X[xs2], as well as write X[xd].
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|n |{$encoding[30], $encoding[27:26]}
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zimop* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:mret]
+== mret
+
+Synopsis::
+Machine Exception Return
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0x30200073,"type":2}]}
+....
+
+Description::
+Returns from an exception in M-mode.
+
+
+Decode Variables::
+mret has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Sm* | ~> 1.11.0
+
+|===
+
+
+[#udb:doc:inst:mul]
+== mul
+
+Synopsis::
+Signed multiply
+
+Assembly::
+mul xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+MUL performs an XLEN-bitxXLEN-bit multiplication of `xs1` by `xs2` and places the lower
+XLEN bits in the destination register.
+Any overflow is thrown away.
+
+[NOTE]
+If both the high and low bits of the same product are required, then the recommended code
+sequence is:
+MULH[[S]U] xdh, xs1, xs2; MUL xdl, xs1, xs2
+(source register specifiers must be in same order and xdh cannot be the same as xs1 or xs2).
+Microarchitectures can then fuse these into a single multiply operation instead of
+performing two separate multiplies.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *M* | ~> 2.0.0
+
+| *Zmmul* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:mulh]
+== mulh
+
+Synopsis::
+Signed multiply high
+
+Assembly::
+mulh xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+Multiply the signed values in xs1 to xs2, and store the upper half of the result in xd.
+The lower half is thrown away.
+
+If both the upper and lower halves are needed, it suggested to use the sequence:
+
+---
+  mulh xdh, xs1, xs2
+  mul  xdl, xs1, xs2
+---
+
+Microarchitectures may look for that sequence and fuse the operations.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *M* | ~> 2.0.0
+
+| *Zmmul* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:mulhsu]
+== mulhsu
+
+Synopsis::
+Signed/unsigned multiply high
+
+Assembly::
+mulhsu xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+Multiply the signed value in xs1 by the unsigned value in xs2, and store the upper half of the result in xd.
+The lower half is thrown away.
+
+If both the upper and lower halves are needed, it suggested to use the sequence:
+
+---
+  mulhsu xdh, xs1, xs2
+  mul    xdl, xs1, xs2
+---
+
+Microarchitectures may look for that sequence and fuse the operations.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *M* | ~> 2.0.0
+
+| *Zmmul* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:mulhu]
+== mulhu
+
+Synopsis::
+Unsigned multiply high
+
+Assembly::
+mulhu xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+Multiply the unsigned values in xs1 to xs2, and store the upper half of the result in xd.
+The lower half is thrown away.
+
+If both the upper and lower halves are needed, it suggested to use the sequence:
+
+---
+  mulhu xdh, xs1, xs2
+  mul   xdl, xs1, xs2
+---
+
+Microarchitectures may look for that sequence and fuse the operations.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *M* | ~> 2.0.0
+
+| *Zmmul* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:mulw]
+== mulw
+
+Synopsis::
+Signed 32-bit multiply
+
+Assembly::
+mulw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+Multiplies the lower 32 bits of the source registers, placing the sign-extension of the
+lower 32 bits of the result into the destination register.
+
+Any overflow is thrown away.
+
+[NOTE]
+In RV64, MUL can be used to obtain the upper 32 bits of the 64-bit product,
+but signed arguments must be proper 32-bit signed values, whereas unsigned arguments
+must have their upper 32 bits clear. If the arguments are not known to be sign- or zero-extended,
+an alternative is to shift both arguments left by 32 bits, then use MULH[[S]U].
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *M* | ~> 2.0.0
+
+| *Zmmul* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:or]
+== or
+
+Synopsis::
+Or
+
+Assembly::
+or xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+Description::
+Or xs1 with xs2, and store the result in xd
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:orc_b]
+== orc.b
+
+Synopsis::
+Bitware OR-combine, byte granule
+
+Assembly::
+orc.b xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x287,"type":2}]}
+....
+
+Description::
+Combines the bits within each byte using bitwise logical OR. This sets the bits
+of each byte in the result xd to all zeros if no bit within the respective byte
+of xs1 is set, or to all ones if any bit within the respective byte of xs1 is set.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:ori]
+== ori
+
+Synopsis::
+Or immediate
+
+Assembly::
+ori xd, xs1, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+Or an immediate to the value in xs1, and store the result in xd
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:orn]
+== orn
+
+Synopsis::
+OR with inverted operand
+
+Assembly::
+orn xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x20,"type":2}]}
+....
+
+Description::
+Performs the bitwise logical OR operation between xs1 and the bitwise inversion of xs2.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:pack]
+== pack
+
+Synopsis::
+No synopsis available
+
+Assembly::
+pack xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x4,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:packh]
+== packh
+
+Synopsis::
+No synopsis available
+
+Assembly::
+packh xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x4,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:packw]
+== packw
+
+Synopsis::
+No synopsis available
+
+Assembly::
+packw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x4,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:rem]
+== rem
+
+Synopsis::
+Signed remainder
+
+Assembly::
+rem xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+Calculate the remainder of signed division of xs1 by xs2, and store the result in xd.
+
+If the value in register xs2 is zero, write the value in xs1 into xd;
+
+If the result of the division overflows, write zero into xd;
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *M* | ~> 2.0.0
+
+|===
+
+
+[#udb:doc:inst:remu]
+== remu
+
+Synopsis::
+Unsigned remainder
+
+Assembly::
+remu xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+Calculate the remainder of unsigned division of xs1 by xs2, and store the result in xd.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *M* | ~> 2.0.0
+
+|===
+
+
+[#udb:doc:inst:remuw]
+== remuw
+
+Synopsis::
+Unsigned 32-bit remainder
+
+Assembly::
+remuw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+Calculate the remainder of unsigned division of the 32-bit values in xs1 by xs2,
+and store the sign-extended result in xd.
+
+If the value in xs2 is zero, xd gets the sign-extended value in xs1.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *M* | ~> 2.0.0
+
+|===
+
+
+[#udb:doc:inst:remw]
+== remw
+
+Synopsis::
+Signed 32-bit remainder
+
+Assembly::
+remw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1,"type":2}]}
+....
+
+Description::
+Calculate the remainder of signed division of the 32-bit values xs1 by xs2,
+and store the sign-extended result in xd.
+
+If the value in register xs2 is zero, write the sign-extended 32-bit value in xs1 into xd;
+
+If the result of the division overflows, write zero into xd;
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *M* | ~> 2.0.0
+
+|===
+
+
+[#udb:doc:inst:rev8]
+== rev8
+
+Synopsis::
+Byte-reverse register (RV64 encoding)
+
+Assembly::
+rev8 xd, xs1
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x698,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x6b8,"type":2}]}
+....
+
+Description::
+Reverses the order of the bytes in rs1.
+
+[NOTE]
+The rev8 mnemonic corresponds to different instruction encodings in RV32 and RV64.
+
+[NOTE]
+The byte-reverse operation is only available for the full register width. To emulate word-sized
+and halfword-sized byte-reversal, perform a `rev8 xd,xs1` followed by a `srai xd,xd,K`, where K
+is XLEN-32 and XLEN-16, respectively.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:rol]
+== rol
+
+Synopsis::
+Rotate left (Register)
+
+Assembly::
+rol xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x30,"type":2}]}
+....
+
+Description::
+Performs a rotate left of xs1 by the amount in least-significant `log2(XLEN)` bits of xs2.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:rolw]
+== rolw
+
+Synopsis::
+Rotate left word (Register)
+
+Assembly::
+rolw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x30,"type":2}]}
+....
+
+Description::
+Performs a rotate left of the least-significant word of xs1 by the amount in least-significant 5 bits of xs2.
+The resulting word value is sign-extended by copying bit 31 to all of the more-significant bits.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:ror]
+== ror
+
+Synopsis::
+Rotate right (Register)
+
+Assembly::
+ror xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x30,"type":2}]}
+....
+
+Description::
+Performs a rotate right of xs1 by the amount in least-significant `log2(XLEN)` bits of xs2.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:rori]
+== rori
+
+Synopsis::
+Rotate right (Immediate)
+
+Assembly::
+rori xd, xs1, shamt
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "shamt","type":4},{"bits":7,"name": 0x30,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":6,"name": "shamt","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+Performs a rotate right of xs1 by the amount in the least-significant log2(XLEN) bits of shamt.
+For RV32, the encodings corresponding to shamt[5]=1 are reserved.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[25:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:roriw]
+== roriw
+
+Synopsis::
+Rotate right word (Immediate)
+
+Assembly::
+roriw xd, xs1, shamt
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x1b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "shamt","type":4},{"bits":7,"name": 0x30,"type":2}]}
+....
+
+Description::
+Performs a rotate right on the least-significant word of xs1 by the amount in
+the least-significant log2(XLEN) bits of shamt. The resulting word value is sign-extended by
+copying bit 31 to all of the more-significant bits.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:rorw]
+== rorw
+
+Synopsis::
+Rotate right word (Register)
+
+Assembly::
+rorw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x30,"type":2}]}
+....
+
+Description::
+Performs a rotate right on the least-significant word of xs1 by the amount in
+least-significant 5 bits of xs2. The resultant word is sign-extended by copying bit 31 to all
+of the more-significant bits.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sb]
+== sb
+
+Synopsis::
+Store byte
+
+Assembly::
+sb xs2, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x23,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
+....
+
+Description::
+Store 8 bits of data from register `xs2` to an
+address formed by adding `xs1` to a signed offset.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31:25], $encoding[11:7]}
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:sb_rl]
+== sb.rl
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sb.rl xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x2f,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zalasr* | ~> 0.3.5
+
+|===
+
+
+[#udb:doc:inst:sc_d]
+== sc.d
+
+Synopsis::
+Store conditional doubleword
+
+Assembly::
+sc.d xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x3,"type":2}]}
+....
+
+Description::
+xref:insts:sc_d.adoc#udb:doc:inst:sc_d[sc.d] conditionally writes a doubleword in _xs2_ to the address in _xs1_:
+the xref:insts:sc_d.adoc#udb:doc:inst:sc_d[sc.d] succeeds only if the reservation is still valid and the
+reservation set contains the bytes being written. If the xref:insts:sc_d.adoc#udb:doc:inst:sc_d[sc.d] succeeds,
+the instruction writes the doubleword in _xs2_ to memory, and it writes zero to _xd_.
+If the xref:insts:sc_d.adoc#udb:doc:inst:sc_d[sc.d] fails, the instruction does not write to memory, and it writes a
+nonzero value to _xd_. For the purposes of memory protection, a failed xref:insts:sc_d.adoc#udb:doc:inst:sc_d[sc.d]
+may be treated like a store. Regardless of success or failure, executing an
+xref:insts:sc_d.adoc#udb:doc:inst:sc_d[sc.d] instruction invalidates any reservation held by this hart.
+
+The failure code with value 1 encodes an unspecified failure.
+Other failure codes are reserved at this time.
+Portable software should only assume the failure code will be non-zero.
+
+The address held in _xs1_ must be naturally aligned to the size of the operand
+(_i.e._, eight-byte aligned).
+If the address is not naturally aligned, an address-misaligned exception or an
+access-fault exception will be generated.
+The access-fault exception can be generated for a memory access that would otherwise
+be able to complete except for the misalignment,
+if the misaligned access should not be emulated.
+
+[NOTE]
+--
+Emulating misaligned LR/SC sequences is impractical in most systems.
+
+Misaligned LR/SC sequences also raise the possibility of accessing multiple
+reservation sets at once, which present definitions do not provide for.
+--
+
+An implementation can register an arbitrarily large reservation set on each LR,
+provided the reservation set includes all bytes of the addressed data word or
+doubleword.
+An SC can only pair with the most recent LR in program order.
+An SC may succeed only if no store from another hart to the reservation set
+can be observed to have occurred between the LR and the SC,
+and if there is no other SC between the LR and itself in program order.
+An SC may succeed only if no write from a device other than a hart to the bytes
+accessed by the LR instruction can be observed to have occurred between the LR
+and SC.
+Note this LR might have had a different effective address and data size,
+but reserved the SC's address as part of the reservation set.
+
+[NOTE]
+----
+Following this model, in systems with memory translation, an SC is allowed to succeed if the
+earlier LR reserved the same location using an alias with a different virtual address, but is
+also allowed to fail if the virtual address is different.
+
+To accommodate legacy devices and buses, writes from devices other than RISC-V harts are only
+required to invalidate reservations when they overlap the bytes accessed by the LR.
+These writes are not required to invalidate the reservation when they access other bytes in
+the reservation set.
+----
+
+The SC must fail if the address is not within the reservation set of the most
+recent LR in program order.
+The SC must fail if a store to the reservation set from another hart can be
+observed to occur between the LR and SC.
+The SC must fail if a write from some other device to the bytes accessed by the
+LR can be observed to occur between the LR and SC.
+(If such a device writes the reservation set but does not write the bytes accessed
+by the LR, the SC may or may not fail.)
+An SC must fail if there is another SC (to any address) between the LR and the SC
+in program order.
+The precise statement of the atomicity requirements for successful LR/SC sequences
+is defined by the Atomicity Axiom of the memory model.
+
+[NOTE]
+--
+The platform should provide a means to determine the size and shape of the reservation set.
+
+A platform specification may constrain the size and shape of the reservation set.
+
+A store-conditional instruction to a scratch word of memory should be used to forcibly invalidate any existing load reservation:
+
+  * during a preemptive context switch, and
+  * if necessary when changing virtual to physical address mappings, such as when migrating pages that might contain an active reservation.
+
+The invalidation of a hart's reservation when it executes an LR or SC imply that a hart can only hold one reservation at a time, and that an SC can only pair with the most recent LR, and LR with the next following SC, in program order. This is a restriction to the Atomicity Axiom in Section 18.1 that ensures software runs correctly on expected common implementations that operate in this manner.
+--
+
+An SC instruction can never be observed by another RISC-V hart before the LR instruction that established the reservation.
+
+[NOTE]
+--
+The LR/SC sequence can be given acquire semantics by setting the aq bit on the LR instruction. The LR/SC sequence can be given release semantics by by setting the rl bit on the SC instruction. Assuming suitable mappings for other atomic operations, setting the aq bit on the LR instruction, and setting the rl bit on the SC instruction makes the LR/SC sequence sequentially consistent in the C++ memory_order_seq_cst sense. Such a sequence does not act as a fence for ordering ordinary load and store instructions before and after the sequence. Specific instruction mappings for other C++ atomic operations, or stronger notions of "sequential consistency", may require both bits to be set on either or both of the LR or SC instruction.
+
+If neither bit is set on either LR or SC, the LR/SC sequence can be observed to occur before or after surrounding memory operations from the same RISC-V hart. This can be appropriate when the LR/SC sequence is used to implement a parallel reduction operation.
+--
+
+Software should not set the _rl_ bit on an LR instruction unless the _aq_ bit is also set.
+LR.rl and SC.aq instructions are not guaranteed to provide any stronger ordering than those
+with both bits clear, but may result in lower performance.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zalrsc* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sc_w]
+== sc.w
+
+Synopsis::
+Store conditional word
+
+Assembly::
+sc.w xd, xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl != 1","type":4},{"bits":1,"name": "aq != 1","type":4},{"bits":5,"name": 0x3,"type":2}]}
+....
+
+Description::
+xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w] conditionally writes a word in _xs2_ to the address in _xs1_:
+the xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w] succeeds only if the reservation is still valid and the
+reservation set contains the bytes being written. If the xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w] succeeds,
+the instruction writes the word in _xs2_ to memory, and it writes zero to _xd_.
+If the xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w] fails, the instruction does not write to memory, and it writes a
+nonzero value to _xd_. For the purposes of memory protection, a failed xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w]
+may be treated like a store. Regardless of success or failure, executing an
+xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w] instruction invalidates any reservation held by this hart.
+
+<%- if MXLEN == 64 -%>
+[NOTE]
+If a value other than 0 or 1 is defined as a result for xref:insts:sc_w.adoc#udb:doc:inst:sc_w[sc.w], the value will before
+sign-extended into _xd_.
+<%- end -%>
+
+The failure code with value 1 encodes an unspecified failure.
+Other failure codes are reserved at this time.
+Portable software should only assume the failure code will be non-zero.
+
+The address held in _xs1_ must be naturally aligned to the size of the operand
+(_i.e._, eight-byte aligned for doublewords and four-byte aligned for words).
+If the address is not naturally aligned, an address-misaligned exception or an
+access-fault exception will be generated.
+The access-fault exception can be generated for a memory access that would otherwise
+be able to complete except for the misalignment,
+if the misaligned access should not be emulated.
+
+[NOTE]
+--
+Emulating misaligned LR/SC sequences is impractical in most systems.
+
+Misaligned LR/SC sequences also raise the possibility of accessing multiple
+reservation sets at once, which present definitions do not provide for.
+--
+
+An implementation can register an arbitrarily large reservation set on each LR,
+provided the reservation set includes all bytes of the addressed data word or
+doubleword.
+An SC can only pair with the most recent LR in program order.
+An SC may succeed only if no store from another hart to the reservation set
+can be observed to have occurred between the LR and the SC,
+and if there is no other SC between the LR and itself in program order.
+An SC may succeed only if no write from a device other than a hart to the bytes
+accessed by the LR instruction can be observed to have occurred between the LR
+and SC.
+Note this LR might have had a different effective address and data size,
+but reserved the SC's address as part of the reservation set.
+
+[NOTE]
+----
+Following this model, in systems with memory translation, an SC is allowed to succeed if the
+earlier LR reserved the same location using an alias with a different virtual address, but is
+also allowed to fail if the virtual address is different.
+
+To accommodate legacy devices and buses, writes from devices other than RISC-V harts are only
+required to invalidate reservations when they overlap the bytes accessed by the LR.
+These writes are not required to invalidate the reservation when they access other bytes in
+the reservation set.
+----
+
+The SC must fail if the address is not within the reservation set of the most
+recent LR in program order.
+The SC must fail if a store to the reservation set from another hart can be
+observed to occur between the LR and SC.
+The SC must fail if a write from some other device to the bytes accessed by the
+LR can be observed to occur between the LR and SC.
+(If such a device writes the reservation set but does not write the bytes accessed
+by the LR, the SC may or may not fail.)
+An SC must fail if there is another SC (to any address) between the LR and the SC
+in program order.
+The precise statement of the atomicity requirements for successful LR/SC sequences
+is defined by the Atomicity Axiom of the memory model.
+
+[NOTE]
+--
+The platform should provide a means to determine the size and shape of the reservation set.
+
+A platform specification may constrain the size and shape of the reservation set.
+
+A store-conditional instruction to a scratch word of memory should be used to forcibly invalidate any existing load reservation:
+
+  * during a preemptive context switch, and
+  * if necessary when changing virtual to physical address mappings, such as when migrating pages that might contain an active reservation.
+
+The invalidation of a hart's reservation when it executes an LR or SC imply that a hart can only hold one reservation at a time, and that an SC can only pair with the most recent LR, and LR with the next following SC, in program order. This is a restriction to the Atomicity Axiom in Section 18.1 that ensures software runs correctly on expected common implementations that operate in this manner.
+--
+
+An SC instruction can never be observed by another RISC-V hart before the LR instruction that established the reservation.
+
+[NOTE]
+--
+The LR/SC sequence can be given acquire semantics by setting the aq bit on the LR instruction. The LR/SC sequence can be given release semantics by by setting the rl bit on the SC instruction. Assuming suitable mappings for other atomic operations, setting the aq bit on the LR instruction, and setting the rl bit on the SC instruction makes the LR/SC sequence sequentially consistent in the C++ memory_order_seq_cst sense. Such a sequence does not act as a fence for ordering ordinary load and store instructions before and after the sequence. Specific instruction mappings for other C++ atomic operations, or stronger notions of "sequential consistency", may require both bits to be set on either or both of the LR or SC instruction.
+
+If neither bit is set on either LR or SC, the LR/SC sequence can be observed to occur before or after surrounding memory operations from the same RISC-V hart. This can be appropriate when the LR/SC sequence is used to implement a parallel reduction operation.
+--
+
+Software should not set the _rl_ bit on an LR instruction unless the _aq_ bit is also set.
+LR.rl and SC.aq instructions are not guaranteed to provide any stronger ordering than those
+with both bits clear, but may result in lower performance.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zalrsc* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sctrclr]
+== sctrclr
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sctrclr sctrclr
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0x10400073,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+sctrclr has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Smdbltrp* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sd]
+== sd
+
+Synopsis::
+Store doubleword
+
+Assembly::
+sd xs2, imm(xs1)
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x23,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2 != {1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31}","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x23,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
+....
+
+Description::
+For RV64, store 64 bits of data from register `xs2` to an
+address formed by adding `xs1` to a signed offset.
+<% if ext?(:Zilsd) %>
+For RV32, store doubleword from even/odd register pair.
+<% end %>
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31:25], $encoding[11:7]}
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |sext({$encoding[31:25], $encoding[11:7]})
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+| *Zilsd* | ~> 1.0
+
+|===
+
+
+[#udb:doc:inst:sd_rl]
+== sd.rl
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sd.rl xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x302f,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zalasr* | ~> 0.3.5
+
+|===
+
+
+[#udb:doc:inst:sext_b]
+== sext.b
+
+Synopsis::
+Sign-extend byte
+
+Assembly::
+sext.b xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x604,"type":2}]}
+....
+
+Description::
+Sign-extends the least-significant byte in the source to XLEN by copying the
+most-significant bit in the byte (i.e., bit 7) to all of the more-significant bits.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sext_h]
+== sext.h
+
+Synopsis::
+Sign-extend halfword
+
+Assembly::
+sext.h xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x605,"type":2}]}
+....
+
+Description::
+Sign-extends the least-significant halfword in the source to XLEN by copying the
+most-significant bit in the halfword (i.e., bit 15) to all of the more-significant bits.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sfence_inval_ir]
+== sfence.inval.ir
+
+Synopsis::
+Order implicit page table reads after invalidation
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0x18100073,"type":2}]}
+....
+
+Description::
+The xref:insts:sfence_inval_ir.adoc#udb:doc:inst:sfence_inval_ir[sfence.inval.ir] instruction guarantees that any previous xref:insts:sinval_vma.adoc#udb:doc:inst:sinval_vma[sinval.vma]
+instructions executed by the current hart are ordered before subsequent implicit references by
+that hart to the memory-management data structures.
+
+
+Decode Variables::
+sfence.inval.ir has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Svinval* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sfence_vma]
+== sfence.vma
+
+Synopsis::
+Supervisor memory-management fence
+
+Assembly::
+sfence.vma xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x73,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x9,"type":2}]}
+....
+
+Description::
+The supervisor memory-management fence instruction `SFENCE.VMA` is used to
+synchronize updates to in-memory memory-management data structures with
+current execution. Instruction execution causes implicit reads and
+writes to these data structures; however, these implicit references are
+ordinarily not ordered with respect to explicit loads and stores.
+Executing an SFENCE.VMA instruction guarantees that any previous stores
+already visible to the current RISC-V hart are ordered before certain
+implicit references by subsequent instructions in that hart to the
+memory-management data structures. The specific set of operations
+ordered by SFENCE.VMA is determined by _xs1_ and _xs2_, as described
+below. SFENCE.VMA is also used to invalidate entries in the
+address-translation cache associated with a hart (see <<sv32algorithm>>). Further details on the behavior of this instruction are described in <<virt-control>> and <<pmp-vmem>>.
+
+[NOTE]
+====
+The SFENCE.VMA is used to flush any local hardware caches related to
+address translation. It is specified as a fence rather than a TLB flush
+to provide cleaner semantics with respect to which instructions are
+affected by the flush operation and to support a wider variety of
+dynamic caching structures and memory-management schemes. SFENCE.VMA is
+also used by higher privilege levels to synchronize page table writes
+and the address translation hardware.
+====
+
+SFENCE.VMA orders only the local hart's implicit references to the
+memory-management data structures.
+
+[NOTE]
+====
+Consequently, other harts must be notified separately when the
+memory-management data structures have been modified. One approach is to
+use 1) a local data fence to ensure local writes are visible globally,
+then 2) an interprocessor interrupt to the other thread, then 3) a local
+SFENCE.VMA in the interrupt handler of the remote thread, and finally 4)
+signal back to originating thread that operation is complete. This is,
+of course, the RISC-V analog to a TLB shootdown.
+====
+
+For the common case that the translation data structures have only been
+modified for a single address mapping (i.e., one page or superpage),
+_xs1_ can specify a virtual address within that mapping to effect a
+translation fence for that mapping only. Furthermore, for the common
+case that the translation data structures have only been modified for a
+single address-space identifier, _xs2_ can specify the address space.
+The behavior of SFENCE.VMA depends on _xs1_ and _xs2_ as follows:
+
+* If __xs1__=`x0` and __xs2__=`x0`, the fence orders all reads and writes
+made to any level of the page tables, for all address spaces. The fence
+also invalidates all address-translation cache entries, for all address
+spaces.
+* If __xs1__=`x0` and __xs2__&#8800;``x0``, the fence orders all
+reads and writes made to any level of the page tables, but only for the
+address space identified by integer register _xs2_. Accesses to _global_
+mappings (see <<translation>>) are not ordered. The
+fence also invalidates all address-translation cache entries matching
+the address space identified by integer register _xs2_, except for
+entries containing global mappings.
+* If __xs1__&#8800;``x0`` and __xs2__=`x0`, the fence orders only
+reads and writes made to leaf page table entries corresponding to the
+virtual address in __xs1__, for all address spaces. The fence also
+invalidates all address-translation cache entries that contain leaf page
+table entries corresponding to the virtual address in _xs1_, for all
+address spaces.
+* If __xs1__&#8800;``x0`` and __xs2__&#8800;``x0``, the
+fence orders only reads and writes made to leaf page table entries
+corresponding to the virtual address in _xs1_, for the address space
+identified by integer register _xs2_. Accesses to global mappings are
+not ordered. The fence also invalidates all address-translation cache
+entries that contain leaf page table entries corresponding to the
+virtual address in _xs1_ and that match the address space identified by
+integer register _xs2_, except for entries containing global mappings.
+
+If the value held in _xs1_ is not a valid virtual address, then the
+SFENCE.VMA instruction has no effect. No exception is raised in this
+case.
+
+When __xs2__&#8800;``x0``, bits SXLEN-1:ASIDMAX of the value held
+in _xs2_ are reserved for future standard use. Until their use is
+defined by a standard extension, they should be zeroed by software and
+ignored by current implementations. Furthermore, if
+ASIDLEN<ASIDMAX, the implementation shall ignore bits
+ASIDMAX-1:ASIDLEN of the value held in _xs2_.
+
+[NOTE]
+====
+It is always legal to over-fence, e.g., by fencing only based on a
+subset of the bits in _xs1_ and/or _xs2_, and/or by simply treating all
+SFENCE.VMA instructions as having _xs1_=`x0` and/or _xs2_=`x0`. For
+example, simpler implementations can ignore the virtual address in _xs1_
+and the ASID value in _xs2_ and always perform a global fence. The
+choice not to raise an exception when an invalid virtual address is held
+in _xs1_ facilitates this type of simplification.
+====
+
+An implicit read of the memory-management data structures may return any
+translation for an address that was valid at any time since the most
+recent SFENCE.VMA that subsumes that address. The ordering implied by
+SFENCE.VMA does not place implicit reads and writes to the
+memory-management data structures into the global memory order in a way
+that interacts cleanly with the standard RVWMO ordering rules. In
+particular, even though an SFENCE.VMA orders prior explicit accesses
+before subsequent implicit accesses, and those implicit accesses are
+ordered before their associated explicit accesses, SFENCE.VMA does not
+necessarily place prior explicit accesses before subsequent explicit
+accesses in the global memory order. These implicit loads also need not
+otherwise obey normal program order semantics with respect to prior
+loads or stores to the same address.
+
+[NOTE]
+====
+A consequence of this specification is that an implementation may use
+any translation for an address that was valid at any time since the most
+recent SFENCE.VMA that subsumes that address. In particular, if a leaf
+PTE is modified but a subsuming SFENCE.VMA is not executed, either the
+old translation or the new translation will be used, but the choice is
+unpredictable. The behavior is otherwise well-defined.
+
+In a conventional TLB design, it is possible for multiple entries to
+match a single address if, for example, a page is upgraded to a
+superpage without first clearing the original non-leaf PTE's valid bit
+and executing an SFENCE.VMA with __xs1__=`x0`. In this case, a similar
+remark applies: it is unpredictable whether the old non-leaf PTE or the
+new leaf PTE is used, but the behavior is otherwise well defined.
+
+Another consequence of this specification is that it is generally unsafe
+to update a PTE using a set of stores of a width less than the width of
+the PTE, as it is legal for the implementation to read the PTE at any
+time, including when only some of the partial stores have taken effect.
+
+***
+
+This specification permits the caching of PTEs whose V (Valid) bit is
+clear. Operating systems must be written to cope with this possibility,
+but implementers are reminded that eagerly caching invalid PTEs will
+reduce performance by causing additional page faults.
+====
+
+Implementations must only perform implicit reads of the translation data
+structures pointed to by the current contents of the xref:csrs:satp.adoc#udb:doc:csr:satp[satp] register or
+a subsequent valid (V=1) translation data structure entry, and must only
+raise exceptions for implicit accesses that are generated as a result of
+instruction execution, not those that are performed speculatively.
+
+Changes to the xref:csrs:sstatus.adoc#udb:doc:csr:sstatus[sstatus] fields SUM and MXR take effect immediately,
+without the need to execute an SFENCE.VMA instruction. Changing
+xref:csrs:satp.adoc#udb:doc:csr:satp[satp].MODE from Bare to other modes and vice versa also takes effect
+immediately, without the need to execute an SFENCE.VMA instruction.
+Likewise, changes to xref:csrs:satp.adoc#udb:doc:csr:satp[satp].ASID take effect immediately.
+
+[TIP]
+====
+The following common situations typically require executing an
+SFENCE.VMA instruction:
+
+* When software recycles an ASID (i.e., reassociates it with a different
+page table), it should _first_ change xref:csrs:satp.adoc#udb:doc:csr:satp[satp] to point to the new page
+table using the recycled ASID, _then_ execute SFENCE.VMA with __xs1__=`x0`
+and _xs2_ set to the recycled ASID. Alternatively, software can execute
+the same SFENCE.VMA instruction while a different ASID is loaded into
+xref:csrs:satp.adoc#udb:doc:csr:satp[satp], provided the next time xref:csrs:satp.adoc#udb:doc:csr:satp[satp] is loaded with the recycled ASID,
+it is simultaneously loaded with the new page table.
+* If the implementation does not provide ASIDs, or software chooses to
+always use ASID 0, then after every xref:csrs:satp.adoc#udb:doc:csr:satp[satp] write, software should
+execute SFENCE.VMA with __xs1__=`x0`. In the common case that no global
+translations have been modified, _xs2_ should be set to a register other
+than `x0` but which contains the value zero, so that global translations
+are not flushed.
+* If software modifies a non-leaf PTE, it should execute SFENCE.VMA with
+__xs1__=`x0`. If any PTE along the traversal path had its G bit set, _xs2_
+must be `x0`; otherwise, _xs2_ should be set to the ASID for which the
+translation is being modified.
+* If software modifies a leaf PTE, it should execute SFENCE.VMA with
+_xs1_ set to a virtual address within the page. If any PTE along the
+traversal path had its G bit set, _xs2_ must be `x0`; otherwise, _xs2_
+should be set to the ASID for which the translation is being modified.
+* For the special cases of increasing the permissions on a leaf PTE and
+changing an invalid PTE to a valid leaf, software may choose to execute
+the SFENCE.VMA lazily. After modifying the PTE but before executing
+SFENCE.VMA, either the new or old permissions will be used. In the
+latter case, a page-fault exception might occur, at which point software
+should execute SFENCE.VMA in accordance with the previous bullet point.
+====
+
+If a hart employs an address-translation cache, that cache must appear
+to be private to that hart. In particular, the meaning of an ASID is
+local to a hart; software may choose to use the same ASID to refer to
+different address spaces on different harts.
+
+[NOTE]
+====
+A future extension could redefine ASIDs to be global across the SEE,
+enabling such options as shared translation caches and hardware support
+for broadcast TLB shootdown. However, as OSes have evolved to
+significantly reduce the scope of TLB shootdowns using novel
+ASID-management techniques, we expect the local-ASID scheme to remain
+attractive for its simplicity and possibly better scalability.
+====
+
+For implementations that make xref:csrs:satp.adoc#udb:doc:csr:satp[satp].MODE read-only zero (always Bare),
+attempts to execute an SFENCE.VMA instruction might raise an
+illegal-instruction exception.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *S* | ~> 1.11.0
+
+|===
+
+
+[#udb:doc:inst:sfence_w_inval]
+== sfence.w.inval
+
+Synopsis::
+Order writes before sfence
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0x18000073,"type":2}]}
+....
+
+Description::
+The xref:insts:sfence_w_inval.adoc#udb:doc:inst:sfence_w_inval[sfence.w.inval] instruction guarantees that any previous stores already visible to the
+current RISC-V hart are ordered before subsequent xref:insts:sinval_vma.adoc#udb:doc:inst:sinval_vma[sinval.vma] instructions executed by the
+same hart.
+
+
+Decode Variables::
+sfence.w.inval has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Svinval* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sh]
+== sh
+
+Synopsis::
+Store halfword
+
+Assembly::
+sh xs2, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x23,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
+....
+
+Description::
+Store 16 bits of data from register `xs2` to an
+address formed by adding `xs1` to a signed offset.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31:25], $encoding[11:7]}
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:sh_rl]
+== sh.rl
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sh.rl xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x102f,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zalasr* | ~> 0.3.5
+
+|===
+
+
+[#udb:doc:inst:sh1add]
+== sh1add
+
+Synopsis::
+Shift left by 1 and add
+
+Assembly::
+sh1add xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x10,"type":2}]}
+....
+
+Description::
+Shifts `xs1` to the left by 1 bit and adds it to `xs2`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zba* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sh1add_uw]
+== sh1add.uw
+
+Synopsis::
+Shift unsigned word left by 1 and add
+
+Assembly::
+sh1add.uw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x10,"type":2}]}
+....
+
+Description::
+Performs an XLEN-wide addition of two addends. The first addend is xs2.
+The second addend is the unsigned value formed by extracting the least-significant word of xs1
+and shifting it left by 1 place.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zba* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sh2add]
+== sh2add
+
+Synopsis::
+Shift left by 2 and add
+
+Assembly::
+sh2add xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x10,"type":2}]}
+....
+
+Description::
+Shifts `xs1` to the left by 2 places and adds it to `xs2`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zba* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sh2add_uw]
+== sh2add.uw
+
+Synopsis::
+Shift unsigned word left by 2 and add
+
+Assembly::
+sh2add.uw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x10,"type":2}]}
+....
+
+Description::
+Performs an XLEN-wide addition of two addends. The first addend is xs2.
+The second addend is the unsigned value formed by extracting the least-significant word of xs1
+and shifting it left by 2 places.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zba* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sh3add]
+== sh3add
+
+Synopsis::
+Shift left by 3 and add
+
+Assembly::
+sh3add xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x10,"type":2}]}
+....
+
+Description::
+Shifts `xs1` to the left by 3 places and adds it to `xs2`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zba* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sh3add_uw]
+== sh3add.uw
+
+Synopsis::
+Shift unsigned word left by 3 and add
+
+Assembly::
+sh3add.uw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x10,"type":2}]}
+....
+
+Description::
+Performs an XLEN-wide addition of two addends. The first addend is xs2.
+The second addend is the unsigned value formed by extracting the least-significant word of xs1
+and shifting it left by 3 places.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zba* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sha256sig0]
+== sha256sig0
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sha256sig0 xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x102,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sha256sig1]
+== sha256sig1
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sha256sig1 xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x103,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sha256sum0]
+== sha256sum0
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sha256sum0 xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x100,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sha256sum1]
+== sha256sum1
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sha256sum1 xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x101,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sha512sig0]
+== sha512sig0
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sha512sig0 xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x106,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sha512sig0h]
+== sha512sig0h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sha512sig0h xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x2e,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sha512sig0l]
+== sha512sig0l
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sha512sig0l xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x2a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sha512sig1]
+== sha512sig1
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sha512sig1 xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x107,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sha512sig1h]
+== sha512sig1h
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sha512sig1h xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x2f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sha512sig1l]
+== sha512sig1l
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sha512sig1l xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sha512sum0]
+== sha512sum0
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sha512sum0 xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x104,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sha512sum0r]
+== sha512sum0r
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sha512sum0r xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sha512sum1]
+== sha512sum1
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sha512sum1 xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x105,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sha512sum1r]
+== sha512sum1r
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sha512sum1r xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zknh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sinval_vma]
+== sinval.vma
+
+Synopsis::
+Invalidate cached address translations
+
+Assembly::
+sinval.vma xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x73,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0xb,"type":2}]}
+....
+
+Description::
+The xref:insts:sinval_vma.adoc#udb:doc:inst:sinval_vma[sinval.vma] instruction invalidates any address-translation cache entries that an xref:insts:sfence_vma.adoc#udb:doc:inst:sfence_vma[sfence.vma] instruction with the same values of xs1 and xs2 would invalidate. However, unlike xref:insts:sfence_vma.adoc#udb:doc:inst:sfence_vma[sfence.vma], xref:insts:sinval_vma.adoc#udb:doc:inst:sinval_vma[sinval.vma] instructions are only ordered with respect to xref:insts:sfence_vma.adoc#udb:doc:inst:sfence_vma[sfence.vma], xref:insts:sfence_w_inval.adoc#udb:doc:inst:sfence_w_inval[sfence.w.inval], and xref:insts:sfence_inval_ir.adoc#udb:doc:inst:sfence_inval_ir[sfence.inval.ir] instructions as defined below.
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Svinval* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sll]
+== sll
+
+Synopsis::
+Shift left logical
+
+Assembly::
+sll xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+Description::
+Shift the value in `xs1` left by the value in the lower 6 bits of `xs2`, and store the result in `xd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:slli]
+== slli
+
+Synopsis::
+Shift left logical immediate
+
+Assembly::
+slli xd, xs1, shamt
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "shamt","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":6,"name": "shamt","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+Shift the value in xs1 left by shamt, and store the result in xd
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[25:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:slli_uw]
+== slli.uw
+
+Synopsis::
+Shift left unsigned word (Immediate)
+
+Assembly::
+slli.uw xd, xs1, shamt
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x1b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":6,"name": "shamt","type":4},{"bits":6,"name": 0x2,"type":2}]}
+....
+
+Description::
+Takes the least-significant word of xs1, zero-extends it, and shifts it
+left by the immediate.
+
+[NOTE]
+This instruction is the same as xref:insts:slli.adoc#udb:doc:inst:slli[slli] with `zext.w` performed on xs1 before shifting.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[25:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zba* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:slliw]
+== slliw
+
+Synopsis::
+Shift left logical immediate word
+
+Assembly::
+slliw xd, xs1, shamt
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x1b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "shamt","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+Description::
+Shift the 32-bit value in xs1 left by shamt, and store the sign-extended result in xd
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:sllw]
+== sllw
+
+Synopsis::
+Shift left logical word
+
+Assembly::
+sllw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+Description::
+Shift the 32-bit value in `xs1` left by the value in the lower 5 bits of `xs2`, and store the sign-extended result in `xd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:slt]
+== slt
+
+Synopsis::
+Set on less than
+
+Assembly::
+slt xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+Description::
+Places the value 1 in register `xd` if register `xs1` is less than the value in register `xs2`, where
+both sources are treated as signed numbers, else 0 is written to `xd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:slti]
+== slti
+
+Synopsis::
+Set on less than immediate
+
+Assembly::
+slti xd, xs1, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+Places the value 1 in register `xd` if register `xs1` is less than the sign-extended immediate
+when both are treated as signed numbers, else 0 is written to `xd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:sltiu]
+== sltiu
+
+Synopsis::
+Set on less than immediate unsigned
+
+Assembly::
+sltiu xd, xs1, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+Places the value 1 in register `xd` if register `xs1` is less than the sign-extended immediate
+when both are treated as unsigned numbers (_i.e._, the immediate is first sign-extended to
+XLEN bits then treated as an unsigned number), else 0 is written to `xd`.
+
+NOTE: `sltiu xd, xs1, 1` sets `xd` to 1 if `xs1` equals zero, otherwise sets `xd` to 0
+(assembler pseudoinstruction `SEQZ xd, rs`).
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:sltu]
+== sltu
+
+Synopsis::
+Set on less than unsigned
+
+Assembly::
+sltu xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+Description::
+Places the value 1 in register `xd` if register `xs1` is less than the value in register `xs2`, where
+both sources are treated as unsigned numbers, else 0 is written to `xd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:sm3p0]
+== sm3p0
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sm3p0 xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x108,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zks* | ~> 1.0.0
+
+| *Zksh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sm3p1]
+== sm3p1
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sm3p1 xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x109,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zks* | ~> 1.0.0
+
+| *Zksh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sm4ed]
+== sm4ed
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sm4ed xd, xs1, xs2, bs
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":5,"name": 0x18,"type":2},{"bits":2,"name": "bs","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|bs |$encoding[31:30]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zks* | ~> 1.0.0
+
+| *Zksed* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sm4ks]
+== sm4ks
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sm4ks xd, xs1, xs2, bs
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":5,"name": 0x1a,"type":2},{"bits":2,"name": "bs","type":4}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|bs |$encoding[31:30]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zks* | ~> 1.0.0
+
+| *Zksed* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sra]
+== sra
+
+Synopsis::
+Shift right arithmetic
+
+Assembly::
+sra xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x20,"type":2}]}
+....
+
+Description::
+Arithmetic shift the value in `xs1` right by the value in the lower 5 bits of `xs2`, and store the result in `xd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:srai]
+== srai
+
+Synopsis::
+Shift right arithmetic immediate
+
+Assembly::
+srai xd, xs1, shamt
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "shamt","type":4},{"bits":7,"name": 0x20,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":6,"name": "shamt","type":4},{"bits":6,"name": 0x10,"type":2}]}
+....
+
+Description::
+Arithmetic shift (the original sign bit is copied into the vacated upper bits) the
+value in xs1 right by shamt, and store the result in xd.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[25:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:sraiw]
+== sraiw
+
+Synopsis::
+Shift right arithmetic immediate word
+
+Assembly::
+sraiw xd, xs1, shamt
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x1b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "shamt","type":4},{"bits":7,"name": 0x20,"type":2}]}
+....
+
+Description::
+Arithmetic shift (the original sign bit is copied into the vacated upper bits) the
+32-bit value in xs1 right by shamt, and store the sign-extended result in xd.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:sraw]
+== sraw
+
+Synopsis::
+Shift right arithmetic word
+
+Assembly::
+sraw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x20,"type":2}]}
+....
+
+Description::
+Arithmetic shift the 32-bit value in `xs1` right by the value in the lower 5 bits of `xs2`, and store the sign-extended result in `xd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:sret]
+== sret
+
+Synopsis::
+Supervisor Exception Return
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0x10200073,"type":2}]}
+....
+
+Description::
+Returns from an exception.
+
+When xref:insts:sret.adoc#udb:doc:inst:sret[sret] is allowed to execute, its behavior depends on whether or not the current privilege
+mode is virtualized.
+
+*When the current privilege mode is (H)S-mode or M-mode*
+
+xref:insts:sret.adoc#udb:doc:inst:sret[sret] sets  xref:csrs:hstatus.adoc#udb:doc:csr:hstatus[hstatus] = 0, xref:csrs:mstatus.adoc#udb:doc:csr_field:mstatus:SPP[mstatus.SPP] = 0,
+xref:csrs:mstatus.adoc#udb:doc:csr_field:mstatus:SIE[mstatus.SIE] = xref:csrs:mstatus.adoc#udb:doc:csr_field:mstatus:SPIE[mstatus.SPIE], and xref:csrs:mstatus.adoc#udb:doc:csr_field:mstatus:SPIE[mstatus.SPIE] = 1,
+changes the privilege mode according to the table below,
+and then jumps to the address in xref:csrs:sepc.adoc#udb:doc:csr:sepc[sepc].
+
+.Next privilege mode following an xref:insts:sret.adoc#udb:doc:inst:sret[sret] in (H)S-mode or M-mode
+[%autowidth]
+|===
+| [.rotate]#xref:csrs:mstatus.adoc#udb:doc:csr_field:mstatus:SPP[mstatus.SPP]# | [.rotate]#xref:csrs:hstatus.adoc#udb:doc:csr_field:hstatus:SPV[hstatus.SPV]# .>| Mode after xref:insts:sret.adoc#udb:doc:inst:sret[sret]
+
+| 0 | 0 | U-mode
+| 0 | 1 | VU-mode
+| 1 | 0 | (H)S-mode
+| 1 | 1 | VS-mode
+|===
+
+*When the current privilege mode is VS-mode*
+
+xref:insts:sret.adoc#udb:doc:inst:sret[sret] sets
+xref:csrs:vsstatus.adoc#udb:doc:csr_field:vsstatus:SPP[vsstatus.SPP] = 0, xref:csrs:vsstatus.adoc#udb:doc:csr_field:vsstatus:SIE[vsstatus.SIE] = `vstatus.SPIE`, and xref:csrs:vsstatus.adoc#udb:doc:csr_field:vsstatus:SPIE[vsstatus.SPIE] = 1,
+changes the privilege mode according to the table below,
+and then jumps to the address in xref:csrs:vsepc.adoc#udb:doc:csr:vsepc[vsepc].
+
+.Next privilege mode following an xref:insts:sret.adoc#udb:doc:inst:sret[sret] in (H)S-mode or M-mode
+[%autowidth]
+|===
+| [.rotate]#xref:csrs:vsstatus.adoc#udb:doc:csr_field:vsstatus:SPP[vsstatus.SPP]# .>| Mode after xref:insts:sret.adoc#udb:doc:inst:sret[sret]
+
+| 0 | VU-mode
+| 1 | VS-mode
+|===
+
+
+Decode Variables::
+sret has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *S* | ~> 1.11.0
+
+|===
+
+
+[#udb:doc:inst:srl]
+== srl
+
+Synopsis::
+Shift right logical
+
+Assembly::
+srl xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+Description::
+Logical shift the value in `xs1` right by the value in the lower bits of `xs2`, and store the result in `xd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:srli]
+== srli
+
+Synopsis::
+Shift right logical immediate
+
+Assembly::
+srli xd, xs1, shamt
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "shamt","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":6,"name": "shamt","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+Shift the value in xs1 right by shamt, and store the result in xd
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[25:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:srliw]
+== srliw
+
+Synopsis::
+Shift right logical immediate word
+
+Assembly::
+srliw xd, xs1, shamt
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x1b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "shamt","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+Description::
+Shift the 32-bit value in xs1 right by shamt, and store the sign-extended result in xd
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|shamt |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:srlw]
+== srlw
+
+Synopsis::
+Shift right logical word
+
+Assembly::
+srlw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+Description::
+Logical shift the 32-bit value in `xs1` right by the value in the lower 5 bits of `xs2`, and store the sign-extended result in `xd`.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:ssamoswap_d]
+== ssamoswap.d
+
+Synopsis::
+No synopsis available
+
+Assembly::
+ssamoswap.d xd, xs2, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicfiss* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:ssamoswap_w]
+== ssamoswap.w
+
+Synopsis::
+No synopsis available
+
+Assembly::
+ssamoswap.w xd, xs2, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x2f,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "rl","type":4},{"bits":1,"name": "aq","type":4},{"bits":5,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|aq |$encoding[26]
+|rl |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicfiss* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sspopchk_x1]
+== sspopchk.x1
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sspopchk.x1 sspopchk_x1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0xcdc0c073,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+sspopchk.x1 has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicfiss* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sspopchk_x5]
+== sspopchk.x5
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sspopchk.x5 sspopchk_x5
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0xcdc2c073,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+sspopchk.x5 has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicfiss* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sspush_x1]
+== sspush.x1
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sspush.x1 sspush_x1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0xce104073,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+sspush.x1 has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicfiss* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sspush_x5]
+== sspush.x5
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sspush.x5 sspush_x5
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0xce504073,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+sspush.x5 has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicfiss* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:ssrdp]
+== ssrdp
+
+Synopsis::
+Read ssp into a Register
+
+Assembly::
+ssrdp xd
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x73,"type":2},{"bits":5,"name": "xd != 0","type":4},{"bits":20,"name": 0xcdc04,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zicfiss* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:sub]
+== sub
+
+Synopsis::
+Subtract
+
+Assembly::
+sub xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x20,"type":2}]}
+....
+
+Description::
+Subtract the value in xs2 from xs1, and store the result in xd
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:subw]
+== subw
+
+Synopsis::
+Subtract word
+
+Assembly::
+subw xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x20,"type":2}]}
+....
+
+Description::
+Subtract the 32-bit values in xs2 from xs1, and store the sign-extended result in xd
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:sw]
+== sw
+
+Synopsis::
+Store word
+
+Assembly::
+sw xs2, imm(xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x23,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": "imm[11:5]","type":4}]}
+....
+
+Description::
+Store 32 bits of data from register `xs2` to an
+address formed by adding `xs1` to a signed offset.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[31:25], $encoding[11:7]}
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:sw_rl]
+== sw.rl
+
+Synopsis::
+No synopsis available
+
+Assembly::
+sw.rl xs2, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":15,"name": 0x202f,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x1d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zalasr* | ~> 0.3.5
+
+|===
+
+
+[#udb:doc:inst:unzip]
+== unzip
+
+Synopsis::
+Bit deinterleave
+
+Assembly::
+unzip xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x8f,"type":2}]}
+....
+
+Description::
+Gathers bits from the high and low halves of the source word into odd/even bit
+positions in the destination word. It is the inverse of the zip instruction. This instruction is
+available only on RV32.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vaadd_vv]
+== vaadd.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vaadd.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vaadd_vx]
+== vaadd.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vaadd.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vaaddu_vv]
+== vaaddu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vaaddu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vaaddu_vx]
+== vaaddu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vaaddu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vadc_vim]
+== vadc.vim
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vadc.vim vd, vs2, imm, v0
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vadc_vvm]
+== vadc.vvm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vadc.vvm vd, vs2, vs1, v0
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vadc_vxm]
+== vadc.vxm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vadc.vxm vd, vs2, xs1, v0
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vadd_vi]
+== vadd.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vadd.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vadd_vv]
+== vadd.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vadd.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vadd_vx]
+== vadd.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vadd.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vaesdf_vs]
+== vaesdf.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vaesdf.vs vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0xa,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvkned* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vaesdf_vv]
+== vaesdf.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vaesdf.vv vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0xa,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvkned* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vaesdm_vs]
+== vaesdm.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vaesdm.vs vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x2,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvkned* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vaesdm_vv]
+== vaesdm.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vaesdm.vv vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x2,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvkned* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vaesef_vs]
+== vaesef.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vaesef.vs vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x1a,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvkned* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vaesef_vv]
+== vaesef.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vaesef.vv vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x1a,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvkned* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vaesem_vs]
+== vaesem.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vaesem.vs vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x12,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvkned* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vaesem_vv]
+== vaesem.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vaesem.vv vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x12,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvkned* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vaeskf1_vi]
+== vaeskf1.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vaeskf1.vi vd, vs2, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "zimm5","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x45,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|zimm5 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvkned* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vaeskf2_vi]
+== vaeskf2.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vaeskf2.vi vd, vs2, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "zimm5","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x55,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|zimm5 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvkned* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vaesz_vs]
+== vaesz.vs
+
+Synopsis::
+Vector AES round zero
+
+Assembly::
+vaesz.vs vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x3a,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvkned* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vand_vi]
+== vand.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vand.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vand_vv]
+== vand.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vand.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vand_vx]
+== vand.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vand.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vandn_vv]
+== vandn.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vandn.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vandn_vx]
+== vandn.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vandn.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vasub_vv]
+== vasub.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vasub.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xb,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vasub_vx]
+== vasub.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vasub.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xb,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vasubu_vv]
+== vasubu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vasubu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vasubu_vx]
+== vasubu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vasubu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vbrev_v]
+== vbrev.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vbrev.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x52,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vbrev8_v]
+== vbrev8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vbrev8.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x42,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vclmul_vv]
+== vclmul.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vclmul.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xc,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbc* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vclmul_vx]
+== vclmul.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vclmul.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xc,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbc* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vclmulh_vv]
+== vclmulh.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vclmulh.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xd,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbc* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vclmulh_vx]
+== vclmulh.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vclmulh.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xd,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbc* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vclz_v]
+== vclz.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vclz.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x62,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vcompress_vm]
+== vcompress.vm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vcompress.vm vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x2f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vcpop_m]
+== vcpop.m
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vcpop.m xd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "xd","type":4},{"bits":8,"name": 0x82,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vcpop_v]
+== vcpop.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vcpop.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x72,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vctz_v]
+== vctz.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vctz.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x6a,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vdiv_vv]
+== vdiv.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vdiv.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vdiv_vx]
+== vdiv.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vdiv.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vdivu_vv]
+== vdivu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vdivu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vdivu_vx]
+== vdivu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vdivu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfadd_vf]
+== vfadd.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfadd.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfadd_vv]
+== vfadd.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfadd.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfclass_v]
+== vfclass.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfclass.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x81,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x13,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfcvt_f_x_v]
+== vfcvt.f.x.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfcvt.f.x.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x19,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfcvt_f_xu_v]
+== vfcvt.f.xu.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfcvt.f.xu.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x11,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfcvt_rtz_x_f_v]
+== vfcvt.rtz.x.f.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfcvt.rtz.x.f.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x39,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfcvt_rtz_xu_f_v]
+== vfcvt.rtz.xu.f.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfcvt.rtz.xu.f.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x31,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfcvt_x_f_v]
+== vfcvt.x.f.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfcvt.x.f.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x9,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfcvt_xu_f_v]
+== vfcvt.xu.f.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfcvt.xu.f.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x1,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfdiv_vf]
+== vfdiv.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfdiv.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfdiv_vv]
+== vfdiv.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfdiv.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfirst_m]
+== vfirst.m
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfirst.m xd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "xd","type":4},{"bits":8,"name": 0x8a,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmacc_vf]
+== vfmacc.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmacc.vf vd, fs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmacc_vv]
+== vfmacc.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmacc.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmadd_vf]
+== vfmadd.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmadd.vf vd, fs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmadd_vv]
+== vfmadd.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmadd.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmax_vf]
+== vfmax.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmax.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x6,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmax_vv]
+== vfmax.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmax.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x6,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmerge_vfm]
+== vfmerge.vfm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmerge.vfm vd, vs2, fs1, v0
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x2e,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmin_vf]
+== vfmin.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmin.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x4,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmin_vv]
+== vfmin.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmin.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x4,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmsac_vf]
+== vfmsac.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmsac.vf vd, fs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2e,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmsac_vv]
+== vfmsac.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmsac.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2e,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmsub_vf]
+== vfmsub.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmsub.vf vd, fs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmsub_vv]
+== vfmsub.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmsub.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmul_vf]
+== vfmul.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmul.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x24,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmul_vv]
+== vfmul.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmul.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x24,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmv_f_s]
+== vfmv.f.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmv.f.s fd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "fd","type":4},{"bits":8,"name": 0x1,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|fd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmv_s_f]
+== vfmv.s.f
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmv.s.f vd, fs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x420,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfmv_v_f]
+== vfmv.v.f
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfmv.v.f vd, fs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":12,"name": 0x5e0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfncvt_f_f_w]
+== vfncvt.f.f.w
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfncvt.f.f.w vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0xa1,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfncvt_f_x_w]
+== vfncvt.f.x.w
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfncvt.f.x.w vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x99,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfncvt_f_xu_w]
+== vfncvt.f.xu.w
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfncvt.f.xu.w vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x91,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfncvt_rod_f_f_w]
+== vfncvt.rod.f.f.w
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfncvt.rod.f.f.w vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0xa9,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfncvt_rtz_x_f_w]
+== vfncvt.rtz.x.f.w
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfncvt.rtz.x.f.w vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0xb9,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfncvt_rtz_xu_f_w]
+== vfncvt.rtz.xu.f.w
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfncvt.rtz.xu.f.w vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0xb1,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfncvt_x_f_w]
+== vfncvt.x.f.w
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfncvt.x.f.w vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x89,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfncvt_xu_f_w]
+== vfncvt.xu.f.w
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfncvt.xu.f.w vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x81,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfncvtbf16_f_f_w]
+== vfncvtbf16.f.f.w
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfncvtbf16.f.f.w vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0xe9,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvfbfmin* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfnmacc_vf]
+== vfnmacc.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfnmacc.vf vd, fs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfnmacc_vv]
+== vfnmacc.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfnmacc.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfnmadd_vf]
+== vfnmadd.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfnmadd.vf vd, fs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfnmadd_vv]
+== vfnmadd.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfnmadd.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfnmsac_vf]
+== vfnmsac.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfnmsac.vf vd, fs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfnmsac_vv]
+== vfnmsac.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfnmsac.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfnmsub_vf]
+== vfnmsub.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfnmsub.vf vd, fs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfnmsub_vv]
+== vfnmsub.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfnmsub.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfrdiv_vf]
+== vfrdiv.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfrdiv.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfrec7_v]
+== vfrec7.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfrec7.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x29,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x13,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfredmax_vs]
+== vfredmax.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfredmax.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x7,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfredmin_vs]
+== vfredmin.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfredmin.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x5,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfredosum_vs]
+== vfredosum.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfredosum.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfredusum_vs]
+== vfredusum.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfredusum.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfrsqrt7_v]
+== vfrsqrt7.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfrsqrt7.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x21,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x13,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfrsub_vf]
+== vfrsub.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfrsub.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x27,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfsgnj_vf]
+== vfsgnj.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfsgnj.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfsgnj_vv]
+== vfsgnj.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfsgnj.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfsgnjn_vf]
+== vfsgnjn.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfsgnjn.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfsgnjn_vv]
+== vfsgnjn.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfsgnjn.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfsgnjx_vf]
+== vfsgnjx.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfsgnjx.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfsgnjx_vv]
+== vfsgnjx.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfsgnjx.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfslide1down_vf]
+== vfslide1down.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfslide1down.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xf,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfslide1up_vf]
+== vfslide1up.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfslide1up.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xe,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfsqrt_v]
+== vfsqrt.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfsqrt.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x1,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x13,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfsub_vf]
+== vfsub.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfsub.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfsub_vv]
+== vfsub.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfsub.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwadd_vf]
+== vfwadd.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwadd.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwadd_vv]
+== vfwadd.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwadd.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwadd_wf]
+== vfwadd.wf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwadd.wf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x34,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwadd_wv]
+== vfwadd.wv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwadd.wv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x34,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwcvt_f_f_v]
+== vfwcvt.f.f.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwcvt.f.f.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x61,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwcvt_f_x_v]
+== vfwcvt.f.x.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwcvt.f.x.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x59,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwcvt_f_xu_v]
+== vfwcvt.f.xu.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwcvt.f.xu.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x51,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwcvt_rtz_x_f_v]
+== vfwcvt.rtz.x.f.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwcvt.rtz.x.f.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x79,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwcvt_rtz_xu_f_v]
+== vfwcvt.rtz.xu.f.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwcvt.rtz.xu.f.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x71,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwcvt_x_f_v]
+== vfwcvt.x.f.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwcvt.x.f.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x49,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwcvt_xu_f_v]
+== vfwcvt.xu.f.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwcvt.xu.f.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x41,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwcvtbf16_f_f_v]
+== vfwcvtbf16.f.f.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwcvtbf16.f.f.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x69,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvfbfmin* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwmacc_vf]
+== vfwmacc.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwmacc.vf vd, fs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwmacc_vv]
+== vfwmacc.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwmacc.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwmaccbf16_vf]
+== vfwmaccbf16.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwmaccbf16.vf vd, fs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvfbfwma* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwmaccbf16_vv]
+== vfwmaccbf16.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwmaccbf16.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvfbfwma* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwmsac_vf]
+== vfwmsac.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwmsac.vf vd, fs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3e,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwmsac_vv]
+== vfwmsac.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwmsac.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3e,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwmul_vf]
+== vfwmul.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwmul.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwmul_vv]
+== vfwmul.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwmul.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwnmacc_vf]
+== vfwnmacc.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwnmacc.vf vd, fs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwnmacc_vv]
+== vfwnmacc.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwnmacc.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwnmsac_vf]
+== vfwnmsac.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwnmsac.vf vd, fs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwnmsac_vv]
+== vfwnmsac.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwnmsac.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwredosum_vs]
+== vfwredosum.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwredosum.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x33,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwredusum_vs]
+== vfwredusum.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwredusum.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x31,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwsub_vf]
+== vfwsub.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwsub.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x32,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwsub_vv]
+== vfwsub.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwsub.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x32,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwsub_wf]
+== vfwsub.wf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwsub.wf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x36,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vfwsub_wv]
+== vfwsub.wv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vfwsub.wv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x36,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vghsh_vv]
+== vghsh.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vghsh.vv vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x59,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvkg* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vgmul_vv]
+== vgmul.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vgmul.vv vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x8a,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvkg* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vid_v]
+== vid.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vid.v vd, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":13,"name": 0x8a,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x14,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:viota_m]
+== viota.m
+
+Synopsis::
+No synopsis available
+
+Assembly::
+viota.m vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x82,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x14,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl1re16_v]
+== vl1re16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl1re16.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl1re32_v]
+== vl1re32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl1re32.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl1re64_v]
+== vl1re64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl1re64.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl1re8_v]
+== vl1re8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl1re8.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl2re16_v]
+== vl2re16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl2re16.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x228,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl2re32_v]
+== vl2re32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl2re32.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x228,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl2re64_v]
+== vl2re64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl2re64.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x228,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl2re8_v]
+== vl2re8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl2re8.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x228,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl4re16_v]
+== vl4re16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl4re16.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x628,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl4re32_v]
+== vl4re32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl4re32.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x628,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl4re64_v]
+== vl4re64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl4re64.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x628,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl4re8_v]
+== vl4re8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl4re8.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x628,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl8re16_v]
+== vl8re16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl8re16.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xe28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl8re32_v]
+== vl8re32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl8re32.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xe28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl8re64_v]
+== vl8re64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl8re64.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xe28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vl8re8_v]
+== vl8re8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vl8re8.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xe28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vle16_v]
+== vle16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vle16.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vle16ff_v]
+== vle16ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vle16ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vle32_v]
+== vle32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vle32.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vle32ff_v]
+== vle32ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vle32ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vle64_v]
+== vle64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vle64.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vle64ff_v]
+== vle64ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vle64ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vle8_v]
+== vle8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vle8.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vle8ff_v]
+== vle8ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vle8ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlm_v]
+== vlm.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlm.v vd, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxei16_v]
+== vloxei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxei32_v]
+== vloxei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxei64_v]
+== vloxei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxei8_v]
+== vloxei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg2ei16_v]
+== vloxseg2ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg2ei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xb,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg2ei32_v]
+== vloxseg2ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg2ei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xb,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg2ei64_v]
+== vloxseg2ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg2ei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xb,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg2ei8_v]
+== vloxseg2ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg2ei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xb,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg3ei16_v]
+== vloxseg3ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg3ei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x13,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg3ei32_v]
+== vloxseg3ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg3ei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x13,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg3ei64_v]
+== vloxseg3ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg3ei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x13,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg3ei8_v]
+== vloxseg3ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg3ei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x13,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg4ei16_v]
+== vloxseg4ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg4ei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg4ei32_v]
+== vloxseg4ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg4ei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg4ei64_v]
+== vloxseg4ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg4ei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg4ei8_v]
+== vloxseg4ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg4ei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg5ei16_v]
+== vloxseg5ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg5ei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg5ei32_v]
+== vloxseg5ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg5ei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg5ei64_v]
+== vloxseg5ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg5ei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg5ei8_v]
+== vloxseg5ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg5ei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg6ei16_v]
+== vloxseg6ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg6ei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg6ei32_v]
+== vloxseg6ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg6ei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg6ei64_v]
+== vloxseg6ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg6ei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg6ei8_v]
+== vloxseg6ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg6ei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg7ei16_v]
+== vloxseg7ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg7ei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x33,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg7ei32_v]
+== vloxseg7ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg7ei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x33,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg7ei64_v]
+== vloxseg7ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg7ei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x33,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg7ei8_v]
+== vloxseg7ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg7ei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x33,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg8ei16_v]
+== vloxseg8ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg8ei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg8ei32_v]
+== vloxseg8ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg8ei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg8ei64_v]
+== vloxseg8ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg8ei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vloxseg8ei8_v]
+== vloxseg8ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vloxseg8ei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlse16_v]
+== vlse16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlse16.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlse32_v]
+== vlse32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlse32.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlse64_v]
+== vlse64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlse64.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlse8_v]
+== vlse8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlse8.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg2e16_v]
+== vlseg2e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg2e16.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg2e16ff_v]
+== vlseg2e16ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg2e16ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg2e32_v]
+== vlseg2e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg2e32.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg2e32ff_v]
+== vlseg2e32ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg2e32ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg2e64_v]
+== vlseg2e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg2e64.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg2e64ff_v]
+== vlseg2e64ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg2e64ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg2e8_v]
+== vlseg2e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg2e8.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg2e8ff_v]
+== vlseg2e8ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg2e8ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg3e16_v]
+== vlseg3e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg3e16.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg3e16ff_v]
+== vlseg3e16ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg3e16ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg3e32_v]
+== vlseg3e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg3e32.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg3e32ff_v]
+== vlseg3e32ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg3e32ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg3e64_v]
+== vlseg3e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg3e64.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg3e64ff_v]
+== vlseg3e64ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg3e64ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg3e8_v]
+== vlseg3e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg3e8.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg3e8ff_v]
+== vlseg3e8ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg3e8ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg4e16_v]
+== vlseg4e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg4e16.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg4e16ff_v]
+== vlseg4e16ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg4e16ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg4e32_v]
+== vlseg4e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg4e32.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg4e32ff_v]
+== vlseg4e32ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg4e32ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg4e64_v]
+== vlseg4e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg4e64.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg4e64ff_v]
+== vlseg4e64ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg4e64ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg4e8_v]
+== vlseg4e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg4e8.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg4e8ff_v]
+== vlseg4e8ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg4e8ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg5e16_v]
+== vlseg5e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg5e16.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg5e16ff_v]
+== vlseg5e16ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg5e16ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg5e32_v]
+== vlseg5e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg5e32.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg5e32ff_v]
+== vlseg5e32ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg5e32ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg5e64_v]
+== vlseg5e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg5e64.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg5e64ff_v]
+== vlseg5e64ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg5e64ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg5e8_v]
+== vlseg5e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg5e8.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg5e8ff_v]
+== vlseg5e8ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg5e8ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg6e16_v]
+== vlseg6e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg6e16.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg6e16ff_v]
+== vlseg6e16ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg6e16ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg6e32_v]
+== vlseg6e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg6e32.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg6e32ff_v]
+== vlseg6e32ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg6e32ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg6e64_v]
+== vlseg6e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg6e64.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg6e64ff_v]
+== vlseg6e64ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg6e64ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg6e8_v]
+== vlseg6e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg6e8.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg6e8ff_v]
+== vlseg6e8ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg6e8ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg7e16_v]
+== vlseg7e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg7e16.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg7e16ff_v]
+== vlseg7e16ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg7e16ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg7e32_v]
+== vlseg7e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg7e32.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg7e32ff_v]
+== vlseg7e32ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg7e32ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg7e64_v]
+== vlseg7e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg7e64.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg7e64ff_v]
+== vlseg7e64ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg7e64ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg7e8_v]
+== vlseg7e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg7e8.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg7e8ff_v]
+== vlseg7e8ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg7e8ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg8e16_v]
+== vlseg8e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg8e16.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg8e16ff_v]
+== vlseg8e16ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg8e16ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg8e32_v]
+== vlseg8e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg8e32.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg8e32ff_v]
+== vlseg8e32ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg8e32ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg8e64_v]
+== vlseg8e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg8e64.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg8e64ff_v]
+== vlseg8e64ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg8e64ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg8e8_v]
+== vlseg8e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg8e8.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlseg8e8ff_v]
+== vlseg8e8ff.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlseg8e8ff.v vd, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x10,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg2e16_v]
+== vlsseg2e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg2e16.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg2e32_v]
+== vlsseg2e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg2e32.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg2e64_v]
+== vlsseg2e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg2e64.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg2e8_v]
+== vlsseg2e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg2e8.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg3e16_v]
+== vlsseg3e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg3e16.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg3e32_v]
+== vlsseg3e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg3e32.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg3e64_v]
+== vlsseg3e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg3e64.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg3e8_v]
+== vlsseg3e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg3e8.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg4e16_v]
+== vlsseg4e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg4e16.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg4e32_v]
+== vlsseg4e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg4e32.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg4e64_v]
+== vlsseg4e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg4e64.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg4e8_v]
+== vlsseg4e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg4e8.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg5e16_v]
+== vlsseg5e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg5e16.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x22,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg5e32_v]
+== vlsseg5e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg5e32.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x22,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg5e64_v]
+== vlsseg5e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg5e64.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x22,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg5e8_v]
+== vlsseg5e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg5e8.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x22,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg6e16_v]
+== vlsseg6e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg6e16.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg6e32_v]
+== vlsseg6e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg6e32.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg6e64_v]
+== vlsseg6e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg6e64.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg6e8_v]
+== vlsseg6e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg6e8.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg7e16_v]
+== vlsseg7e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg7e16.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x32,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg7e32_v]
+== vlsseg7e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg7e32.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x32,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg7e64_v]
+== vlsseg7e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg7e64.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x32,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg7e8_v]
+== vlsseg7e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg7e8.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x32,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg8e16_v]
+== vlsseg8e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg8e16.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg8e32_v]
+== vlsseg8e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg8e32.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg8e64_v]
+== vlsseg8e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg8e64.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vlsseg8e8_v]
+== vlsseg8e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vlsseg8e8.v vd, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxei16_v]
+== vluxei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxei32_v]
+== vluxei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxei64_v]
+== vluxei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxei8_v]
+== vluxei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg2ei16_v]
+== vluxseg2ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg2ei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg2ei32_v]
+== vluxseg2ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg2ei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg2ei64_v]
+== vluxseg2ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg2ei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg2ei8_v]
+== vluxseg2ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg2ei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg3ei16_v]
+== vluxseg3ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg3ei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x11,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg3ei32_v]
+== vluxseg3ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg3ei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x11,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg3ei64_v]
+== vluxseg3ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg3ei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x11,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg3ei8_v]
+== vluxseg3ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg3ei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x11,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg4ei16_v]
+== vluxseg4ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg4ei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x19,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg4ei32_v]
+== vluxseg4ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg4ei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x19,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg4ei64_v]
+== vluxseg4ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg4ei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x19,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg4ei8_v]
+== vluxseg4ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg4ei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x19,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg5ei16_v]
+== vluxseg5ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg5ei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg5ei32_v]
+== vluxseg5ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg5ei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg5ei64_v]
+== vluxseg5ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg5ei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg5ei8_v]
+== vluxseg5ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg5ei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg6ei16_v]
+== vluxseg6ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg6ei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg6ei32_v]
+== vluxseg6ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg6ei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg6ei64_v]
+== vluxseg6ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg6ei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg6ei8_v]
+== vluxseg6ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg6ei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg7ei16_v]
+== vluxseg7ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg7ei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x31,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg7ei32_v]
+== vluxseg7ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg7ei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x31,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg7ei64_v]
+== vluxseg7ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg7ei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x31,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg7ei8_v]
+== vluxseg7ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg7ei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x31,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg8ei16_v]
+== vluxseg8ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg8ei16.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x39,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg8ei32_v]
+== vluxseg8ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg8ei32.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x39,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg8ei64_v]
+== vluxseg8ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg8ei64.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x39,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vluxseg8ei8_v]
+== vluxseg8ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vluxseg8ei8.v vd, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x7,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x39,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmacc_vv]
+== vmacc.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmacc.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmacc_vx]
+== vmacc.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmacc.vx vd, xs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmadc_vi]
+== vmadc.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmadc.vi vd, vs2, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x23,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmadc_vim]
+== vmadc.vim
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmadc.vim vd, vs2, imm, v0
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x22,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmadc_vv]
+== vmadc.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmadc.vv vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x23,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmadc_vvm]
+== vmadc.vvm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmadc.vvm vd, vs2, vs1, v0
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x22,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmadc_vx]
+== vmadc.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmadc.vx vd, vs2, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x23,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmadc_vxm]
+== vmadc.vxm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmadc.vxm vd, vs2, xs1, v0
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x22,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmadd_vv]
+== vmadd.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmadd.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmadd_vx]
+== vmadd.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmadd.vx vd, xs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmand_mm]
+== vmand.mm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmand.mm vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x33,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmandn_mm]
+== vmandn.mm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmandn.mm vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x31,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmax_vv]
+== vmax.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmax.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x7,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmax_vx]
+== vmax.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmax.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x7,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmaxu_vv]
+== vmaxu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmaxu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x6,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmaxu_vx]
+== vmaxu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmaxu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x6,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmerge_vim]
+== vmerge.vim
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmerge.vim vd, vs2, imm, v0
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x2e,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmerge_vvm]
+== vmerge.vvm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmerge.vvm vd, vs2, vs1, v0
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x2e,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmerge_vxm]
+== vmerge.vxm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmerge.vxm vd, vs2, xs1, v0
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x2e,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmfeq_vf]
+== vmfeq.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmfeq.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmfeq_vv]
+== vmfeq.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmfeq.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmfge_vf]
+== vmfge.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmfge.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmfgt_vf]
+== vmfgt.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmfgt.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmfle_vf]
+== vmfle.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmfle.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x19,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmfle_vv]
+== vmfle.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmfle.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x19,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmflt_vf]
+== vmflt.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmflt.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmflt_vv]
+== vmflt.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmflt.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmfne_vf]
+== vmfne.vf
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmfne.vf vd, vs2, fs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "fs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|fs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmfne_vv]
+== vmfne.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmfne.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmin_vv]
+== vmin.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmin.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x5,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmin_vx]
+== vmin.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmin.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x5,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vminu_vv]
+== vminu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vminu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x4,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vminu_vx]
+== vminu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vminu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x4,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmnand_mm]
+== vmnand.mm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmnand.mm vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x3b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmnor_mm]
+== vmnor.mm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmnor.mm vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x3d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmor_mm]
+== vmor.mm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmor.mm vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x35,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmorn_mm]
+== vmorn.mm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmorn.mm vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x39,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsbc_vv]
+== vmsbc.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsbc.vv vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x27,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsbc_vvm]
+== vmsbc.vvm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsbc.vvm vd, vs2, vs1, v0
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x26,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsbc_vx]
+== vmsbc.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsbc.vx vd, vs2, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x27,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsbc_vxm]
+== vmsbc.vxm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsbc.vxm vd, vs2, xs1, v0
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x26,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsbf_m]
+== vmsbf.m
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsbf.m vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0xa,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x14,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmseq_vi]
+== vmseq.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmseq.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmseq_vv]
+== vmseq.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmseq.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmseq_vx]
+== vmseq.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmseq.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsgt_vi]
+== vmsgt.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsgt.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsgt_vx]
+== vmsgt.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsgt.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsgtu_vi]
+== vmsgtu.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsgtu.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1e,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsgtu_vx]
+== vmsgtu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsgtu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1e,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsif_m]
+== vmsif.m
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsif.m vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x1a,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x14,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsle_vi]
+== vmsle.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsle.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsle_vv]
+== vmsle.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsle.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsle_vx]
+== vmsle.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsle.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsleu_vi]
+== vmsleu.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsleu.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsleu_vv]
+== vmsleu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsleu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsleu_vx]
+== vmsleu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsleu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmslt_vv]
+== vmslt.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmslt.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmslt_vx]
+== vmslt.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmslt.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsltu_vv]
+== vmsltu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsltu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsltu_vx]
+== vmsltu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsltu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsne_vi]
+== vmsne.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsne.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x19,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsne_vv]
+== vmsne.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsne.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x19,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsne_vx]
+== vmsne.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsne.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x19,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmsof_m]
+== vmsof.m
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmsof.m vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x12,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x14,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmul_vv]
+== vmul.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmul.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x25,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmul_vx]
+== vmul.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmul.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x25,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmulh_vv]
+== vmulh.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmulh.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x27,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmulh_vx]
+== vmulh.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmulh.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x27,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmulhsu_vv]
+== vmulhsu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmulhsu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x26,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmulhsu_vx]
+== vmulhsu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmulhsu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x26,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmulhu_vv]
+== vmulhu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmulhu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x24,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmulhu_vx]
+== vmulhu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmulhu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x24,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmv_s_x]
+== vmv.s.x
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmv.s.x vd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x420,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmv_v_i]
+== vmv.v.i
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmv.v.i vd, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":12,"name": 0x5e0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmv_v_v]
+== vmv.v.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmv.v.v vd, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":12,"name": 0x5e0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmv_v_x]
+== vmv.v.x
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmv.v.x vd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x5e0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmv_x_s]
+== vmv.x.s
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmv.x.s xd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "xd","type":4},{"bits":8,"name": 0x2,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmv1r_v]
+== vmv1r.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmv1r.v vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x3,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x4f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmv2r_v]
+== vmv2r.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmv2r.v vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0xb,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x4f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmv4r_v]
+== vmv4r.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmv4r.v vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x1b,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x4f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmv8r_v]
+== vmv8r.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmv8r.v vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x3b,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x4f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmxnor_mm]
+== vmxnor.mm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmxnor.mm vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x3f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vmxor_mm]
+== vmxor.mm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vmxor.mm vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x37,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnclip_wi]
+== vnclip.wi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnclip.wi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnclip_wv]
+== vnclip.wv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnclip.wv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnclip_wx]
+== vnclip.wx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnclip.wx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnclipu_wi]
+== vnclipu.wi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnclipu.wi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2e,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnclipu_wv]
+== vnclipu.wv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnclipu.wv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2e,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnclipu_wx]
+== vnclipu.wx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnclipu.wx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2e,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnmsac_vv]
+== vnmsac.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnmsac.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnmsac_vx]
+== vnmsac.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnmsac.vx vd, xs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnmsub_vv]
+== vnmsub.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnmsub.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnmsub_vx]
+== vnmsub.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnmsub.vx vd, xs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnsra_wi]
+== vnsra.wi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnsra.wi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnsra_wv]
+== vnsra.wv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnsra.wv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnsra_wx]
+== vnsra.wx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnsra.wx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnsrl_wi]
+== vnsrl.wi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnsrl.wi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnsrl_wv]
+== vnsrl.wv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnsrl.wv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vnsrl_wx]
+== vnsrl.wx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vnsrl.wx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vor_vi]
+== vor.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vor.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vor_vv]
+== vor.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vor.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vor_vx]
+== vor.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vor.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vredand_vs]
+== vredand.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vredand.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vredmax_vs]
+== vredmax.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vredmax.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x7,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vredmaxu_vs]
+== vredmaxu.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vredmaxu.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x6,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vredmin_vs]
+== vredmin.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vredmin.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x5,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vredminu_vs]
+== vredminu.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vredminu.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x4,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vredor_vs]
+== vredor.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vredor.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vredsum_vs]
+== vredsum.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vredsum.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vredxor_vs]
+== vredxor.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vredxor.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vrem_vv]
+== vrem.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vrem.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vrem_vx]
+== vrem.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vrem.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vremu_vv]
+== vremu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vremu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x22,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vremu_vx]
+== vremu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vremu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x22,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vrev8_v]
+== vrev8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vrev8.v vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x4a,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vrgather_vi]
+== vrgather.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vrgather.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xc,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vrgather_vv]
+== vrgather.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vrgather.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xc,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vrgather_vx]
+== vrgather.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vrgather.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xc,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vrgatherei16_vv]
+== vrgatherei16.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vrgatherei16.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xe,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vrol_vv]
+== vrol.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vrol.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x15,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vrol_vx]
+== vrol.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vrol.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x15,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vror_vi]
+== vror.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vror.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm[4:0]","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":1,"name": "imm[5]","type":4},{"bits":5,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |{$encoding[26], $encoding[19:15]}
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vror_vv]
+== vror.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vror.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x14,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vror_vx]
+== vror.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vror.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x14,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vrsub_vi]
+== vrsub.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vrsub.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vrsub_vx]
+== vrsub.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vrsub.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vs1r_v]
+== vs1r.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vs1r.v vs3, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vs2r_v]
+== vs2r.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vs2r.v vs3, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x228,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vs4r_v]
+== vs4r.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vs4r.v vs3, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x628,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vs8r_v]
+== vs8r.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vs8r.v vs3, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0xe28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsadd_vi]
+== vsadd.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsadd.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsadd_vv]
+== vsadd.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsadd.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsadd_vx]
+== vsadd.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsadd.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsaddu_vi]
+== vsaddu.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsaddu.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsaddu_vv]
+== vsaddu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsaddu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsaddu_vx]
+== vsaddu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsaddu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsbc_vvm]
+== vsbc.vvm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsbc.vvm vd, vs2, vs1, v0
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x24,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsbc_vxm]
+== vsbc.vxm
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsbc.vxm vd, vs2, xs1, v0
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x24,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vse16_v]
+== vse16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vse16.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vse32_v]
+== vse32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vse32.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vse64_v]
+== vse64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vse64.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vse8_v]
+== vse8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vse8.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsetivli]
+== vsetivli
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsetivli xd, uimm, vtypei
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "uimm","type":4},{"bits":10,"name": "vtypei","type":4},{"bits":2,"name": 0x3,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vtypei |$encoding[29:20]
+|uimm |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsetvl]
+== vsetvl
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsetvl xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x40,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsetvli]
+== vsetvli
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsetvli xd, xs1, vtypei
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":11,"name": "xs1","type":4},{"bits":1,"name": 0x0,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[30:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsext_vf2]
+== vsext.vf2
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsext.vf2 vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x3a,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsext_vf4]
+== vsext.vf4
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsext.vf4 vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x2a,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsext_vf8]
+== vsext.vf8
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsext.vf8 vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x1a,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsha2ch_vv]
+== vsha2ch.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsha2ch.vv vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x5d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvknha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsha2cl_vv]
+== vsha2cl.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsha2cl.vv vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x5f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvknha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsha2ms_vv]
+== vsha2ms.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsha2ms.vv vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x5b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvknha* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vslide1down_vx]
+== vslide1down.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vslide1down.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xf,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vslide1up_vx]
+== vslide1up.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vslide1up.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xe,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vslidedown_vi]
+== vslidedown.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vslidedown.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xf,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vslidedown_vx]
+== vslidedown.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vslidedown.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xf,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vslideup_vi]
+== vslideup.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vslideup.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xe,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vslideup_vx]
+== vslideup.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vslideup.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xe,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsll_vi]
+== vsll.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsll.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x25,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsll_vv]
+== vsll.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsll.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x25,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsll_vx]
+== vsll.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsll.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x25,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsm_v]
+== vsm.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsm.v vs3, (xs1)
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsm3c_vi]
+== vsm3c.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsm3c.vi vd, vs2, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "zimm5","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x57,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|zimm5 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvks* | ~> 1.0.0
+
+| *Zvksh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsm3me_vv]
+== vsm3me.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsm3me.vv vd, vs2, vs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x41,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvks* | ~> 1.0.0
+
+| *Zvksh* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsm4k_vi]
+== vsm4k.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsm4k.vi vd, vs2, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "zimm5","type":4},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x43,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|zimm5 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvks* | ~> 1.0.0
+
+| *Zvksed* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsm4r_vs]
+== vsm4r.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsm4r.vs vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x82,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x53,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvks* | ~> 1.0.0
+
+| *Zvksed* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsm4r_vv]
+== vsm4r.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsm4r.vv vd, vs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x77,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x82,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":7,"name": 0x51,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvks* | ~> 1.0.0
+
+| *Zvksed* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsmul_vv]
+== vsmul.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsmul.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x27,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsmul_vx]
+== vsmul.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsmul.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x27,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxei16_v]
+== vsoxei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxei32_v]
+== vsoxei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxei64_v]
+== vsoxei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxei8_v]
+== vsoxei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg2ei16_v]
+== vsoxseg2ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg2ei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xb,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg2ei32_v]
+== vsoxseg2ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg2ei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xb,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg2ei64_v]
+== vsoxseg2ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg2ei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xb,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg2ei8_v]
+== vsoxseg2ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg2ei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xb,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg3ei16_v]
+== vsoxseg3ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg3ei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x13,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg3ei32_v]
+== vsoxseg3ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg3ei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x13,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg3ei64_v]
+== vsoxseg3ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg3ei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x13,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg3ei8_v]
+== vsoxseg3ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg3ei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x13,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg4ei16_v]
+== vsoxseg4ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg4ei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg4ei32_v]
+== vsoxseg4ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg4ei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg4ei64_v]
+== vsoxseg4ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg4ei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg4ei8_v]
+== vsoxseg4ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg4ei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg5ei16_v]
+== vsoxseg5ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg5ei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg5ei32_v]
+== vsoxseg5ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg5ei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg5ei64_v]
+== vsoxseg5ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg5ei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg5ei8_v]
+== vsoxseg5ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg5ei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg6ei16_v]
+== vsoxseg6ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg6ei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg6ei32_v]
+== vsoxseg6ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg6ei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg6ei64_v]
+== vsoxseg6ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg6ei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg6ei8_v]
+== vsoxseg6ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg6ei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg7ei16_v]
+== vsoxseg7ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg7ei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x33,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg7ei32_v]
+== vsoxseg7ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg7ei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x33,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg7ei64_v]
+== vsoxseg7ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg7ei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x33,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg7ei8_v]
+== vsoxseg7ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg7ei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x33,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg8ei16_v]
+== vsoxseg8ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg8ei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg8ei32_v]
+== vsoxseg8ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg8ei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg8ei64_v]
+== vsoxseg8ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg8ei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsoxseg8ei8_v]
+== vsoxseg8ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsoxseg8ei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsra_vi]
+== vsra.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsra.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsra_vv]
+== vsra.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsra.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsra_vx]
+== vsra.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsra.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsrl_vi]
+== vsrl.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsrl.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsrl_vv]
+== vsrl.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsrl.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsrl_vx]
+== vsrl.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsrl.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsse16_v]
+== vsse16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsse16.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsse32_v]
+== vsse32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsse32.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsse64_v]
+== vsse64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsse64.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsse8_v]
+== vsse8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsse8.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg2e16_v]
+== vsseg2e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg2e16.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg2e32_v]
+== vsseg2e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg2e32.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg2e64_v]
+== vsseg2e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg2e64.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg2e8_v]
+== vsseg2e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg2e8.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x8,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg3e16_v]
+== vsseg3e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg3e16.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg3e32_v]
+== vsseg3e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg3e32.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg3e64_v]
+== vsseg3e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg3e64.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg3e8_v]
+== vsseg3e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg3e8.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x10,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg4e16_v]
+== vsseg4e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg4e16.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg4e32_v]
+== vsseg4e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg4e32.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg4e64_v]
+== vsseg4e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg4e64.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg4e8_v]
+== vsseg4e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg4e8.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x18,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg5e16_v]
+== vsseg5e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg5e16.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg5e32_v]
+== vsseg5e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg5e32.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg5e64_v]
+== vsseg5e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg5e64.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg5e8_v]
+== vsseg5e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg5e8.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x20,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg6e16_v]
+== vsseg6e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg6e16.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg6e32_v]
+== vsseg6e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg6e32.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg6e64_v]
+== vsseg6e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg6e64.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg6e8_v]
+== vsseg6e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg6e8.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x28,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg7e16_v]
+== vsseg7e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg7e16.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg7e32_v]
+== vsseg7e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg7e32.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg7e64_v]
+== vsseg7e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg7e64.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg7e8_v]
+== vsseg7e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg7e8.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg8e16_v]
+== vsseg8e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg8e16.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg8e32_v]
+== vsseg8e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg8e32.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg8e64_v]
+== vsseg8e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg8e64.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsseg8e8_v]
+== vsseg8e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsseg8e8.v vs3, (xs1), vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssra_vi]
+== vssra.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssra.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssra_vv]
+== vssra.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssra.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssra_vx]
+== vssra.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssra.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssrl_vi]
+== vssrl.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssrl.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssrl_vv]
+== vssrl.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssrl.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssrl_vx]
+== vssrl.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssrl.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg2e16_v]
+== vssseg2e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg2e16.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg2e32_v]
+== vssseg2e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg2e32.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg2e64_v]
+== vssseg2e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg2e64.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg2e8_v]
+== vssseg2e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg2e8.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xa,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg3e16_v]
+== vssseg3e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg3e16.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg3e32_v]
+== vssseg3e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg3e32.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg3e64_v]
+== vssseg3e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg3e64.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg3e8_v]
+== vssseg3e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg3e8.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg4e16_v]
+== vssseg4e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg4e16.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg4e32_v]
+== vssseg4e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg4e32.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg4e64_v]
+== vssseg4e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg4e64.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg4e8_v]
+== vssseg4e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg4e8.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg5e16_v]
+== vssseg5e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg5e16.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x22,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg5e32_v]
+== vssseg5e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg5e32.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x22,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg5e64_v]
+== vssseg5e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg5e64.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x22,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg5e8_v]
+== vssseg5e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg5e8.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x22,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg6e16_v]
+== vssseg6e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg6e16.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg6e32_v]
+== vssseg6e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg6e32.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg6e64_v]
+== vssseg6e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg6e64.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg6e8_v]
+== vssseg6e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg6e8.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg7e16_v]
+== vssseg7e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg7e16.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x32,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg7e32_v]
+== vssseg7e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg7e32.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x32,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg7e64_v]
+== vssseg7e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg7e64.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x32,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg7e8_v]
+== vssseg7e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg7e8.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x32,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg8e16_v]
+== vssseg8e16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg8e16.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg8e32_v]
+== vssseg8e32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg8e32.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg8e64_v]
+== vssseg8e64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg8e64.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssseg8e8_v]
+== vssseg8e8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssseg8e8.v vs3, (xs1), xs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssub_vv]
+== vssub.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssub.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssub_vx]
+== vssub.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssub.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x23,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssubu_vv]
+== vssubu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssubu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x22,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vssubu_vx]
+== vssubu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vssubu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x22,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsub_vv]
+== vsub.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsub.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsub_vx]
+== vsub.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsub.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x2,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxei16_v]
+== vsuxei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxei32_v]
+== vsuxei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxei64_v]
+== vsuxei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxei8_v]
+== vsuxei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x1,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg2ei16_v]
+== vsuxseg2ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg2ei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg2ei32_v]
+== vsuxseg2ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg2ei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg2ei64_v]
+== vsuxseg2ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg2ei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg2ei8_v]
+== vsuxseg2ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg2ei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x9,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg3ei16_v]
+== vsuxseg3ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg3ei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x11,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg3ei32_v]
+== vsuxseg3ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg3ei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x11,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg3ei64_v]
+== vsuxseg3ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg3ei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x11,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg3ei8_v]
+== vsuxseg3ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg3ei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x11,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg4ei16_v]
+== vsuxseg4ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg4ei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x19,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg4ei32_v]
+== vsuxseg4ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg4ei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x19,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg4ei64_v]
+== vsuxseg4ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg4ei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x19,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg4ei8_v]
+== vsuxseg4ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg4ei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x19,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg5ei16_v]
+== vsuxseg5ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg5ei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg5ei32_v]
+== vsuxseg5ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg5ei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg5ei64_v]
+== vsuxseg5ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg5ei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg5ei8_v]
+== vsuxseg5ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg5ei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x21,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg6ei16_v]
+== vsuxseg6ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg6ei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg6ei32_v]
+== vsuxseg6ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg6ei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg6ei64_v]
+== vsuxseg6ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg6ei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg6ei8_v]
+== vsuxseg6ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg6ei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x29,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg7ei16_v]
+== vsuxseg7ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg7ei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x31,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg7ei32_v]
+== vsuxseg7ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg7ei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x31,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg7ei64_v]
+== vsuxseg7ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg7ei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x31,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg7ei8_v]
+== vsuxseg7ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg7ei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x31,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg8ei16_v]
+== vsuxseg8ei16.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg8ei16.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x5,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x39,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg8ei32_v]
+== vsuxseg8ei32.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg8ei32.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x39,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg8ei64_v]
+== vsuxseg8ei64.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg8ei64.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x7,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x39,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vsuxseg8ei8_v]
+== vsuxseg8ei8.v
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vsuxseg8ei8.v vs3, (xs1), vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x27,"type":2},{"bits":5,"name": "vs3","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x39,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vs3 |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwadd_vv]
+== vwadd.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwadd.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x31,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwadd_vx]
+== vwadd.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwadd.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x31,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwadd_wv]
+== vwadd.wv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwadd.wv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x35,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwadd_wx]
+== vwadd.wx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwadd.wx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x35,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwaddu_vv]
+== vwaddu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwaddu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwaddu_vx]
+== vwaddu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwaddu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwaddu_wv]
+== vwaddu.wv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwaddu.wv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x34,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwaddu_wx]
+== vwaddu.wx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwaddu.wx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x34,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwmacc_vv]
+== vwmacc.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwmacc.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwmacc_vx]
+== vwmacc.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwmacc.vx vd, xs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3d,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwmaccsu_vv]
+== vwmaccsu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwmaccsu.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwmaccsu_vx]
+== vwmaccsu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwmaccsu.vx vd, xs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3f,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwmaccu_vv]
+== vwmaccu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwmaccu.vv vd, vs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwmaccu_vx]
+== vwmaccu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwmaccu.vx vd, xs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3c,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwmaccus_vx]
+== vwmaccus.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwmaccus.vx vd, xs1, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3e,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwmul_vv]
+== vwmul.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwmul.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwmul_vx]
+== vwmul.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwmul.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3b,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwmulsu_vv]
+== vwmulsu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwmulsu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwmulsu_vx]
+== vwmulsu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwmulsu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x3a,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwmulu_vv]
+== vwmulu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwmulu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwmulu_vx]
+== vwmulu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwmulu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x38,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwredsum_vs]
+== vwredsum.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwredsum.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x31,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwredsumu_vs]
+== vwredsumu.vs
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwredsumu.vs vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x30,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwsll_vi]
+== vwsll.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwsll.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "zimm5","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x35,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|zimm5 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwsll_vv]
+== vwsll.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwsll.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x35,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwsll_vx]
+== vwsll.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwsll.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x35,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zvbb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwsub_vv]
+== vwsub.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwsub.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x33,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwsub_vx]
+== vwsub.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwsub.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x33,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwsub_wv]
+== vwsub.wv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwsub.wv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x37,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwsub_wx]
+== vwsub.wx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwsub.wx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x37,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwsubu_vv]
+== vwsubu.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwsubu.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x32,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwsubu_vx]
+== vwsubu.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwsubu.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x32,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwsubu_wv]
+== vwsubu.wv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwsubu.wv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x36,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vwsubu_wx]
+== vwsubu.wx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vwsubu.wx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x6,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x36,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vxor_vi]
+== vxor.vi
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vxor.vi vd, vs2, imm, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x3,"type":2},{"bits":5,"name": "imm","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xb,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|imm |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vxor_vv]
+== vxor.vv
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vxor.vv vd, vs2, vs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x0,"type":2},{"bits":5,"name": "vs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xb,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vxor_vx]
+== vxor.vx
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vxor.vx vd, vs2, xs1, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0xb,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vzext_vf2]
+== vzext.vf2
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vzext.vf2 vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x32,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vzext_vf4]
+== vzext.vf4
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vzext.vf4 vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x22,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:vzext_vf8]
+== vzext.vf8
+
+Synopsis::
+No synopsis available
+
+Assembly::
+vzext.vf8 vd, vs2, vm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x57,"type":2},{"bits":5,"name": "vd","type":4},{"bits":8,"name": 0x12,"type":2},{"bits":5,"name": "vs2","type":4},{"bits":1,"name": "vm","type":4},{"bits":6,"name": 0x12,"type":2}]}
+....
+
+Description::
+No description available.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|vm |$encoding[25]
+|vs2 |$encoding[24:20]
+|vd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *V* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:wfi]
+== wfi
+
+Synopsis::
+Wait for interrupt
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0x10500073,"type":2}]}
+....
+
+Description::
+Can causes the processor to enter a low-power state until the next interrupt occurs.
+
+<%- if ext?(:H) -%>
+The behavior of xref:insts:wfi.adoc#udb:doc:inst:wfi[wfi] is affected by the xref:csrs:mstatus.adoc#udb:doc:csr_field:mstatus:TW[mstatus.TW]
+and xref:csrs:hstatus.adoc#udb:doc:csr_field:hstatus:VTW[hstatus.VTW] bits, as summarized below.
+
+[%autowidth,%footer]
+|===
+.2+| [.rotate]#xref:csrs:mstatus.adoc#udb:doc:csr_field:mstatus:TW[mstatus.TW]# .2+| [.rotate]#xref:csrs:hstatus.adoc#udb:doc:csr_field:hstatus:VTW[hstatus.VTW]# 4+^.>| xref:insts:wfi.adoc#udb:doc:inst:wfi[wfi] behavior
+h| HS-mode h| U-mode h| VS-mode h| in VU-mode
+
+| 0 | 0 | Wait | Trap (I) | Wait | Trap (V)
+| 0 | 1 | Wait | Trap (I) | Trap (V) | Trap (V)
+| 1 | - | Trap (I) | Trap (I) | Trap (I) | Trap (I)
+
+6+| Trap (I) - Trap with `Illegal Instruction` code +
+Trap (V) - Trap with `Virtual Instruction` code
+|===
+
+<%- else -%>
+The xref:insts:wfi.adoc#udb:doc:inst:wfi[wfi] instruction is also affected by xref:csrs:mstatus.adoc#udb:doc:csr_field:mstatus:TW[mstatus.TW], as shown below:
+
+[%autowidth,%footer]
+|===
+.2+| [.rotate]#xref:csrs:mstatus.adoc#udb:doc:csr_field:mstatus:TW[mstatus.TW]# 2+^.>| xref:insts:wfi.adoc#udb:doc:inst:wfi[wfi] behavior
+h| S-mode h| U-mode
+
+| 0 | Wait | Trap (I)
+| 1 | Trap (I) | Trap (I)
+
+3+| Trap (I) - Trap with `Illegal Instruction` code
+|===
+
+<%- end -%>
+
+When xref:insts:wfi.adoc#udb:doc:inst:wfi[wfi] is marked as causing a trap above, the implementation is allowed to wait
+for an unspecified period of time to see if an interrupt occurs before raising the trap.
+That period of time can be zero (_i.e._, xref:insts:wfi.adoc#udb:doc:inst:wfi[wfi] always causes a trap in the cases identified
+above).
+
+
+Decode Variables::
+wfi has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Sm* | ~> 1.11.0
+
+|===
+
+
+[#udb:doc:inst:wrs_nto]
+== wrs.nto
+
+Synopsis::
+Wait-on-Reservation-Set-with-No-Timeout
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0xd00073,"type":2}]}
+....
+
+Description::
+To mitigate the wasteful looping in such usages, a xref:insts:wrs_nto.adoc#udb:doc:inst:wrs_nto[wrs.nto] (WRS-with-no-timeout) instruction is provided.
+Instead of polling for a store to a specific memory location, software registers a reservation set that
+includes all the bytes of the memory location using the LR instruction. Then a subsequent xref:insts:wrs_nto.adoc#udb:doc:inst:wrs_nto[wrs.nto]
+instruction would cause the hart to temporarily stall execution in a low-power state until a store
+occurs to the reservation set or an interrupt is observed.
+
+This instruction is not supported in a constrained LR/SC loop.
+While stalled, an implementation is permitted to occasionally terminate the stall and complete
+execution for any reason.
+
+xref:insts:wrs_nto.adoc#udb:doc:inst:wrs_nto[wrs.nto] follows the rules of the WFI instruction for resuming execution
+on a pending interrupt.
+
+When the TW (Timeout Wait) bit in xref:csrs:mstatus.adoc#udb:doc:csr:mstatus[mstatus] is set and xref:insts:wrs_nto.adoc#udb:doc:inst:wrs_nto[wrs.nto] is executed
+in any privilege mode otherthan M mode, and it does not complete within an implementation-specific
+bounded time limit, the xref:insts:wrs_nto.adoc#udb:doc:inst:wrs_nto[wrs.nto] instruction will cause an illegal instruction exception.
+
+When executing in VS or VU mode, if the VTW bit is set in xref:csrs:hstatus.adoc#udb:doc:csr:hstatus[hstatus], the TW bit in xref:csrs:mstatus.adoc#udb:doc:csr:mstatus[mstatus] is clear,
+and the xref:insts:wrs_nto.adoc#udb:doc:inst:wrs_nto[wrs.nto] does not complete within an implementation-specific bounded time limit,
+the xref:insts:wrs_nto.adoc#udb:doc:inst:wrs_nto[wrs.nto] instruction will cause a virtual instruction exception.
+
+[Note]
+Since xref:insts:wrs_nto.adoc#udb:doc:inst:wrs_nto[wrs.nto] can complete execution for reasons other than stores to the reservation set,
+software will likely need a means of looping until the required stores have occurred.
+
+[Note]
+xref:insts:wrs_nto.adoc#udb:doc:inst:wrs_nto[wrs.nto], unlike WFI, is not specified to cause an illegal instruction exception if executed in U-mode
+when the governing TW bit is 0. WFI is typically not expected to be used in U-mode and on many systems
+may promptly cause an illegal instruction exception if used at U-mode.
+Unlike WFI, xref:insts:wrs_nto.adoc#udb:doc:inst:wrs_nto[wrs.nto] is expected to be used by software in U-mode when waiting on memory but without
+a deadline for that wait.
+
+
+Decode Variables::
+wrs.nto has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zawrs* | ~> 1.0.1
+
+|===
+
+
+[#udb:doc:inst:wrs_sto]
+== wrs.sto
+
+Synopsis::
+Wait-on-Reservation-Set-with-Short-Timeout
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":32,"name": 0x1d00073,"type":2}]}
+....
+
+Description::
+Instead of polling for a store to a specific memory location, software registers a
+reservation set that includes all the bytes of the memory location using the LR instruction.
+A subsequent xref:insts:wrs_sto.adoc#udb:doc:inst:wrs_sto[wrs.sto] instruction would cause the hart to temporarily stall execution in a
+low-power state until a store occurs to the reservation set or an interrupt is observed.
+Sometimes the program waiting on a memory update may also need to carry out a task at a future time
+or otherwise place an upper bound on the wait. To support such use cases, xref:insts:wrs_sto.adoc#udb:doc:inst:wrs_sto[wrs.sto] bounds the
+stall duration to an implementation-define short timeout such that the stall is terminated on the
+timeout if no other conditions have occurred to terminate the stall. The program using this instruction
+may then determine if its deadline has been reached.
+xref:insts:wrs_sto.adoc#udb:doc:inst:wrs_sto[wrs.sto] causes the hart to temporarily stall execution in a low-power state as long as the reservation
+set is valid and no pending interrupts, even if disabled, are observed. For xref:insts:wrs_sto.adoc#udb:doc:inst:wrs_sto[wrs.sto] the stall duration
+is bounded by an implementation defined short timeout. These instructions are not supported in a
+constrained LR/SC loop.
+Hart execution may be stalled while the following conditions are all satisfied:
+a. The reservation set is valid
+b. If xref:insts:wrs_sto.adoc#udb:doc:inst:wrs_sto[wrs.sto], a "short" duration since start of stall has not elapsed
+c. No pending interrupt is observed (see the rules below)
+
+While stalled, an implementation is permitted to occasionally terminate the stall and complete
+execution for any reason. xref:insts:wrs_sto.adoc#udb:doc:inst:wrs_sto[wrs.sto] follows the rules of the WFI instruction for resuming execution
+on a pending interrupt. Since xref:insts:wrs_sto.adoc#udb:doc:inst:wrs_sto[wrs.sto] can complete execution for reasons other than stores to
+the reservation set, software will likely need a means of looping until the required stores have occurred.
+
+[Note]
+The duration of a xref:insts:wrs_sto.adoc#udb:doc:inst:wrs_sto[wrs.sto] instruction's timeout may vary significantly within and among implementations.
+In typical implementations this duration should be roughly in the range of 10 to 100 times an on-chip
+cache miss latency or a cacheless access to main memory.
+
+
+Decode Variables::
+wrs.sto has no decode variables.
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zawrs* | ~> 1.0.1
+
+|===
+
+
+[#udb:doc:inst:xnor]
+== xnor
+
+Synopsis::
+Exclusive NOR
+
+Assembly::
+xnor xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x20,"type":2}]}
+....
+
+Description::
+Performs the bit-wise exclusive-NOR operation on xs1 and xs2.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbb* | ~> 1.0.0
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:xor]
+== xor
+
+Synopsis::
+Exclusive Or
+
+Assembly::
+xor xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x0,"type":2}]}
+....
+
+Description::
+Exclusive or xs1 with xs2, and store the result in xd
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:xori]
+== xori
+
+Synopsis::
+Exclusive Or immediate
+
+Assembly::
+xori xd, xs1, imm
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": "imm","type":4}]}
+....
+
+Description::
+Exclusive or an immediate to the value in xs1, and store the result in xd
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|imm |$encoding[31:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *I* | ~> 2.1.0
+
+|===
+
+
+[#udb:doc:inst:xperm4]
+== xperm4
+
+Synopsis::
+Crossbar permutation (nibbles)
+
+Assembly::
+xperm4 xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x2,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x14,"type":2}]}
+....
+
+Description::
+The xperm4 instruction operates on nibbles. The xs1 register contains a vector of XLEN/4 4-bit
+elements. The xs2 register contains a vector of XLEN/4 4-bit indexes. The result is each element in
+xs2 replaced by the indexed element in xs1, or zero if the index into xs2 is out of bounds.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbkx* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:xperm8]
+== xperm8
+
+Synopsis::
+Crossbar permutation (bytes)
+
+Assembly::
+xperm8 xd, xs1, xs2
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": "xs2","type":4},{"bits":7,"name": 0x14,"type":2}]}
+....
+
+Description::
+The xperm8 instruction operates on bytes. The xs1 register contains a vector of XLEN/8 8-bit
+elements. The xs2 register contains a vector of XLEN/8 8-bit indexes. The result is each element in
+xs2 replaced by the indexed element in xs1, or zero if the index into xs2 is out of bounds.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs2 |$encoding[24:20]
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbkx* | ~> 1.0.0
+
+|===
+
+
+[#udb:doc:inst:zext_h]
+== zext.h
+
+Synopsis::
+Zero-extend halfword
+
+Assembly::
+zext.h xd, xs1
+
+Encoding::
+[NOTE]
+This instruction has different encodings in RV32 and RV64
+
+RV32::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x33,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x80,"type":2}]}
+....
+
+RV64::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x3b,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x4,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x80,"type":2}]}
+....
+
+Description::
+Zero-extends the least-significant halfword of the source to XLEN by inserting
+0's into all of the bits more significant than 15.
+
+[NOTE]
+The *zext.h* instruction is a pseudo-op for xref:insts:pack.adoc#udb:doc:inst:pack[pack] when xref:exts:Zbkb.adoc#udb:doc:ext:Zbkb[Zbkb] is implemented and XLEN == 32.
+
+[NOTE]
+The *zext.h* instruction is a pseudo-op for xref:insts:packw.adoc#udb:doc:inst:packw[packw] when xref:exts:Zbkb.adoc#udb:doc:ext:Zbkb[Zbkb] is implemented and XLEN == 64.
+
+
+Decode Variables::
+*RV32:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+*RV64:*
+
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+* allOf:
+*** Zbb, version >= Zbb@1.0.0
+*** not:
+***** Zbkb, version >= Zbkb@1.0.0
+
+
+[#udb:doc:inst:zip]
+== zip
+
+Synopsis::
+Bit interleave
+
+Assembly::
+zip xd, xs1
+
+Encoding::
+[wavedrom, ,svg,subs='attributes',width="100%"]
+....
+{"reg":[{"bits":7,"name": 0x13,"type":2},{"bits":5,"name": "xd","type":4},{"bits":3,"name": 0x1,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":12,"name": 0x8f,"type":2}]}
+....
+
+Description::
+Scatters all of the odd and even bits of a source word into the high and low halves
+of a destination word. It is the inverse of the unzip instruction. This instruction is available only on
+RV32.
+
+
+Decode Variables::
+[width="100%", cols="1,2", options="header"]
+|===
+|Variable Name |Location
+|xs1 |$encoding[19:15]
+|xd |$encoding[11:7]
+|===
+
+Included in::
+[options="autowrap,autowidth"]
+|===
+| Extension | Version
+
+| *Zbkb* | ~> 1.0.0
+
+|===
+
+

--- a/spec/std/isa/inst_type/I.yaml
+++ b/spec/std/isa/inst_type/I.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../schemas/inst_type_schema.json#
+
+$schema: inst_type_schema.json#
+kind: instruction_type
+name: I
+description: I-type instructions usually have one source register, an immediate value, and one destination register
+length: 32
+opcodes:
+  funct3:
+    location: 14-12
+  opcode:
+    location: 6-0
+variables:
+  imm:
+    location: 31-20
+  rs1:
+    location: 19-15
+  rd:
+    location: 11-7


### PR DESCRIPTION
In (#686), a new instruction schema was created
for types/subtypes. This commit add the schema
for the I-type. It is also part of effort in (#655).