### PR TITLE
fix : Solved Huge number of wavedrom failures when generating CTP #929

### DIFF
--- a/backends/instructions_appendix/tasks.rake
+++ b/backends/instructions_appendix/tasks.rake
@@ -44,6 +44,7 @@ file MERGED_INSTRUCTIONS_PDF.to_s => [
     "-a pdf-theme=#{ENV['THEME'] || "#{$root}/ext/docs-resources/themes/riscv-pdf.yml"}",
     "-a pdf-fontsdir=#{$root}/ext/docs-resources/fonts",
     "-a imagesdir=#{$root}/ext/docs-resources/images",
+    "-a wavedrom=#{$root}/node_modules/.bin/wavedrom-cli",
     "-r asciidoctor-diagram",
     "-o #{t.name}",
     MERGED_INSTRUCTIONS_FILE.to_s

--- a/backends/portfolio/tasks.rake
+++ b/backends/portfolio/tasks.rake
@@ -13,6 +13,14 @@ require "idlc/passes/gen_adoc"
 
 require "udb/config"
 
+# Ensure npm dependencies are installed, particularly wavedrom-cli for diagram generation
+def ensure_npm_dependencies
+  unless File.exist?("#{$root}/node_modules/.bin/wavedrom-cli")
+    puts "Installing npm dependencies (wavedrom-cli not found)..."
+    system("cd #{$root} && npm install") || raise("Failed to install npm dependencies")
+  end
+end
+
 sig { returns(Udb::ConfiguredArchitecture) }
 def pf_create_arch
   $resolver.cfg_arch_for("_")
@@ -87,6 +95,7 @@ end
 # @param adoc_file [String] Full name of source adoc file
 # @param target_pname [String] Full name of PDF file being generated
 def pf_adoc2pdf(adoc_file, target_pname)
+  ensure_npm_dependencies
   FileUtils.mkdir_p File.dirname(target_pname)
 
   $logger.info "Generating PDF in #{target_pname}"
@@ -99,6 +108,7 @@ def pf_adoc2pdf(adoc_file, target_pname)
     "-a pdf-theme=#{$root}/ext/docs-resources/themes/riscv-pdf.yml",
     "-a pdf-fontsdir=#{$root}/ext/docs-resources/fonts",
     "-a imagesdir=#{$root}/ext/docs-resources/images",
+    "-a wavedrom=#{$root}/node_modules/.bin/wavedrom-cli",
     "-r asciidoctor-diagram",
     "-r idl_highlighter",
     "-o #{target_pname}",
@@ -125,6 +135,7 @@ end
 # @param adoc_file [String] Full name of source adoc file
 # @param target_pname [String] Full name of HTML file being generated
 def pf_adoc2html(adoc_file, target_pname)
+  ensure_npm_dependencies
   FileUtils.mkdir_p File.dirname(target_pname)
 
   $logger.info "Generating HTML in #{target_pname}"
@@ -134,6 +145,7 @@ def pf_adoc2html(adoc_file, target_pname)
     "-v",
     "-a toc",
     "-a imagesdir=#{$root}/ext/docs-resources/images",
+    "-a wavedrom=#{$root}/node_modules/.bin/wavedrom-cli",
     "-r asciidoctor-diagram",
     "-r idl_highlighter",
     "-o #{target_pname}",


### PR DESCRIPTION
### **The Problem**
The error occurred because:   Path resolution issue: Even when installed, asciidoctor-diagram couldn't find [wavedrom-cli](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) in the PATH

### **The Solution**
I implemented a comprehensive fix with multiple layers:   
Fixed path resolution in rake tasks: Added the -a wavedrom=#{$root}/node_modules/.bin/wavedrom-cli attribute to all asciidoctor commands that use the diagram extension:

[tasks.rake](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (both PDF and HTML generation)
[tasks.rake](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (PDF generation)
[tasks.rake](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (already had this fix)
Added robustness check: Created an [ensure_npm_dependencies](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) function that automatically installs npm dependencies if [wavedrom-cli](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) is missing, and integrated it into the build process.  

