### PR TITLE
feat: make all deploy actions dry-run from regress

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -6,10 +6,16 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      dry-run:
+        required: true
+        type: boolean
 env:
   SINGULARITY: 1
 jobs:
   build-reuse-manifest:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
 
     steps:
@@ -18,6 +24,7 @@ jobs:
       - name: run reuse
         run: ./bin/reuse spdx
   build-udb-api-doc:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -27,6 +34,7 @@ jobs:
       - name: Generate UDB API Docs
         run: ./do gen:udb:api_doc
   build-isa-explorer-csr:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -36,6 +44,7 @@ jobs:
       - name: Generate ISA Explorer CSR
         run: ./do gen:isa_explorer_browser_csr
   build-isa-explorer-ext:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -45,6 +54,7 @@ jobs:
       - name: Generate ISA Explorer Extension
         run: ./do gen:isa_explorer_browser_ext
   build-isa-explorer-inst:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -54,6 +64,7 @@ jobs:
       - name: Generate ISA Explorer Instructions
         run: ./do gen:isa_explorer_browser_insts
   build-isa-explorer-spreadsheet:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -63,6 +74,7 @@ jobs:
       - name: Generate ISA Explorer Spreadsheet
         run: ./do gen:isa_explorer_browser_spreadsheet
   build-html-isa-manual:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     env:
       MANUAL_NAME: isa
@@ -75,6 +87,7 @@ jobs:
       - name: Generate HTML ISA manual
         run: ./do gen:html_manual
   build-html-cfg-isa-manual:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -84,6 +97,7 @@ jobs:
       - name: Generate HTML ISA manual for a config
         run: ./do gen:html[example_rv64_with_overlay]
   build-instruction-appendix:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -93,6 +107,7 @@ jobs:
       - name: Generate instruction appendix
         run: ./do gen:instruction_appendix
   build-rvi20-profile:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -102,6 +117,7 @@ jobs:
       - name: Generate RVI20
         run: ./do gen:profile_release_pdf[RVI20]
   build-rva20-profile:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -111,6 +127,7 @@ jobs:
       - name: Generate RVA20
         run: ./do gen:profile_release_pdf[RVA20]
   build-rva22-profile:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -120,6 +137,7 @@ jobs:
       - name: Generate RVA22
         run: ./do gen:profile_release_pdf[RVA22]
   build-rva23-profile:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -129,6 +147,7 @@ jobs:
       - name: Generate RVA23
         run: ./do gen:profile_release_pdf[RVA23]
   build-rvb23-profile:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -138,6 +157,7 @@ jobs:
       - name: Generate RVB23
         run: ./do gen:profile_release_pdf[RVB23]
   build-ac100-crd:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -147,6 +167,7 @@ jobs:
       - name: Generate AC100 CRD
         run: ./do gen:proc_crd_pdf[AC100]
   build-ac200-crd:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -156,6 +177,7 @@ jobs:
       - name: Generate AC200 CRD
         run: ./do gen:proc_crd_pdf[AC200]
   build-mc100-32-crd:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -165,6 +187,7 @@ jobs:
       - name: Generate MC100-32 CRD
         run: ./do gen:proc_crd_pdf[MC100-32]
   build-mc100-64-crd:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -174,6 +197,7 @@ jobs:
       - name: Generate MC100-64 CRD
         run: ./do gen:proc_crd_pdf[MC100-64]
   build-mc200-32-crd:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -183,6 +207,7 @@ jobs:
       - name: Generate MC200-32 CRD
         run: ./do gen:proc_crd_pdf[MC200-32]
   build-mc200-64-crd:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -192,6 +217,7 @@ jobs:
       - name: Generate MC200-64 CRD
         run: ./do gen:proc_crd_pdf[MC200-64]
   build-mc300-32-crd:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -201,6 +227,7 @@ jobs:
       - name: Generate MC300-32 CRD
         run: ./do gen:proc_crd_pdf[MC300-32]
   build-mc300-64-crd:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action
@@ -210,6 +237,7 @@ jobs:
       - name: Generate MC300-64 CRD
         run: ./do gen:proc_crd_pdf[MC300-64]
   build-mc100-32-ctp:
+    if: inputs.dry-run == false
     runs-on: ubuntu-latest
     steps:
       - name: Clone Github Repo Action

--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -201,3 +201,7 @@ jobs:
         uses: ./.github/actions/singularity-setup
       - name: Run cpp unit tests
         run: ./do test:cpp_hart CONFIG=rv64 JOBS=4
+  call-deploy:
+    uses: ./.github/workflows/merge.yml
+    with:
+      dry-run: true


### PR DESCRIPTION
This should let us make sure PRs fail in the merge queue if they fail to build a deployment target