### PR TITLE
B/rev8: use the new instruction schema

### DIFF
--- a/spec/std/isa/inst/B/rev8.yaml
+++ b/spec/std/isa/inst/B/rev8.yaml
@@ -20,21 +20,31 @@ description: |
 definedBy:
   anyOf: [Zbb, Zbkb]
 assembly: xd, xs1
-encoding:
+format:
   RV32:
-    match: 011010011000-----101-----0010011
+    $inherits:
+      - inst_subtype/I/I-x-x.yaml#/data
+    opcodes:
+      funct3:
+        display_name: REV8
+        value: 0b101
+      opcode: { $inherits: inst_opcode/OP-IMM.yaml#/data }
     variables:
-      - name: xs1
-        location: 19-15
-      - name: xd
-        location: 11-7
+      imm:
+        $inherits: inst_var/I-imm.yaml#/data
+        value: 0b011010011000
   RV64:
-    match: 011010111000-----101-----0010011
+    $inherits:
+      - inst_subtype/I/I-x-x.yaml#/data
+    opcodes:
+      funct3:
+        display_name: REV8
+        value: 0b101
+      opcode: { $inherits: inst_opcode/OP-IMM.yaml#/data }
     variables:
-      - name: xs1
-        location: 19-15
-      - name: xd
-        location: 11-7
+      imm:
+        $inherits: inst_var/I-imm.yaml#/data
+        value: 0b011010111000
 access:
   s: always
   u: always

--- a/spec/std/isa/inst_opcode/OP-IMM.yaml
+++ b/spec/std/isa/inst_opcode/OP-IMM.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Usman Akinyemi
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../schemas/inst_opcode_schema.json#
+
+$schema: inst_opcode_schema.json#
+kind: instruction_opcode
+name: OP-IMM
+
+data:
+  display_name: OP-IMM
+  value: 0b0010011


### PR DESCRIPTION
In (#686), a new instruction schema was created
for types/subtypes. This commit change B/rev8
instruction to use the new schema. It is also part of effort in (#655).