### PR TITLE
fix: henvcfg upper-half fields: add base: 64

### DIFF
--- a/spec/std/isa/csr/H/henvcfg.yaml
+++ b/spec/std/isa/csr/H/henvcfg.yaml
@@ -103,6 +103,7 @@ definedBy:
 fields:
   STCE:
     location: 63
+    base: 64
     description: |
       *STimecmp Enable*
 
@@ -126,6 +127,7 @@ fields:
       return (implemented?(ExtensionName::Sstc)) ? UNDEFINED_LEGAL : 0;
   PBMTE:
     location: 62
+    base: 64
     description: |
       *Page Based Memory Type Enable*
 
@@ -166,6 +168,7 @@ fields:
       return (implemented?(ExtensionName::Svpbmt)) ? UNDEFINED_LEGAL : 0;
   ADUE:
     location: 61
+    base: 64
     description: |
       If the `Svadu` extension is implemented, the ADUE bit controls whether hardware updating of
       PTE A/D bits is enabled for VS-stage address translation.


### PR DESCRIPTION
Add base: 64 to henvcfg fields with location >= 32:
- STCE (location: 63)
- PBMTE (location: 62)
- ADUE (location: 61)

This ensures these fields are only present when XLEN == 64. On 32-bit systems, they must be accessed via henvcfgh.

Fixes #1041

Note: Other CSRs (menvcfg, mstatus, etc.) need similar fixes and will be addressed in follow-up PRs.

Ready for check sir @ThinkOpenly @dhower-qc 