### PR TITLE
fix: incorrect pseudoinstruction name for bge (fixes #1062)

### DIFF
--- a/spec/std/isa/inst/I/bge.yaml
+++ b/spec/std/isa/inst/I/bge.yaml
@@ -33,7 +33,7 @@ pseudoinstructions:
   - when: xs1 == 0
     to: blez xs2,imm
   - when: xs2 == 0
-    to: blez xs1,imm
+    to: bgez xs1,imm
 operation(): |
   XReg lhs = X[xs1];
   XReg rhs = X[xs2];


### PR DESCRIPTION
the second pseudoinstruction name is incorrect (see #1062)