### PR TITLE
fix fmv.h.x definedBy extension from F to [Zfh, Zfhmin, Zhinx]

### DIFF
--- a/spec/std/isa/inst/Zfh/fmv.h.x.yaml
+++ b/spec/std/isa/inst/Zfh/fmv.h.x.yaml
@@ -12,7 +12,8 @@ description: |
   from the lower 16 bits of integer register `xs1` to the floating-point
   register `fd`. The bits are not modified in the transfer, and in particular,
   the payloads of non-canonical NaNs are preserved.
-definedBy: F
+definedBy:
+  anyOf: [Zfh, Zfhmin, Zhinx]
 assembly: fd, xs1
 encoding:
   match: 111101000000-----000-----1010011


### PR DESCRIPTION
Fixes #1052 - fmv.h.x was incorrectly defined by extension F instead of the proper half-precision floating-point extensions. Updated to match the pattern used by fmv.x.h instruction.

Raedy for review sir @ThinkOpenly @dhower-qc 