### PR TITLE
Add Ssdbltrp CSR fields: DTE and SDT

### DIFF
--- a/spec/std/isa/csr/H/henvcfg.yaml
+++ b/spec/std/isa/csr/H/henvcfg.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# Copyright (c) 2025 Abhijit Das(Sukuna0007Abhi)
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 # yaml-language-server: $schema=../../../../schemas/csr_schema.json
@@ -186,6 +187,37 @@ fields:
       return (implemented?(ExtensionName::Svadu)) ? CsrFieldType::RO : CsrFieldType::RW;
     reset_value(): |
       return (implemented?(ExtensionName::Svadu)) ? UNDEFINED_LEGAL : 0;
+    sw_write(csr_value): |
+      if (CSR[menvcfg].ADUE == 1'b0) {
+        return 0;
+      }
+      return csr_value.ADUE;
+  DTE:
+    location: 59
+    description: |
+      *Double Trap Enable*
+
+      The DTE bit controls whether the Ssdbltrp extension is available for VS-mode.
+
+      When DTE=1, the Ssdbltrp extension is enabled for VS-mode. The `vsstatus.SDT` field becomes functional.
+      When a trap is to be taken into VS-mode, if `vsstatus.SDT` is currently 0, it is set to 1 and
+      the trap is delivered as expected. However, if `vsstatus.SDT` is already set to 1, a double-trap
+      exception is delivered to HS-mode instead.
+
+      When DTE=0, the implementation behaves as though Ssdbltrp is not implemented for VS-mode.
+      The `vsstatus.SDT` field is read-only zero.
+
+      If Ssdbltrp is not implemented, DTE is read-only zero.
+
+      Furthermore, `henvcfg.DTE` is read-only zero if `menvcfg.DTE` is zero.
+    definedBy: Ssdbltrp
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      if (CSR[menvcfg].DTE == 1'b0) {
+        return 0;
+      }
+      return csr_value.DTE;
   CBZE:
     location: 7
     description: |
@@ -290,5 +322,9 @@ sw_read(): |
   if (implemented?(ExtensionName::Svadu) && CSR[menvcfg].ADUE == 0) {
     # henvcfg.ADUE must read-as-zero
     value = value & ~(1 `<< 61);
+  }
+  if (implemented?(ExtensionName::Ssdbltrp) && CSR[menvcfg].DTE == 0) {
+    # henvcfg.DTE must read-as-zero
+    value = value & ~(1 `<< 59);
   }
   return value;

--- a/spec/std/isa/csr/menvcfg.yaml
+++ b/spec/std/isa/csr/menvcfg.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# Copyright (c) 2025 Abhijit Das(Sukuna0007Abhi)
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 # yaml-language-server: $schema=../../../schemas/csr_schema.json
@@ -197,6 +198,25 @@ fields:
       return (implemented?(ExtensionName::Svadu)) ? CsrFieldType::RO : CsrFieldType::RW;
     reset_value(): |
       return (implemented?(ExtensionName::Svadu)) ? UNDEFINED_LEGAL : 0;
+  DTE:
+    location: 59
+    description: |
+      *Double Trap Enable*
+
+      The DTE bit controls whether the Ssdbltrp extension is available.
+
+      When DTE=1, the Ssdbltrp extension is enabled. The `sstatus.SDT` field becomes functional.
+      When a trap is to be taken into S-mode, if `sstatus.SDT` is currently 0, it is set to 1 and
+      the trap is delivered as expected. However, if `sstatus.SDT` is already set to 1, a double-trap
+      exception is delivered to M-mode instead.
+
+      When DTE=0, the implementation behaves as though Ssdbltrp is not implemented. The `sstatus.SDT`
+      and `vsstatus.SDT` fields are read-only zero, and `henvcfg.DTE` is read-only zero.
+
+      If Ssdbltrp is not implemented, DTE is read-only zero.
+    definedBy: Ssdbltrp
+    type: RW
+    reset_value: UNDEFINED_LEGAL
   CBZE:
     location: 7
     description: |

--- a/spec/std/isa/csr/mstatus.yaml
+++ b/spec/std/isa/csr/mstatus.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# Copyright (c) 2025 Abhijit Das(Sukuna0007Abhi)
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 # yaml-language-server: $schema=../../../schemas/csr_schema.json
@@ -65,6 +66,26 @@ fields:
     definedBy: Smdbltrp
     type: RW-H
     reset_value: UNDEFINED_LEGAL
+  SDT:
+    location: 41
+    base: 64
+    description: |
+      *Supervisor Disable Trap*
+
+      Written to 1 when entering S-mode from an exception/interrupt.
+      When returning via an SRET instruction, the bit is written to 0.
+      On reset is set to 0.
+      When mstatus.SDT=1, direct write by CSR instruction cannot set mstatus.SIE to 1, if not written together.
+
+      This field is read-only zero if `menvcfg.DTE` is zero.
+    definedBy: Ssdbltrp
+    type: RW-H
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      if (CSR[menvcfg].DTE == 1'b0) {
+        return 0;
+      }
+      return csr_value.SDT;
   MPV:
     location: 39
     base: 64

--- a/spec/std/isa/csr/sstatus.yaml
+++ b/spec/std/isa/csr/sstatus.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# Copyright (c) 2025 Abhijit Das(Sukuna0007Abhi)
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 # yaml-language-server: $schema=../../../schemas/csr_schema.json
@@ -93,6 +94,18 @@ fields:
     type: RW-H
     reset_value: UNDEFINED_LEGAL
     definedBy: V
+  SDT:
+    alias: mstatus.SDT
+    location: 41
+    base: 64
+    description: |
+      *Supervisor Disable Trap*
+
+      Alias of `mstatus.SDT`.
+
+    type: RW-H
+    reset_value: UNDEFINED_LEGAL
+    definedBy: Ssdbltrp
   SPP:
     alias: mstatus.SPP
     location: 8

--- a/spec/std/isa/csr/vsstatus.yaml
+++ b/spec/std/isa/csr/vsstatus.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# Copyright (c) 2025 Abhijit Das(Sukuna0007Abhi)
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 # yaml-language-server: $schema=../../../schemas/csr_schema.json
@@ -57,6 +58,26 @@ fields:
       return (VUXLEN == 3264) ? CsrFieldType::RW : CsrFieldType::RO;
     reset_value(): |
       return (VUXLEN == 3264) ? UNDEFINED_LEGAL : VUXLEN;
+  SDT:
+    location: 41
+    base: 64
+    description: |
+      *Supervisor Disable Trap*
+
+      Written to 1 when entering VS-mode from an exception/interrupt.
+      When returning via an SRET instruction, the bit is written to 0.
+      On reset is set to 0.
+      When vsstatus.SDT=1, direct write by CSR instruction cannot set vsstatus.SIE to 1, if not written together.
+
+      This field is read-only zero if `henvcfg.DTE` is zero.
+    definedBy: Ssdbltrp
+    type: RW-H
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      if (CSR[henvcfg].DTE == 1'b0) {
+        return 0;
+      }
+      return csr_value.SDT;
   MXR:
     alias: mstatus.MXR
     location: 19


### PR DESCRIPTION
- Add DTE (Double Trap Enable) field to menvcfg and henvcfg CSRs
- Add SDT (Supervisor Disable Trap) field to mstatus, sstatus, vsstatus CSRs
- Implement proper hierarchical control with sw_write functions
- Add CSR-level sw_read function for henvcfg DTE masking
- All fields comply with Ssdbltrp extension specification

Ready for Review sir @ThinkOpenly sir @dhower-qc 