### PR TITLE
Xqci: sign extend imm in qc.insbi/insbri

### DIFF
--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.insbi.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.insbi.yaml
@@ -39,4 +39,5 @@ operation(): |
   XReg width = width_minus1 + 1;
   XReg mask = ((32'b1 << width) - 1) << shamt;
   XReg orig_val = X[rd];
-  X[rd] = (orig_val & ~mask) | ((imm << shamt) & mask);
+  XReg src = $signed(imm);
+  X[rd] = (orig_val & ~mask) | ((src << shamt) & mask);

--- a/spec/custom/isa/qc_iu/inst/Xqci/qc.insbri.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqci/qc.insbri.yaml
@@ -43,5 +43,6 @@ operation(): |
   if (width > 0) {
     XReg mask = ((32'b1 << width) - 1) << shamt;
     XReg orig_val = X[rd];
-    X[rd] = (orig_val & ~mask) | ((imm << shamt) & mask);
+    XReg src = $signed(imm);
+    X[rd] = (orig_val & ~mask) | ((src << shamt) & mask);
   }


### PR DESCRIPTION
The 5-bit immediate argument needs to be sign extended to XLEN to account for larger than 5-bit subsets of a negative immediate.

As an example consider and qc.e.ori and qc.insbi which here should produce the same output 0x1ffff

  li t1, 0x10000
  qc.e.ori t0, t1, 0xffff ; -> t0 = 0x1ffff
  qc.insbi t1, -1, 16, 0  ; -> t1 = 0x1ffff

for qc.insbi this only works if imm is sign extended 0x1f -> 0xffffffff, otherwise the subset inserted is simply 0x1f and we get 0x1001f as output.

The same problem exists for qc.insbri.