### PR TITLE
fix: use VS field when updating mstatus.VS

### DIFF
--- a/spec/std/isa/csr/mstatus.yaml
+++ b/spec/std/isa/csr/mstatus.yaml
@@ -476,13 +476,13 @@ fields:
       }
     sw_write(csr_value): |
       if (CSR[misa].V == 1'b1){
-        return ary_includes?<$array_size(MSTATUS_VS_LEGAL_VALUES), 2>(MSTATUS_VS_LEGAL_VALUES, csr_value.FS) ? csr_value.FS : UNDEFINED_LEGAL_DETERMINISTIC;
+        return ary_includes?<$array_size(MSTATUS_VS_LEGAL_VALUES), 2>(MSTATUS_VS_LEGAL_VALUES, csr_value.VS) ? csr_value.VS : UNDEFINED_LEGAL_DETERMINISTIC;
       } else if ((CSR[misa].S == 1'b0) && (CSR[misa].V == 1'b0)) {
         # must be read-only-0
         return 0;
       } else {
         # there will be no hardware update in this case because we know the V extension isn't implemented
-        return ary_includes?<$array_size(MSTATUS_VS_LEGAL_VALUES), 2>(MSTATUS_VS_LEGAL_VALUES, csr_value.FS) ? csr_value.FS : UNDEFINED_LEGAL_DETERMINISTIC;
+        return ary_includes?<$array_size(MSTATUS_VS_LEGAL_VALUES), 2>(MSTATUS_VS_LEGAL_VALUES, csr_value.VS) ? csr_value.VS : UNDEFINED_LEGAL_DETERMINISTIC;
       }
   SPP:
     location: 8


### PR DESCRIPTION
The mstatus.VS field was incorrectly written with the value of the FS field from a CSR write. Update it to use the VS field as expected.