### PR TITLE
docs: better length formatting when the length is conditional

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/obj/csr.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/csr.rb
@@ -373,10 +373,10 @@ class Csr < TopLevelDatabaseObject
         end
 
       if effective_xlen.nil?
-        <<~LENGTH
-          #{length(32)} when #{cond.sub('%%', '0')}
-          #{length(64)} when #{cond.sub('%%', '1')}
-        LENGTH
+        [
+          "* #{length(32)} when #{cond.sub('%%', '0')}",
+          "* #{length(64)} when #{cond.sub('%%', '1')}"
+        ].join("\n")
       else
         "#{length(effective_xlen)}-bit"
       end


### PR DESCRIPTION
Earlier the CSR Attributes had irregular formatting when its value was conditional as in the case 
<img width="848" height="270" alt="image" src="https://github.com/user-attachments/assets/472362cf-53cb-42ff-b7cb-e88b671ea1c3" />
The commit adds a better fomatting for that specific case when both the values were printed in CSR.
fixes #928 