### PR TITLE
fix: always recreate bundle config by default #980

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -9,27 +9,30 @@ CONTAINER_TAG=`cat ${ROOT}/bin/.container-tag`
 # Parse command line arguments
 PRESERVE_CONFIG=0
 
-for arg in "$@"; do
-  case $arg in
-    --preserve-config)
-      PRESERVE_CONFIG=1
-      shift
-      ;;
-    --help|-h)
-      echo "Usage: $0 [OPTIONS]"
-      echo ""
-      echo "Options:"
-      echo "  --preserve-config    Only create .bundle/config if missing (default: always recreate)"
-      echo "  --help, -h           Show this help message"
-      exit 0
-      ;;
-    *)
-      echo "Unknown option: $arg"
-      echo "Use --help for usage information"
-      exit 1
-      ;;
-  esac
-done
+# Only parse arguments if this script is being run directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  for arg in "$@"; do
+    case $arg in
+      --preserve-config)
+        PRESERVE_CONFIG=1
+        shift
+        ;;
+      --help|-h)
+        echo "Usage: $0 [OPTIONS]"
+        echo ""
+        echo "Options:"
+        echo "  --preserve-config    Only create .bundle/config if missing (default: always recreate)"
+        echo "  --help, -h           Show this help message"
+        exit 0
+        ;;
+      *)
+        echo "Unknown option: $arg"
+        echo "Use --help for usage information"
+        exit 1
+        ;;
+    esac
+  done
+fi
 
 # Supported container types:
 #

--- a/bin/setup
+++ b/bin/setup
@@ -6,6 +6,31 @@ cd $ROOT
 
 CONTAINER_TAG=`cat ${ROOT}/bin/.container-tag`
 
+# Parse command line arguments
+PRESERVE_CONFIG=0
+
+for arg in "$@"; do
+  case $arg in
+    --preserve-config)
+      PRESERVE_CONFIG=1
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: $0 [OPTIONS]"
+      echo ""
+      echo "Options:"
+      echo "  --preserve-config    Only create .bundle/config if missing (default: always recreate)"
+      echo "  --help, -h           Show this help message"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg"
+      echo "Use --help for usage information"
+      exit 1
+      ;;
+  esac
+done
+
 # Supported container types:
 #
 # = devcontainer
@@ -128,7 +153,10 @@ if [ ! -d $ROOT/.home ]; then
     mkdir $ROOT/.home
 fi
 
-if [ ! -f $ROOT/.bundle/config ]; then
+if [ $PRESERVE_CONFIG -eq 0 ] || [ ! -f $ROOT/.bundle/config ]; then
+    if [ -f $ROOT/.bundle/config ] && [ $PRESERVE_CONFIG -eq 0 ]; then
+        echo "Recreating bundle config..."
+    fi
     OLDDIR=$PWD
     cd $ROOT
     ${RUN} bundle config set --local path ${ROOT}/.home/.gems


### PR DESCRIPTION
- Change default behavior to always recreate .bundle/config
- Users will now always get configuration updates
- Add --preserve-config option for backward compatibility
- Add --help option for usage information
- Fix argument processing conflicts when script is sourced by other tools
- Prioritizes reliability over performance concerns 
- Addresses overly cautious guard that prevented config updates
- Uses sir @rpsene's argument parsing approach with improved defaults

Fixes #980

Ready for Review sir @ThinkOpenly sir @dhower-qc sir @christian-herber-nxp 