### PR TITLE
fix: correct Svadu ADUE field type logic in environment CSRs

### DIFF
--- a/spec/std/isa/csr/H/henvcfg.yaml
+++ b/spec/std/isa/csr/H/henvcfg.yaml
@@ -183,7 +183,7 @@ fields:
       zero if menvcfg.ADUE is zero.
     definedBy: Svadu
     type(): |
-      return (implemented?(ExtensionName::Svadu)) ? CsrFieldType::RO : CsrFieldType::RW;
+      return (implemented?(ExtensionName::Svadu)) ? CsrFieldType::RW : CsrFieldType::RO;
     reset_value(): |
       return (implemented?(ExtensionName::Svadu)) ? UNDEFINED_LEGAL : 0;
   CBZE:

--- a/spec/std/isa/csr/H/henvcfgh.yaml
+++ b/spec/std/isa/csr/H/henvcfgh.yaml
@@ -105,7 +105,7 @@ fields:
       zero if menvcfg.ADUE is zero.
     definedBy: Svadu
     type(): |
-      return (implemented?(ExtensionName::Svadu)) ? CsrFieldType::RO : CsrFieldType::RW;
+      return (implemented?(ExtensionName::Svadu)) ? CsrFieldType::RW : CsrFieldType::RO;
     reset_value(): |
       return (implemented?(ExtensionName::Svadu)) ? UNDEFINED_LEGAL : 0;
 sw_read(): |

--- a/spec/std/isa/csr/menvcfg.yaml
+++ b/spec/std/isa/csr/menvcfg.yaml
@@ -194,7 +194,7 @@ fields:
       zero if menvcfg.ADUE is zero.
     definedBy: Svadu
     type(): |
-      return (implemented?(ExtensionName::Svadu)) ? CsrFieldType::RO : CsrFieldType::RW;
+      return (implemented?(ExtensionName::Svadu)) ? CsrFieldType::RW : CsrFieldType::RO;
     reset_value(): |
       return (implemented?(ExtensionName::Svadu)) ? UNDEFINED_LEGAL : 0;
   CBZE:

--- a/spec/std/isa/csr/menvcfgh.yaml
+++ b/spec/std/isa/csr/menvcfgh.yaml
@@ -46,6 +46,6 @@ fields:
       Alias of `menvcfg.ADUE`
     definedBy: Svadu
     type(): |
-      return (implemented?(ExtensionName::Svadu)) ? CsrFieldType::RO : CsrFieldType::RW;
+      return (implemented?(ExtensionName::Svadu)) ? CsrFieldType::RW : CsrFieldType::RO;
     reset_value(): |
       return (implemented?(ExtensionName::Svadu)) ? UNDEFINED_LEGAL : 0;


### PR DESCRIPTION
The ADUE field type() logic was backwards in all environment configuration CSRs.

Fixed logic:
- When Svadu IS implemented  ADUE field is Read-Write (software control)
- When Svadu is NOT implemented  ADUE field is Read-Only-0 (hardwired)

Closes #1026