### PR TITLE
fix: printing object string in profile extension appendix

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/obj/database_obj.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/database_obj.rb
@@ -49,7 +49,7 @@ class DatabaseObject
   attr_reader :long_name
 
   sig { returns(String) }
-  def kind = @kind.to_s
+  def kind = @kind.serialize
 
   # @return [Architecture] If only a specification (no config) is known
   # @return [ConfiguredArchitecture] If a specification and config is known


### PR DESCRIPTION
### **The Problem**
Using `to_s` on a `T::Enum` like `kind` returns the object reference (e.g., `#<DatabaseObject::Kind::Profile>`) instead of the actual string value.

### **The Solution**
Replaced `to_s` with `serialize`, which correctly returns the string value (e.g., `"profile"`).

### **Why**
`serialize` is the intended way to extract string values from `T::Enum`. 

Fixes #853
