### PR TITLE
fix(csr): add Q-bit in sw_read()

### DIFF
--- a/spec/std/isa/csr/misa.yaml
+++ b/spec/std/isa/csr/misa.yaml
@@ -236,6 +236,7 @@ sw_read(): |
     (CSR[misa].V << 21) |
     (CSR[misa].U << 20) |
     (CSR[misa].S << 18) |
+    (CSR[misa].Q << 16) |
     (CSR[misa].M << 12) |
     (CSR[misa].I << 7) |
     (CSR[misa].H << 6) |


### PR DESCRIPTION
Added bit 16 to sw_read for Q-bit according to Table 10 in Section 3.1.1. of [The RISC-V Instruction Set Manual Volume II] [1].

[1] <https://drive.google.com/file/d/17GeetSnT5wW3xNuAHI95-SI1gPGd5sJ_/view?usp=drive_link> 'Privileged Architecture'