### PR TITLE
fix: ratified version of Sstc is 1.0.0

### DIFF
--- a/cfgs/example_rv64_with_overlay.yaml
+++ b/cfgs/example_rv64_with_overlay.yaml
@@ -30,7 +30,7 @@ implemented_extensions:
   - [Sscofpmf, "1.0.0"]
   - [Ssaia, "1.0.0"]
   - [Ssccfg, "1.0.0"]
-  - [Sstc, "0.9.0"]
+  - [Sstc, "1.0.0"]
   - [Sv39, "1.12.0"]
   - [Sv48, "1.12.0"]
   - [Zicboz, "1.0.0"]

--- a/spec/std/isa/ext/Sstc.yaml
+++ b/spec/std/isa/ext/Sstc.yaml
@@ -10,7 +10,7 @@ long_name: Supervisor-mode timer interrupts
 description: Supervisor-mode timer interrupts
 type: privileged
 versions:
-  - version: "0.9.0"
+  - version: "1.0.0"
     state: ratified
     ratification_date: null
     url: https://drive.google.com/file/d/1m84Re2yK8m_vbW7TspvevCDR82MOBaSX/view?usp=drive_link


### PR DESCRIPTION
The ratified version of the Sstc extension is 1.0.0, not 0.9.0. Discovered while creating a UDB configuration for [CVW](github.com/openhwgroup/cvw).