### PR TITLE
docs: fix typos in documentation files

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -11,7 +11,7 @@ Bug reports should be filed as a https://github.com/riscv-software-src/riscv-uni
 
 === Feature Requests
 
-Bug reports should be filed as a https://github.com/riscv-software-src/riscv-unified-db/issues[GitHub Issue] using the `Feature request` template.
+Feature requests should be filed as a https://github.com/riscv-software-src/riscv-unified-db/issues[GitHub Issue] using the `Feature request` template.
 
 === Bug Fixes
 
@@ -105,7 +105,7 @@ When a commit will close a GitHub Issue, it should be noted in the footer:
 
 ```
 Fixes #<issue number>
-Closes #<issue numer>
+Closes #<issue number>
 ```
 
 ==== Git trailers
@@ -170,7 +170,7 @@ Under special circumstances code may be added under a different license.
 For example, code from an existing project may be integrated after careful deliberation.
 Any contributions under a different license will receive extra review.
 When any contribution is made under a different license, it must be tracked using
-https://reuse.software/tutorial/#step-2[a Reuse-compatible identifer].
+https://reuse.software/tutorial/#step-2[a Reuse-compatible identifier].
 
 To keep UnifiedDB open to both private and commercial interests, contributions under a
 https://en.wikipedia.org/wiki/copyleft[copyleft license] will never be accepted.

--- a/backends/portfolio/templates/README.adoc
+++ b/backends/portfolio/templates/README.adoc
@@ -1,1 +1,1 @@
-This directory contains partial ERB templates shared by multiple portfolio-based backend.
+This directory contains partial ERB templates shared by multiple portfolio-based backends.

--- a/doc/idl.adoc
+++ b/doc/idl.adoc
@@ -4,7 +4,7 @@
 The RISC-V ISA functionality is formally described in a domain specific language called ISA Description Language (IDL). The language is intended to be:
 
  * *Human readable* so that it can serve as a reliable documentation source.
- * *Familiar* to both hardware and software designers. For that reason, the syntax resembles a mix of Verilog and C++ (which both share inherit a C-like syntax).
+ * *Familiar* to both hardware and software designers. For that reason, the syntax resembles a mix of Verilog and C++ (which both inherit a C-like syntax).
  * *Strongly typed* to reduce ambiguity as a documentation source.
  * *Modular* to reflect RISC-V's modular ISA structure. IDL can describe a wide range of devices, and then be customized with configuration variables to generate an implementation-specific description.
 
@@ -239,7 +239,7 @@ Bits<2> pbmt = pte.PBMT;
 
 ==== Structs
 
-A struct is a collection of unrelated types, similar to a `struct` in C/C++ or Verilog. Structs are declared using the `struct` keyword. Struct names must begin with a capital letter. Struct members can begin with either lowercase or uppercase; in the former, the member is mutable and in the former the member is const. Struct members may be any type, including other structs.
+A struct is a collection of unrelated types, similar to a `struct` in C/C++ or Verilog. Structs are declared using the `struct` keyword. Struct names must begin with a capital letter. Struct members can begin with either lowercase or uppercase; in the former, the member is mutable and in the latter the member is const. Struct members may be any type, including other structs.
 
 Struct declarations do _not_ need to be followed by a semicolon (as they are in C/C++).
 


### PR DESCRIPTION
Correct spelling errors in CONTRIBUTING.adoc, README files, and IDL documentation:
- Fix "identifer" to "identifier" in CONTRIBUTING.adoc
- Fix "numer" to "number" in CONTRIBUTING.adoc
- Fix "Bug reports" to "Feature requests" in feature request section
- Fix "backend" to "backends" in portfolio templates README
- Fix "both share inherit" to "both inherit" in IDL documentation
- Fix duplicated "former" to "former"/"latter" in struct description

Clean up.