### PR TITLE
refactor: remove unneeded type in jsonschema when const defined

### DIFF
--- a/spec/schemas/proc_cert_class_schema.json
+++ b/spec/schemas/proc_cert_class_schema.json
@@ -1,16 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-
   "type": "object",
   "required": ["$schema", "kind", "name", "long_name", "introduction"],
   "additionalProperties": false,
   "properties": {
     "$schema": {
-      "type": "string",
       "const": "proc_cert_class_schema.json#"
     },
     "kind": {
-      "type": "string",
       "const": "processor certificate class"
     },
     "name": {

--- a/spec/schemas/proc_cert_model_schema.json
+++ b/spec/schemas/proc_cert_model_schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-
   "type": "object",
   "required": ["$schema", "kind", "name", "long_name", "base"],
   "additionalProperties": false,
@@ -54,11 +53,9 @@
       ]
     },
     "$schema": {
-      "type": "string",
       "const": "proc_cert_model_schema.json#"
     },
     "kind": {
-      "type": "string",
       "const": "processor certificate model"
     },
     "name": {

--- a/spec/schemas/profile_family_schema.json
+++ b/spec/schemas/profile_family_schema.json
@@ -1,15 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-
   "type": "object",
   "required": ["$schema", "kind", "name", "long_name"],
   "properties": {
     "$schema": {
-      "type": "string",
       "const": "profile_family_schema.json#"
     },
     "kind": {
-      "type": "string",
       "const": "profile family"
     },
     "processor_kind": {

--- a/spec/schemas/profile_release_schema.json
+++ b/spec/schemas/profile_release_schema.json
@@ -1,15 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-
   "type": "object",
   "required": ["$schema", "kind", "name", "long_name", "description"],
   "properties": {
     "$schema": {
-      "type": "string",
       "const": "profile_release_schema.json#"
     },
     "kind": {
-      "type": "string",
       "const": "profile release"
     },
     "name": {

--- a/spec/schemas/profile_schema.json
+++ b/spec/schemas/profile_schema.json
@@ -1,15 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-
   "type": "object",
   "required": ["$schema", "kind", "name", "long_name", "base"],
   "properties": {
     "$schema": {
-      "type": "string",
       "const": "profile_schema.json#"
     },
     "kind": {
-      "type": "string",
       "const": "profile"
     },
     "name": {


### PR DESCRIPTION
Removes unnecessary "type" from schema definition when a "const" is declared. 
This prevents problem where code using the jsonschema makes the type mandatory like here: https://github.com/riscv-software-src/riscv-unified-db/issues/636
fixes #1015