### PR TITLE
ci: fix deploy pages workflow error

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -223,11 +223,7 @@ jobs:
           PAGES_URL: https://riscv-software-src.github.io/riscv-unified-db
         run: >
           cp doc/udb-block.svg _site/ &&
-          ruby -r erb -r date
-            -e "File.write('_site/index.html',
-                           ERB.new(File.read('tools/scripts/pages.html.erb'),
-                                   trim_mode: '-').result(binding))"
-
+          ruby -r erb -r date -e "File.write('_site/index.html', ERB.new(File.read('tools/scripts/pages.html.erb'), trim_mode: '-').result(binding))"
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
Workflow action "pages" is failing:
```
  cp doc/udb-block.svg _site/ && ruby -r erb -r date
    -e "File.write('_site/index.html',
                   ERB.new(File.read('tools/scripts/pages.html.erb'),
                           trim_mode: '-').result(binding))"
  shell: /usr/bin/bash -e {0}
  env:
    SINGULARITY: 1
    PAGES_URL: https://riscv-software-src.github.io/riscv-unified-db
/home/runner/work/_temp/66305e27-873c-44c3-94d0-8903895f3902.sh: line 4: -e: command not found
```

I think the line invoking Ruby needs to be all on one logical line.