### PR TITLE
fix: replace `-` and `.` with `_` in generated C header

### DIFF
--- a/backends/generators/c_header/generate_encoding.py
+++ b/backends/generators/c_header/generate_encoding.py
@@ -79,7 +79,10 @@ def load_exception_codes(ext_dir, enabled_extensions=None, include_all=False):
 
                     if num is not None and name is not None:
                         sanitized_name = (
-                            name.lower().replace(" ", "_").replace("/", "_")
+                            name.lower()
+                            .replace(" ", "_")
+                            .replace("/", "_")
+                            .replace("-", "_")
                         )
                         exception_codes.append((num, sanitized_name))
 
@@ -361,8 +364,8 @@ def main():
     csr_names_str = ""
     declare_csr_str = ""
     for addr, name in sorted(csrs.items()):
-        csr_names_str += f"#define CSR_{name.upper()} 0x{addr:x}\n"
-        declare_csr_str += f"DECLARE_CSR({name.lower()}, CSR_{name.upper()})\n"
+        csr_names_str += f"#define CSR_{name.upper().replace(".","_")} 0x{addr:x}\n"
+        declare_csr_str += f"DECLARE_CSR({name.lower().replace(".","_")}, CSR_{name.upper().replace(".","_")})\n"
 
     causes_str = ""
     declare_cause_str = ""


### PR DESCRIPTION
`-` and `.` are not legal in the name of a `#define` in C. This replaces `-` and `.` with `_` in CSR and exception code names in the generated C header, as is already done for instruction names.

Currently, invalid examples are emitted in the "C header" (`gen/c_header/encoding.out.h`) generated via `./do gen:c_header`, for example:
```
#define CSR_MSTATUSH.RV32 0x310
#define CSR_MEDELEGH.RV32 0x312
#define CSR_MENVCFGH.RV32 0x31a
[...]
#define CAUSE_ENVIRONMENT_CALL_FROM_VS-MODE 0xa
#define CAUSE_ENVIRONMENT_CALL_FROM_M-MODE 0xb
```
With proposed changes:
```
#define CSR_MSTATUSH_RV32 0x310
#define CSR_MEDELEGH_RV32 0x312
#define CSR_MENVCFGH_RV32 0x31a
[...]
#define CAUSE_ENVIRONMENT_CALL_FROM_VS_MODE 0xa
#define CAUSE_ENVIRONMENT_CALL_FROM_M_MODE 0xb
```