### PR TITLE
FIXES ISSUE #827: Improve Zclsd Constraint Visibility Outside of operation() Function

### DIFF
--- a/spec/std/isa/inst/C/c.ld.yaml
+++ b/spec/std/isa/inst/C/c.ld.yaml
@@ -18,6 +18,7 @@ definedBy:
     - C
     - Zca
     - Zclsd
+base: 32
 assembly: xd, imm(xs1)
 encoding:
   RV32:


### PR DESCRIPTION
this PR resolves issue #827 by moving the `Zclsd` constraint from the `operation()` function to the instruction-level `definedBy` field in `c.ld.yaml`, improving visibility for downstream tools such as disassemblers that do not evaluate `operation()` logic

why not used the suggested schema format?

```yaml
definedBy:
  RV32:
    name: Zclsd
  RV64:
    anyOf:
      - name: C
      - name: Zca
````

This format is not valid under the current `inst_schema.json` constraints. Specifically, `definedBy` only supports `string`, `anyOf`, `allOf`, `oneOf`, or `not` constructs based on `requires_entry`, and does not allow architecture-specific keys like `RV32` or `RV64` So this approach had to be adapted within the allowed schema
