### PR TITLE
fix inconsistent destination register naming in compressed shift instructions

### DIFF
--- a/backends/instructions_appendix/all_instructions.golden.adoc
+++ b/backends/instructions_appendix/all_instructions.golden.adoc
@@ -5206,18 +5206,18 @@ This instruction has different encodings in RV32 and RV64
 RV32::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "shamt != 0","type":4},{"bits":5,"name": "rd","type":4},{"bits":4,"name": 0x0,"type":2}]}
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "shamt != 0","type":4},{"bits":5,"name": "xd","type":4},{"bits":4,"name": 0x0,"type":2}]}
 ....
 
 RV64::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "shamt != 0[4:0]","type":4},{"bits":5,"name": "rd","type":4},{"bits":1,"name": "shamt != 0[5]","type":4},{"bits":3,"name": 0x0,"type":2}]}
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":5,"name": "shamt != 0[4:0]","type":4},{"bits":5,"name": "xd","type":4},{"bits":1,"name": "shamt != 0[5]","type":4},{"bits":3,"name": 0x0,"type":2}]}
 ....
 
 Description::
-Shift the value in rd left by shamt, and store the result back in rd.
-C.SLLI expands into `slli rd, rd, shamt`.
+Shift the value in xd left by shamt, and store the result back in xd.
+C.SLLI expands into `slli xd, xd, shamt`.
 
 
 Decode Variables::
@@ -5227,7 +5227,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |shamt |$encoding[6:2]
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 *RV64:*
@@ -5236,7 +5236,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |shamt |{$encoding[12], $encoding[6:2]}
-|rd |$encoding[11:7]
+|xd |$encoding[11:7]
 |===
 
 Included in::
@@ -5267,19 +5267,19 @@ This instruction has different encodings in RV32 and RV64
 RV32::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "shamt != 0","type":4},{"bits":3,"name": "rd","type":4},{"bits":6,"name": 0x21,"type":2}]}
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "shamt != 0","type":4},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x21,"type":2}]}
 ....
 
 RV64::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "shamt != 0[4:0]","type":4},{"bits":3,"name": "rd","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":1,"name": "shamt != 0[5]","type":4},{"bits":3,"name": 0x4,"type":2}]}
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "shamt != 0[4:0]","type":4},{"bits":3,"name": "xd","type":4},{"bits":2,"name": 0x1,"type":2},{"bits":1,"name": "shamt != 0[5]","type":4},{"bits":3,"name": 0x4,"type":2}]}
 ....
 
 Description::
-Arithmetic shift (the original sign bit is copied into the vacated upper bits) the value in rd right by shamt, and store the result in rd.
-The rd register index should be used as rd+8 (registers x8-x15).
-C.SRAI expands into `srai rd, rd, shamt`.
+Arithmetic shift (the original sign bit is copied into the vacated upper bits) the value in xd right by shamt, and store the result in xd.
+The xd register index should be used as xd+8 (registers x8-x15).
+C.SRAI expands into `srai xd, xd, shamt`.
 
 
 Decode Variables::
@@ -5289,7 +5289,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |shamt |$encoding[6:2]
-|rd |$encoding[9:7]
+|xd |$encoding[9:7]
 |===
 
 *RV64:*
@@ -5298,7 +5298,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |shamt |{$encoding[12], $encoding[6:2]}
-|rd |$encoding[9:7]
+|xd |$encoding[9:7]
 |===
 
 Included in::
@@ -5329,19 +5329,19 @@ This instruction has different encodings in RV32 and RV64
 RV32::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "shamt != 0","type":4},{"bits":3,"name": "rd","type":4},{"bits":6,"name": 0x20,"type":2}]}
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "shamt != 0","type":4},{"bits":3,"name": "xd","type":4},{"bits":6,"name": 0x20,"type":2}]}
 ....
 
 RV64::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "shamt != 0[4:0]","type":4},{"bits":3,"name": "rd","type":4},{"bits":2,"name": 0x0,"type":2},{"bits":1,"name": "shamt != 0[5]","type":4},{"bits":3,"name": 0x4,"type":2}]}
+{"reg":[{"bits":2,"name": 0x1,"type":2},{"bits":5,"name": "shamt != 0[4:0]","type":4},{"bits":3,"name": "xd","type":4},{"bits":2,"name": 0x0,"type":2},{"bits":1,"name": "shamt != 0[5]","type":4},{"bits":3,"name": 0x4,"type":2}]}
 ....
 
 Description::
-Shift the value in rd right by shamt, and store the result back in rd.
-The rd register index should be used as rd+8 (registers x8-x15).
-C.SRLI expands into `srli rd, rd, shamt`.
+Shift the value in xd right by shamt, and store the result back in xd.
+The xd register index should be used as xd+8 (registers x8-x15).
+C.SRLI expands into `srli xd, xd, shamt`.
 
 
 Decode Variables::
@@ -5351,7 +5351,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |shamt |$encoding[6:2]
-|rd |$encoding[9:7]
+|xd |$encoding[9:7]
 |===
 
 *RV64:*
@@ -5360,7 +5360,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |shamt |{$encoding[12], $encoding[6:2]}
-|rd |$encoding[9:7]
+|xd |$encoding[9:7]
 |===
 
 Included in::

--- a/spec/std/isa/inst/C/c.slli.yaml
+++ b/spec/std/isa/inst/C/c.slli.yaml
@@ -8,8 +8,8 @@ kind: instruction
 name: c.slli
 long_name: Shift left logical immediate
 description: |
-  Shift the value in rd left by shamt, and store the result back in rd.
-  C.SLLI expands into `slli rd, rd, shamt`.
+  Shift the value in xd left by shamt, and store the result back in xd.
+  C.SLLI expands into `slli xd, xd, shamt`.
 definedBy:
   anyOf:
     - C
@@ -22,7 +22,7 @@ encoding:
       - name: shamt
         location: 6-2
         not: 0
-      - name: rd
+      - name: xd
         location: 11-7
   RV64:
     match: 000-----------10
@@ -30,7 +30,7 @@ encoding:
       - name: shamt
         location: 12|6-2
         not: 0
-      - name: rd
+      - name: xd
         location: 11-7
 access:
   s: always
@@ -39,7 +39,7 @@ access:
   vu: always
 operation(): |
   # shamt is between 0-63
-  X[rd] = X[rd] << shamt;
+  X[xd] = X[xd] << shamt;
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/spec/std/isa/inst/C/c.srai.yaml
+++ b/spec/std/isa/inst/C/c.srai.yaml
@@ -8,9 +8,9 @@ kind: instruction
 name: c.srai
 long_name: Shift right arithmetical immediate
 description: |
-  Arithmetic shift (the original sign bit is copied into the vacated upper bits) the value in rd right by shamt, and store the result in rd.
-  The rd register index should be used as rd+8 (registers x8-x15).
-  C.SRAI expands into `srai rd, rd, shamt`.
+  Arithmetic shift (the original sign bit is copied into the vacated upper bits) the value in xd right by shamt, and store the result in xd.
+  The xd register index should be used as xd+8 (registers x8-x15).
+  C.SRAI expands into `srai xd, xd, shamt`.
 definedBy:
   anyOf:
     - C
@@ -23,7 +23,7 @@ encoding:
       - name: shamt
         location: 6-2
         not: 0
-      - name: rd
+      - name: xd
         location: 9-7
   RV64:
     match: 100-01--------01
@@ -31,7 +31,7 @@ encoding:
       - name: shamt
         location: 12|6-2
         not: 0
-      - name: rd
+      - name: xd
         location: 9-7
 access:
   s: always
@@ -40,7 +40,7 @@ access:
   vu: always
 operation(): |
   # shamt is between 0-63
-  X[creg2reg(rd)] = X[creg2reg(rd)] >>> shamt;
+  X[creg2reg(xd)] = X[creg2reg(xd)] >>> shamt;
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>

--- a/spec/std/isa/inst/C/c.srli.yaml
+++ b/spec/std/isa/inst/C/c.srli.yaml
@@ -8,9 +8,9 @@ kind: instruction
 name: c.srli
 long_name: Shift right logical immediate
 description: |
-  Shift the value in rd right by shamt, and store the result back in rd.
-  The rd register index should be used as rd+8 (registers x8-x15).
-  C.SRLI expands into `srli rd, rd, shamt`.
+  Shift the value in xd right by shamt, and store the result back in xd.
+  The xd register index should be used as xd+8 (registers x8-x15).
+  C.SRLI expands into `srli xd, xd, shamt`.
 definedBy:
   anyOf:
     - C
@@ -23,7 +23,7 @@ encoding:
       - name: shamt
         location: 6-2
         not: 0
-      - name: rd
+      - name: xd
         location: 9-7
   RV64:
     match: 100-00--------01
@@ -31,7 +31,7 @@ encoding:
       - name: shamt
         location: 12|6-2
         not: 0
-      - name: rd
+      - name: xd
         location: 9-7
 access:
   s: always
@@ -40,7 +40,7 @@ access:
   vu: always
 operation(): |
   # shamt is between 0-63
-  X[creg2reg(rd)] = X[creg2reg(rd)] >> shamt;
+  X[creg2reg(xd)] = X[creg2reg(xd)] >> shamt;
 
 # SPDX-SnippetBegin
 # SPDX-FileCopyrightText: 2017-2025 Contributors to the RISCV Sail Model <https://github.com/riscv/sail-riscv/blob/master/LICENCE>


### PR DESCRIPTION
In all the other instructions the destination register is named xd, not rd, except the shift instructions.
Furthermore in the assembly attribute of the shift instructions the destination register is designated as xd, not rd,
thus causing code generators to generate incorrect code.