### PR TITLE
fix:  seperated for RV32/RV64 in instruction generating schema

### DIFF
--- a/spec/schemas/inst_schema.json
+++ b/spec/schemas/inst_schema.json
@@ -330,8 +330,19 @@
           "description": "Detailed description of the instruction"
         },
         "definedBy": {
-          "$ref": "schema_defs.json#/$defs/requires_entry",
-          "description": "Extension(s) that defines the instruction"
+          "description": "Extension(s) that define the instruction. Can be per-base (RV32/RV64) or a single set for both.",
+          "oneOf": [
+            { "$ref": "schema_defs.json#/$defs/requires_entry" },
+            {
+              "type": "object",
+              "properties": {
+                "RV32": { "$ref": "schema_defs.json#/$defs/requires_entry" },
+                "RV64": { "$ref": "schema_defs.json#/$defs/requires_entry" }
+              },
+              "required": ["RV32", "RV64"],
+              "additionalProperties": false
+            }
+          ]
         },
 
         "hints": {


### PR DESCRIPTION
The `definedBy` was defined commonly for both RV32/RV64. The schema has been changed to allow accepting different extensions for both the configurations in both the ways whichever is convenient
```bash
definedBy:
  RV32:
    not: I
  RV64:
    allOf: [I, Zicsr]
```
fixes #986 