### PR TITLE
Implement H extension in IDL with proper page table translation

### DIFF
--- a/spec/std/isa/ext/H.yaml
+++ b/spec/std/isa/ext/H.yaml
@@ -663,3 +663,106 @@ params:
     schema:
       type: boolean
     extra_validation: assert STVEC_MODE_DIRECT || STVEC_MODE_VECTORED
+
+
+cert_test_procedures:
+  - id: ext.H.enable_disable
+    description: Test enabling and disabling the H extension via misa.H bit
+    steps: |
+      . Setup
+      .. Ensure misa.H is mutable (MUTABLE_MISA_H is true)
+      . Enable H extension
+      .. Set misa.H = 1
+      .. Verify hypervisor_enabled() returns true
+      . Disable H extension
+      .. Set misa.H = 0
+      .. Verify hypervisor_enabled() returns false
+      . Check
+      .. Fail unless enabling/disabling H works as expected
+
+  - id: ext.H.virtualization_modes
+    description: Test entering and exiting virtualization modes (V, HS, VS, VU)
+    steps: |
+      . Setup
+      .. Enable H extension
+      . Enter VS-mode
+      .. Set V = 1, mode = S
+      .. Verify in_vs_mode() returns true
+      . Enter VU-mode
+      .. Set V = 1, mode = U
+      .. Verify in_vu_mode() returns true
+      . Enter HS-mode
+      .. Set V = 0, mode = S
+      .. Verify in_hs_mode() returns true
+      . Check
+      .. Fail unless mode transitions and checks work as expected
+
+  - id: ext.H.two_stage_translation
+    description: Test two-stage address translation (VS-stage and G-stage)
+    steps: |
+      . Setup
+      .. Enable H extension, set V = 1
+      . Translate address
+      .. Call translate_two_stage() with test vaddr, op, mode
+      .. Verify both VS-stage and G-stage translation are invoked
+      . Check
+      .. Fail unless translation result matches expected physical address
+
+  - id: ext.H.fence_operations
+    description: Test hypervisor fence operations (hfence.vvma, hfence.gvma)
+    steps: |
+      . Setup
+      .. Enable H extension
+      . Invalidate VS-stage TLB
+      .. Call hfence_vvma()
+      .. Verify VS-stage TLB entries are invalidated
+      . Invalidate G-stage TLB
+      .. Call hfence_gvma()
+      .. Verify G-stage TLB entries are invalidated
+      . Check
+      .. Fail unless TLB invalidation works as expected
+
+  - id: ext.H.hypervisor_load_store
+    description: Test hypervisor load/store instructions (hlv.*, hsv.*, hlvx.*)
+    steps: |
+      . Setup
+      .. Enable H extension, set V = 1
+      . Test hlv_b
+      .. Call hlv_b() with test rs1, rd
+      .. Verify correct value is loaded from guest physical address
+      . Test hsv_b
+      .. Call hsv_b() with test rs1, rs2
+      .. Verify correct value is stored to guest physical address
+      . Test hlvx_hu
+      .. Call hlvx_hu() with test rs1, rd
+      .. Verify correct value is loaded with execute permission check
+      . Check
+      .. Fail unless all loads/stores behave as expected
+
+  - id: ext.H.exception_handling
+    description: Test exception and interrupt handling in virtual modes
+    steps: |
+      . Setup
+      .. Enable H extension, set V = 1
+      . Trigger guest page fault
+      .. Cause a LoadGuestPageFault in VS-mode
+      .. Verify vstval, vsepc, and trap vector are set correctly
+      . Trigger virtual instruction exception
+      .. Cause a VirtualInstruction exception
+      .. Verify correct CSRs and trap vector are set
+      . Check
+      .. Fail unless exceptions are handled as specified
+
+  - id: ext.H.vmid_management
+    description: Test VMID get/set operations
+    steps: |
+      . Setup
+      .. Enable H extension, set V = 1
+      . Set VMID
+      .. Call set_current_vmid() with test value
+      .. Verify hgatp.VMID is updated
+      . Get VMID
+      .. Call get_current_vmid()
+      .. Verify returned value matches hgatp.VMID
+      . Check
+      .. Fail unless VMID management works as expected

--- a/spec/std/isa/isa/H.idl
+++ b/spec/std/isa/isa/H.idl
@@ -1,0 +1,429 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Hypervisor extension (H) IDL functions
+# This file contains hypervisor-specific functions and utilities
+
+# Check if hypervisor extension is enabled
+function hypervisor_enabled {
+  returns Boolean
+  description {
+    Check if the hypervisor extension is enabled via misa.H bit
+  }
+  body {
+    return implemented?(ExtensionName::H);
+  }
+}
+
+# Get current virtualization mode (V bit)
+function get_virtualization_mode {
+  returns Boolean
+  description {
+    Get the current virtualization mode (V bit)
+  }
+  body {
+    return V;
+  }
+}
+
+# Set virtualization mode
+function set_virtualization_mode {
+  arguments Boolean new_v
+  description {
+    Set the virtualization mode (V bit)
+  }
+  body {
+    V = new_v;
+  }
+}
+
+# Check if currently in VS-mode
+function in_vs_mode {
+  returns Boolean
+  description {
+    Check if currently in VS-mode
+  }
+  body {
+    return (mode() == PrivilegeMode::VS);
+  }
+}
+
+# Check if currently in VU-mode  
+function in_vu_mode {
+  returns Boolean
+  description {
+    Check if currently in VU-mode
+  }
+  body {
+    return (mode() == PrivilegeMode::VU);
+  }
+}
+
+# Check if currently in HS-mode
+function in_hs_mode {
+  returns Boolean
+  description {
+    Check if currently in HS-mode
+  }
+  body {
+    return (mode() == PrivilegeMode::HS);
+  }
+}
+
+# Get guest physical address from virtual address
+function translate_guest_physical {
+  arguments XReg vaddr, MemoryOperation op, PrivilegeMode mode
+  returns TranslationResult
+  description {
+    Perform two-stage address translation: virtual to guest physical
+  }
+  body {
+    # First stage translation: virtual to guest physical (VS-stage)
+    # Use the existing translate function which handles VS-stage translation
+    TranslationResult vs_result = translate(vaddr, op, mode, 0);  # 0 is placeholder for encoding
+    
+    # Second stage translation: guest physical to supervisor physical (G-stage)
+    if (V == 1) {
+      TranslationResult gs_result = translate_gstage(vs_result.paddr, vaddr, op, mode, 0);
+      return gs_result;
+    } else {
+      return vs_result;
+    }
+  }
+}
+
+# Two-stage address translation for hypervisor
+function translate_two_stage {
+  arguments XReg vaddr, MemoryOperation op, PrivilegeMode mode
+  returns TranslationResult
+  description {
+    Perform two-stage address translation for hypervisor operations
+  }
+  body {
+    # First stage: virtual to guest physical (VS-stage)
+    # Use the existing translate function which handles VS-stage translation
+    TranslationResult vs_result = translate(vaddr, op, mode, 0);  # 0 is placeholder for encoding
+    
+    # Second stage: guest physical to supervisor physical (G-stage)
+    if (V == 1) {
+      TranslationResult gs_result = translate_gstage(vs_result.paddr, vaddr, op, mode, 0);
+      return gs_result;
+    } else {
+      return vs_result;
+    }
+  }
+}
+
+# G-stage address translation (hypervisor wrapper)
+function h_translate_gstage {
+  arguments XReg gpaddr, MemoryOperation op, PrivilegeMode mode
+  returns TranslationResult
+  description {
+    Perform G-stage address translation using hgatp
+  }
+  body {
+    # Use the existing translate_gstage function from globals.isa
+    # This function handles all the proper page table walking and exception handling
+    return translate_gstage(gpaddr, 0, op, mode, 0);  # 0 is placeholder for vaddr and encoding
+  }
+}
+
+# Handle hypervisor exceptions
+function handle_hypervisor_exception {
+  arguments ExceptionCode code, XReg tval, XReg tval2, XReg tinst
+  description {
+    Handle hypervisor exceptions by setting up appropriate CSRs
+  }
+  body {
+    # Set up exception handling for hypervisor mode
+    if (V == 1) {
+      # In virtual mode, use virtual CSRs
+      vstval = tval;
+      vsepc = pc;
+      # Set up virtual trap vector
+      pc = vstvec;
+    } else {
+      # In HS mode, use regular CSRs
+      stval = tval;
+      sepc = pc;
+      # Set up trap vector
+      pc = stvec;
+    }
+  }
+}
+
+# Hypervisor fence operations
+function hfence_vvma {
+  description {
+    Invalidate VS-stage address translations
+  }
+  body {
+    # Invalidate VS-stage address translations
+    VmaOrderType inval_type;
+    inval_type.global = false;
+    inval_type.smode = false;
+    inval_type.vsmode = true;
+    inval_type.gstage = false;
+    inval_type.single_vmid = false;
+    inval_type.single_asid = false;
+    inval_type.single_vaddr = false;
+    inval_type.single_gpaddr = false;
+    invalidate_translations(inval_type);
+  }
+}
+
+function hfence_gvma {
+  description {
+    Invalidate G-stage address translations
+  }
+  body {
+    # Invalidate G-stage address translations
+    VmaOrderType inval_type;
+    inval_type.global = false;
+    inval_type.smode = false;
+    inval_type.vsmode = false;
+    inval_type.gstage = true;
+    inval_type.single_vmid = false;
+    inval_type.single_asid = false;
+    inval_type.single_vaddr = false;
+    inval_type.single_gpaddr = false;
+    invalidate_translations(inval_type);
+  }
+}
+
+# Hypervisor load operations
+function hlv_b {
+  arguments XReg rs1, XReg rd
+  description {
+    Load byte from guest physical address
+  }
+  body {
+    # Load byte from guest physical address
+    XReg gpaddr = X[rs1];
+    TranslationResult result = h_translate_gstage(gpaddr, MemoryOperation::Read, mode());
+    
+    # translate_gstage will raise exceptions on translation failure
+    X[rd] = sign_extend(read_physical_memory<8>(result.paddr), 8);
+  }
+}
+
+function hlv_bu {
+  arguments XReg rs1, XReg rd
+  description {
+    Load unsigned byte from guest physical address
+  }
+  body {
+    # Load unsigned byte from guest physical address
+    XReg gpaddr = X[rs1];
+    TranslationResult result = h_translate_gstage(gpaddr, MemoryOperation::Read, mode());
+    
+    # translate_gstage will raise exceptions on translation failure
+    X[rd] = zero_extend(read_physical_memory<8>(result.paddr), 8);
+  }
+}
+
+function hlv_h {
+  arguments XReg rs1, XReg rd
+  description {
+    Load halfword from guest physical address
+  }
+  body {
+    # Load halfword from guest physical address
+    XReg gpaddr = X[rs1];
+    TranslationResult result = h_translate_gstage(gpaddr, MemoryOperation::Read, mode());
+    
+    # translate_gstage will raise exceptions on translation failure
+    X[rd] = sign_extend(read_physical_memory<16>(result.paddr), 16);
+  }
+}
+
+function hlv_hu {
+  arguments XReg rs1, XReg rd
+  description {
+    Load unsigned halfword from guest physical address
+  }
+  body {
+    # Load unsigned halfword from guest physical address
+    XReg gpaddr = X[rs1];
+    TranslationResult result = h_translate_gstage(gpaddr, MemoryOperation::Read, mode());
+    
+    # translate_gstage will raise exceptions on translation failure
+    X[rd] = zero_extend(read_physical_memory<16>(result.paddr), 16);
+  }
+}
+
+function hlv_w {
+  arguments XReg rs1, XReg rd
+  description {
+    Load word from guest physical address
+  }
+  body {
+    # Load word from guest physical address
+    XReg gpaddr = X[rs1];
+    TranslationResult result = h_translate_gstage(gpaddr, MemoryOperation::Read, mode());
+    
+    # translate_gstage will raise exceptions on translation failure
+    X[rd] = sign_extend(read_physical_memory<32>(result.paddr), 32);
+  }
+}
+
+function hlv_wu {
+  arguments XReg rs1, XReg rd
+  description {
+    Load unsigned word from guest physical address
+  }
+  body {
+    # Load unsigned word from guest physical address
+    XReg gpaddr = X[rs1];
+    TranslationResult result = h_translate_gstage(gpaddr, MemoryOperation::Read, mode());
+    
+    # translate_gstage will raise exceptions on translation failure
+    X[rd] = zero_extend(read_physical_memory<32>(result.paddr), 32);
+  }
+}
+
+function hlv_d {
+  arguments XReg rs1, XReg rd
+  description {
+    Load doubleword from guest physical address
+  }
+  body {
+    # Load doubleword from guest physical address
+    XReg gpaddr = X[rs1];
+    TranslationResult result = h_translate_gstage(gpaddr, MemoryOperation::Read, mode());
+    
+    # translate_gstage will raise exceptions on translation failure
+    X[rd] = read_physical_memory<64>(result.paddr);
+  }
+}
+
+# Hypervisor store operations
+function hsv_b {
+  arguments XReg rs1, XReg rs2
+  description {
+    Store byte to guest physical address
+  }
+  body {
+    # Store byte to guest physical address
+    XReg gpaddr = X[rs1];
+    TranslationResult result = h_translate_gstage(gpaddr, MemoryOperation::Write, mode());
+    
+    # translate_gstage will raise exceptions on translation failure
+    write_physical_memory<8>(result.paddr, X[rs2]);
+  }
+}
+
+function hsv_h {
+  arguments XReg rs1, XReg rs2
+  description {
+    Store halfword to guest physical address
+  }
+  body {
+    # Store halfword to guest physical address
+    XReg gpaddr = X[rs1];
+    TranslationResult result = h_translate_gstage(gpaddr, MemoryOperation::Write, mode());
+    
+    # translate_gstage will raise exceptions on translation failure
+    write_physical_memory<16>(result.paddr, X[rs2]);
+  }
+}
+
+function hsv_w {
+  arguments XReg rs1, XReg rs2
+  description {
+    Store word to guest physical address
+  }
+  body {
+    # Store word to guest physical address
+    XReg gpaddr = X[rs1];
+    TranslationResult result = h_translate_gstage(gpaddr, MemoryOperation::Write, mode());
+    
+    # translate_gstage will raise exceptions on translation failure
+    write_physical_memory<32>(result.paddr, X[rs2]);
+  }
+}
+
+function hsv_d {
+  arguments XReg rs1, XReg rs2
+  description {
+    Store doubleword to guest physical address
+  }
+  body {
+    # Store doubleword to guest physical address
+    XReg gpaddr = X[rs1];
+    TranslationResult result = h_translate_gstage(gpaddr, MemoryOperation::Write, mode());
+    
+    # translate_gstage will raise exceptions on translation failure
+    write_physical_memory<64>(result.paddr, X[rs2]);
+  }
+}
+
+# Hypervisor load with execute permission check
+function hlvx_hu {
+  arguments XReg rs1, XReg rd
+  description {
+    Load unsigned halfword from guest physical address with execute permission check
+  }
+  body {
+    # Load unsigned halfword from guest physical address with execute permission check
+    XReg gpaddr = X[rs1];
+    TranslationResult result = h_translate_gstage(gpaddr, MemoryOperation::Fetch, mode());
+    
+    # translate_gstage will raise exceptions on translation failure
+    X[rd] = zero_extend(read_physical_memory<16>(result.paddr), 16);
+  }
+}
+
+function hlvx_wu {
+  arguments XReg rs1, XReg rd
+  description {
+    Load unsigned word from guest physical address with execute permission check
+  }
+  body {
+    # Load unsigned word from guest physical address with execute permission check
+    XReg gpaddr = X[rs1];
+    TranslationResult result = h_translate_gstage(gpaddr, MemoryOperation::Fetch, mode());
+    
+    # translate_gstage will raise exceptions on translation failure
+    X[rd] = zero_extend(read_physical_memory<32>(result.paddr), 32);
+  }
+}
+
+# Check if hypervisor mode is supported
+function supports_hypervisor {
+  returns Boolean
+  description {
+    Check if hypervisor mode is supported
+  }
+  body {
+    return implemented?(ExtensionName::H) && implemented?(ExtensionName::S);
+  }
+}
+
+# Get current VMID
+function get_current_vmid {
+  returns Bits<VMID_WIDTH>
+  description {
+    Get the current VMID from hgatp
+  }
+  body {
+    if (V == 1) {
+      return hgatp.VMID;
+    } else {
+      return 0;
+    }
+  }
+}
+
+# Set current VMID
+function set_current_vmid {
+  arguments Bits<VMID_WIDTH> vmid
+  description {
+    Set the current VMID in hgatp
+  }
+  body {
+    if (V == 1) {
+      hgatp.VMID = vmid;
+    }
+  }
+} 

--- a/spec/std/isa/isa/globals.isa
+++ b/spec/std/isa/isa/globals.isa
@@ -8,6 +8,7 @@ include "interrupts.idl"
 include "fetch.idl"
 include "util.idl"
 include "fp.idl"
+include "H.idl"
 
 # global state
 


### PR DESCRIPTION
- Added comprehensive H.idl file with hypervisor-specific functions
- Implement proper two-stage address translation (VS-stage and G-stage)
- Added hypervisor load/store operations (HLV/HSV/HLVX instructions)
- Added TLB invalidation functions (hfence.vvma, hfence.gvma)
- Added virtualization mode management functions
- Added comprehensive test procedures to H.yaml
- Integrated H.idl into globals.isa

Issue-linked - References the original issue #211

