### PR TITLE
Remove extension version numbers from certificate model YAML files

### DIFF
--- a/spec/std/isa/proc_cert_model/MC100-32.yaml
+++ b/spec/std/isa/proc_cert_model/MC100-32.yaml
@@ -102,27 +102,20 @@ unpriv_isa_manual_revision: "20191213"
 priv_isa_manual_revision: "20190608-Priv-MSU-Ratified"
 debug_manual_revision: "0.13.2"
 
-# XXX - Remove version information since specifying priv/unpriv ISA manual should imply this.
 extensions:
   I:
-    version: "~> 2.1"
     presence: mandatory
   C:
-    version: "~> 2.2"
     presence: mandatory
   M:
-    version: "~> 2.0"
     presence: optional
   Zicsr:
-    version: "~> 2.0"
     presence: mandatory
   Zicntr:
-    version: "~> 2.0"
     presence: mandatory
     param_constraints:
       TIME_CSR_IMPLEMENTED: {} # Unconstrained
   Sm:
-    version: "~> 1.11.0"
     presence: mandatory
     param_constraints:
       MTVEC_BASE_ALIGNMENT_DIRECT: {} # Unconstrained

--- a/spec/std/isa/proc_cert_model/MockProcessor.yaml
+++ b/spec/std/isa/proc_cert_model/MockProcessor.yaml
@@ -81,7 +81,6 @@ extensions:
         schema:
           contains: { const: DEF }
   C:
-    version: "~> 2.2"
     presence: mandatory
     param_constraints:
       MUTABLE_MISA_C:
@@ -93,15 +92,12 @@ extensions:
   M:
     presence: mandatory
   Zicsr:
-    version: "~> 2.0"
     presence: mandatory
   Zicntr:
-    version: "~> 2.0"
     presence: mandatory
     param_constraints:
       TIME_CSR_IMPLEMENTED: {} # Unconstrained
   Sm:
-    version: "~> 1.11"
     presence: mandatory
     param_constraints:
       MTVEC_BASE_ALIGNMENT_DIRECT: {} # Unconstrained
@@ -180,7 +176,6 @@ extensions:
           const: 64
   B:
     presence: mandatory
-    version: "~> 1.0"
     note: "Added this as mandatory to see if Zba, Zbb, and Zbs are included."
 
 requirement_groups:


### PR DESCRIPTION
Fixes #325

This PR removes extension version numbers from certificate model YAML files since they specify the version of the related standards.

## Changes Made

- Removed `version` fields from extensions in `MC100-32.yaml` and `MockProcessor.yaml`
- Extension versions are now implied by the spec versions (`unpriv_isa_manual_revision`, `priv_isa_manual_revision`)
- The system automatically uses minimum extension versions when no version is specified
- This aligns with the goal that certificate model version numbers should determine spec versions

## Background

As mentioned in issue #325, the plan is to change the major version number when newer spec versions are required. So, MC100v1 would use these old 2019 specs and then v2 would use the next ratified versions of the specs and so on.

## Testing

- Verified that YAML files are still valid
- The Ruby code gracefully handles missing version information by falling back to minimum extension versions
- No breaking changes to existing functionality

## Files Changed

- `spec/std/isa/proc_cert_model/MC100-32.yaml`
- `spec/std/isa/proc_cert_model/MockProcessor.yaml`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author