### PR TITLE
feat(backends): add binutils generator for RISC-V opcode tables

### DIFF
--- a/backends/generators/binutils/README.md
+++ b/backends/generators/binutils/README.md
@@ -1,0 +1,154 @@
+# Binutils RISC-V Generator
+
+This generator creates binutils-compatible opcode table entries from RISC-V UDB instruction definitions, following the format used in `binutils-gdb/opcodes/riscv-opc.c`.
+
+## Generated Files
+
+The generator produces two files for every run:
+
+### 1. Opcode Table (`.c` file)
+- **Format**: `{output_name}.c` 
+- **Purpose**: Contains the `riscv_opcodes[]` array with instruction definitions
+- **Structure**: Each entry follows binutils format: `{name, xlen, insn_class, operands, MATCH, MASK, match_func, pinfo}`
+- **Example**: `{"add", 0, INSN_CLASS_I, "d,s,t", MATCH_ADD, MASK_ADD, match_opcode, 0}`
+
+### 2. Header File (`.h` file)
+- **Format**: `{output_name}.h`
+- **Purpose**: Contains `#define` constants and custom instruction class definitions
+- **Contents**:
+  - `MATCH_*` constants for instruction matching
+  - `MASK_*` constants for instruction masking
+  - Custom `INSN_CLASS_*` definitions (commented out for manual addition to binutils)
+
+## Architecture
+
+### Single Source of Truth
+All instruction class mappings are centralized in `insn_class_config.py`:
+
+- **`BUILTIN_CLASSES`**: Maps extensions to existing binutils instruction classes
+- **`BUILTIN_COMBINATIONS`**: Maps complex extension combinations to binutils classes
+- **`is_builtin_class()`**: Determines if a class already exists in binutils
+
+### Extension Mapping
+The `ExtensionMapper` class handles UDB `definedBy` specifications:
+
+- **Simple extensions**: Direct 1:1 mapping (e.g., `Zba` → `INSN_CLASS_ZBA`)
+- **Complex combinations**: 
+  - `anyOf` → `*_OR_*` classes (e.g., `[Zbb, Zbkb]` → `INSN_CLASS_ZBB_OR_ZBKB`)
+  - `allOf` → `*_AND_*` classes (e.g., `[Zcb, Zba]` → `INSN_CLASS_ZCB_AND_ZBA`)
+- **Custom extensions**: Auto-generates class names (e.g., `Zfoo` → `INSN_CLASS_ZFOO`)
+
+### Operand Mapping
+The `OperandMapper` class converts UDB assembly format to binutils operand strings:
+
+- Maps register operands (e.g., `xd` → `d`, `xs1` → `s`)
+- Handles immediate operands (e.g., `imm` → `j`)
+- Marks unknown patterns as `NON_DEFINED_*`
+
+## Usage
+
+### Basic Usage
+```bash
+python3 binutils_generator.py --extensions=I,M,Zba,Zbb --output=my_opcodes.c
+```
+
+### Command Line Options
+- `--inst-dir`: Directory containing instruction YAML files (default: `../../../spec/std/isa/inst/`)
+- `--output`: Output C file name (corresponding .h file generated automatically)
+- `--extensions`: Comma-separated list of enabled extensions
+- `--arch`: Target architecture (`RV32`, `RV64`, `BOTH`)
+- `--include-all` / `-a`: Include all instructions, ignoring extension filtering
+- `--verbose` / `-v`: Enable verbose logging
+
+### Examples
+```bash
+# Generate for specific extensions
+python3 binutils_generator.py --extensions=I,M,A,F,D --output=rv64_core.c
+
+# Generate all instructions
+python3 binutils_generator.py --include-all --output=complete_riscv.c
+
+# Custom extension
+python3 binutils_generator.py --extensions=I,MyCustomExt --output=custom.c
+```
+
+## Integration with Binutils
+
+### Adding Custom Instruction Classes
+
+1. **Review generated header file**: Check the "Custom instruction class definitions" section
+2. **Add to binutils enum**: Edit `binutils-gdb/include/opcode/riscv.h`
+   ```c
+   enum riscv_insn_class
+   {
+     // ... existing classes ...
+     INSN_CLASS_ZFOO,           // Add your custom classes here
+     INSN_CLASS_I_OR_ZILSD,
+     // ...
+   };
+   ```
+
+3. **Add subset support**: Edit `binutils-gdb/bfd/elfxx-riscv.c` to handle extension requirements
+   ```c
+   static bool
+   riscv_multi_subset_supports (riscv_parse_subset_t *rps,
+                                enum riscv_insn_class insn_class)
+   {
+     switch (insn_class)
+     {
+       // ... existing cases ...
+       case INSN_CLASS_ZFOO:
+         return riscv_subset_supports (rps, "zfoo");
+       // ...
+     }
+   }
+   ```
+
+### Adding Generated Opcodes
+
+1. **Include header**: Add `#include "my_opcodes.h"` to your opcode file
+2. **Merge opcode arrays**: 
+   - Option A: Replace existing `riscv_opcodes[]` in `opcodes/riscv-opc.c`
+   - Option B: Create separate opcode table and modify binutils to use it
+   - Option C: Append entries to existing table
+
+### File Locations in Binutils
+- **Instruction classes**: `include/opcode/riscv.h` (enum `riscv_insn_class`)
+- **Opcode tables**: `opcodes/riscv-opc.c` (`riscv_opcodes[]` array)
+- **Extension support**: `bfd/elfxx-riscv.c` (`riscv_multi_subset_supports()`)
+- **Operand parsing**: `opcodes/riscv-dis.c` and `gas/config/tc-riscv.c`
+
+## Extending the Generator
+
+### Adding New Extensions
+```python
+from extension_mapper import ExtensionMapper
+
+mapper = ExtensionMapper()
+mapper.add_simple_mapping('Zfoo', 'INSN_CLASS_ZFOO')
+mapper.add_complex_mapping('anyOf', ['Zfoo', 'Zbar'], 'INSN_CLASS_ZFOO_OR_ZBAR')
+```
+
+### Custom Operand Mappings
+Edit `operand_mapper.py` to add support for new operand patterns.
+
+### Configuration
+Edit `insn_class_config.py` to modify built-in extension mappings.
+
+## Output Statistics
+
+The generator provides detailed statistics:
+- **Total instructions**: Number of instructions processed
+- **Successfully processed**: Instructions with complete mappings
+- **Non-defined operands**: Instructions with unknown operand patterns
+- **Non-defined extensions**: Instructions with unknown extensions (should be 0 with current design)
+- **Custom classes**: Number of custom instruction classes generated
+
+## Validation
+
+Use `validate_output.py` to compare generated output against reference binutils opcodes:
+```bash
+python3 validate_output.py reference.c generated.c
+```
+
+The validator provides detailed comparison including instruction class, operands, and MATCH/MASK values.

--- a/backends/generators/binutils/binutils_generator.py
+++ b/backends/generators/binutils/binutils_generator.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""
+Binutils RISC-V Generator
+
+Generates binutils-compatible opcode table entries from RISC-V UDB instruction definitions.
+Follows the format used in binutils-gdb/opcodes/riscv-opc.c
+"""
+
+import os
+import sys
+import argparse
+import logging
+import yaml
+import glob
+
+# Add parent directory to path to find generator.py
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from generator import parse_match, parse_extension_requirements
+from naming_config import USER_DEFINED_INSN_NAMES, USER_DEFINED_OPERAND_PREFERENCES, is_user_defined_class
+import re
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s:: %(message)s")
+
+
+# Inline minimal mappers to keep only three files in this toolchain
+
+class ExtensionMapper:
+    def __init__(self) -> None:
+        self._defaults_used = []  # list[(ext, class_name)]
+        self._records = []        # list[(ext, class_name)]
+
+    def map_extension(self, defined_by, instruction_name: str = "") -> str:
+        if isinstance(defined_by, str):
+            ext = defined_by
+            if ext in USER_DEFINED_INSN_NAMES:
+                class_name = USER_DEFINED_INSN_NAMES[ext]
+            else:
+                class_name = f"INSN_CLASS_{ext.upper()}"
+                self._defaults_used.append((ext, class_name))
+            self._records.append((ext, class_name))
+            return class_name
+        if isinstance(defined_by, dict):
+            base = instruction_name or "custom"
+            class_name = f"INSN_CLASS_{base.upper()}"
+            self._defaults_used.append((base, class_name))
+            self._records.append((base, class_name))
+            return class_name
+        class_name = "INSN_CLASS_I"
+        self._records.append(("I", class_name))
+        return class_name
+
+    def get_defaults_warning(self) -> str:
+        if not self._records:
+            return ""
+        lines = []
+        lines.append("\n============================================================")
+        lines.append("WARNING: Default instruction class names were generated")
+        lines.append("============================================================")
+        lines.append("The following extensions used auto-generated names:\n")
+        for ext, cls in self._records:
+            lines.append(f"  • Extension '{ext}' -> {cls}")
+        lines.append("\nTo define custom names, add them to USER_DEFINED_INSN_NAMES in naming_config.py")
+        lines.append("============================================================")
+        return "\n".join(lines)
+
+
+class OperandMatch:
+    def __init__(self, binutils_char, info, score, reasons):
+        self.binutils_char = binutils_char
+        self.binutils_info = info
+        self.score = score
+        self.match_reasons = reasons
+
+
+class OperandMatcher:
+    def __init__(self, binutils_parser):
+        self.parser = binutils_parser
+        self.match_suggestions = {}
+
+    def _parse_bit_range(self, location_str):
+        m = re.match(r'^(\d+)-(\d+)$', location_str)
+        if m:
+            high = int(m.group(1)); low = int(m.group(2))
+            return (low, high)
+        ranges = []
+        for part in location_str.split(','):
+            if '-' in part:
+                m = re.match(r'^(\d+)-(\d+)$', part)
+                if m:
+                    endb = int(m.group(1)); startb = int(m.group(2))
+                    ranges.append((startb, endb))
+            else:
+                b = int(part)
+                ranges.append((b, b))
+        if ranges:
+            ranges.sort(key=lambda x: x[1]-x[0], reverse=True)
+            return ranges[0]
+        return (0, 31)
+
+    def find_matches(self, name, location_str):
+        if not self.parser.parsed:
+            return []
+        low, high = self._parse_bit_range(location_str)
+        matches = []
+        for char, info in self.parser.get_all_operands().items():
+            if info.bit_start == low and info.bit_end == high:
+                matches.append(OperandMatch(char, info, 1.0, [f"Exact bit match ({low}-{high})"]))
+        return matches
+
+    def suggest_operand_mapping(self, operand_name, location_str):
+        key = (operand_name, location_str)
+        if key in USER_DEFINED_OPERAND_PREFERENCES:
+            return USER_DEFINED_OPERAND_PREFERENCES[key]
+        cache_key = f"{operand_name}({location_str})"
+        if cache_key in self.match_suggestions:
+            return None
+        matches = self.find_matches(operand_name, location_str)
+        if not matches:
+            suggestion = f"no_match_{operand_name}_{location_str.replace('-', '_').replace(',', '_')}"
+            logging.warning(f"No exact bit match found for UDB '{operand_name}({location_str})' → using '{suggestion}'")
+            self.match_suggestions[cache_key] = suggestion
+            return suggestion
+        if len(matches) == 1:
+            m = matches[0]
+            logging.info(f"Auto-mapped UDB '{operand_name}({location_str})' → binutils '{m.binutils_char}' (exact bit match)")
+            self.match_suggestions[cache_key] = m.binutils_char
+            return m.binutils_char
+        # Multiple matches: prefer user config; otherwise first
+        preferred = USER_DEFINED_OPERAND_PREFERENCES.get(key)
+        choice = preferred or matches[0].binutils_char
+        return choice
+
+
+class OperandMapper:
+    def __init__(self, binutils_path: str | None = None):
+        self.variable_map = {
+            ('xd', '11-7'): 'd', ('xs1', '19-15'): 's', ('xs2', '24-20'): 't',
+            ('fd', '11-7'): 'D', ('fs1', '19-15'): 'S', ('fs2', '24-20'): 'T',
+            ('imm', '31-20'): 'j', ('imm', '31-25,11-7'): 'o', ('imm', '31,7,30-25,11-8'): 'p', ('imm', '31,19-12,20,30-21'): 'a',
+            ('shamt', '25-20'): '>', ('shamt', '24-20'): '<',
+        }
+        self.binutils_parser = None
+        self.operand_matcher = None
+        if binutils_path:
+            from binutils_parser import BinutilsParser
+            self.binutils_parser = BinutilsParser(binutils_path)
+            if self.binutils_parser.parse_operand_definitions():
+                self.operand_matcher = OperandMatcher(self.binutils_parser)
+                logging.info("Dynamic operand matching enabled with binutils source")
+            else:
+                logging.warning("Could not parse binutils source, using static mappings only")
+        else:
+            logging.info("No binutils path provided, using static mappings only")
+
+    def map_assembly(self, assembly_str, instr_info):
+        if not assembly_str or not assembly_str.strip():
+            return ""
+        variables = self._extract_variables(instr_info)
+        parts = self._parse_assembly(assembly_str)
+        out = []
+        for comp in parts:
+            out.append(self._map_single_operand(comp, variables, instr_info))
+        return ",".join(out)
+
+    def _extract_variables(self, instr_info):
+        variables = {}
+        encoding = instr_info.get("encoding", {})
+        if isinstance(encoding, dict):
+            var_list = encoding.get("variables", [])
+            if not var_list and "RV64" in encoding:
+                rv64 = encoding.get("RV64", {})
+                if isinstance(rv64, dict):
+                    var_list = rv64.get("variables", [])
+            elif not var_list and "RV32" in encoding:
+                rv32 = encoding.get("RV32", {})
+                if isinstance(rv32, dict):
+                    var_list = rv32.get("variables", [])
+            for var in var_list:
+                if isinstance(var, dict):
+                    name = var.get("name"); location = var.get("location"); not_c = var.get("not")
+                    if name and location:
+                        variables[name] = {'location': str(location), 'not': not_c}
+        return variables
+
+    def _parse_assembly(self, assembly_str):
+        comps = [c.strip() for c in assembly_str.split(',')]
+        parsed = []
+        for comp in comps:
+            if '(' in comp and ')' in comp:
+                m = re.match(r'([^(]+)\(([^)]+)\)', comp)
+                if m:
+                    offset, base = m.groups(); parsed.extend([offset.strip(), base.strip()])
+                else:
+                    parsed.append(comp)
+            else:
+                parsed.append(comp)
+        return parsed
+
+    def _map_single_operand(self, operand, variables, instr_info):
+        operand = operand.strip()
+        if operand in ("rm", "csr"):
+            return ""
+        if operand in variables:
+            var = variables[operand]; location = var['location']; not_c = var.get('not')
+            is_compressed = instr_info.get("name", "").startswith("c.")
+            mapping_keys = [ (operand, location), (operand, location, 'compressed') if is_compressed else None, (operand, location, 'x8-x15') if not_c == 0 else None ]
+            for key in mapping_keys:
+                if key and key in self.variable_map:
+                    res = self.variable_map[key]
+                    if res:
+                        return res
+            if self.operand_matcher:
+                suggestion = self.operand_matcher.suggest_operand_mapping(operand, location)
+                if suggestion:
+                    return suggestion
+            if self.operand_matcher:
+                return self.operand_matcher.get_fallback_operand(operand, location)
+            else:
+                return f"NON_DEFINED_{operand}_{location}"
+        return f"NON_DEFINED_{operand}"
+
+
+def load_full_instructions(inst_dir, enabled_extensions, include_all, target_arch):
+    instructions = {}
+    if enabled_extensions is None:
+        enabled_extensions = []
+    yaml_files = glob.glob(os.path.join(inst_dir, "**/*.yaml"), recursive=True)
+    logging.info(f"Found {len(yaml_files)} instruction files in {inst_dir}")
+    for yaml_file in yaml_files:
+        try:
+            with open(yaml_file, 'r', encoding='utf-8') as f:
+                data = yaml.safe_load(f)
+            if not isinstance(data, dict) or data.get('kind') != 'instruction':
+                continue
+            name = data.get('name')
+            if not name:
+                continue
+            defined_by = data.get('definedBy')
+            if not include_all and defined_by:
+                try:
+                    meets_req = parse_extension_requirements(defined_by)
+                    if not meets_req(enabled_extensions):
+                        logging.debug(f"Skipping {name} - extension requirements not met")
+                        continue
+                except Exception as e:
+                    logging.debug(f"Error parsing extension requirements for {name}: {e}")
+                    continue
+            encoding = data.get('encoding', {})
+            if target_arch in ['RV32', 'RV64'] and target_arch in encoding:
+                arch_encoding = encoding[target_arch]
+                data['encoding'] = arch_encoding
+            instructions[name] = data
+        except Exception as e:
+            logging.error(f"Error loading {yaml_file}: {e}")
+            continue
+    logging.info(f"Loaded {len(instructions)} instructions after filtering")
+    return instructions
+
+
+def generate_binutils_opcodes(instr_dict, output_file="riscv-opc.c", extension_mapper=None, binutils_path=None):
+    operand_mapper = OperandMapper(binutils_path)
+    if extension_mapper is None:
+        extension_mapper = ExtensionMapper()
+    args = " ".join(sys.argv)
+
+    opcode_entries = []
+    stats = {'total': 0, 'success': 0, 'non_defined_operands': 0, 'non_defined_extensions': 0, 'errors': 0}
+
+    for name, info in sorted(instr_dict.items(), key=lambda x: x[0].upper()):
+        stats['total'] += 1
+        try:
+            encoding = info.get("encoding", {})
+            match_str = encoding.get("match", "")
+            if not match_str:
+                logging.warning(f"No match string found for {name}")
+                continue
+            defined_by = info.get("definedBy", "I")
+            assembly = info.get("assembly", "")
+            enc_match = parse_match(match_str)
+            enc_mask = int(''.join('1' if c != '-' else '0' for c in match_str), 2)
+            insn_class = extension_mapper.map_extension(defined_by, instruction_name=name)
+            if "NON_DEFINED" in insn_class:
+                stats['non_defined_extensions'] += 1
+                logging.warning(f"Non-defined extension for {name}: {defined_by} -> {insn_class}")
+            if insn_class.startswith('INSN_CLASS_') and not is_user_defined_class(insn_class):
+                if not hasattr(generate_binutils_opcodes, 'custom_classes'):
+                    generate_binutils_opcodes.custom_classes = set()
+                generate_binutils_opcodes.custom_classes.add(insn_class)
+            operand_format = operand_mapper.map_assembly(assembly, info)
+            if "NON_DEFINED" in operand_format:
+                stats['non_defined_operands'] += 1
+                logging.warning(f"Non-defined operands for {name}: {assembly} -> {operand_format}")
+            match_const = f"MATCH_{name.upper().replace('.', '_')}"
+            mask_const = f"MASK_{name.upper().replace('.', '_')}"
+            entry = f'  {{"{name}", 0, {insn_class}, "{operand_format}", {match_const}, {mask_const}, match_opcode, 0}}'
+            opcode_entries.append(entry)
+            if not hasattr(generate_binutils_opcodes, 'constants'):
+                generate_binutils_opcodes.constants = []
+            generate_binutils_opcodes.constants.append({
+                'name': name,
+                'match_const': match_const,
+                'mask_const': mask_const,
+                'match_value': f"0x{enc_match:x}",
+                'mask_value': f"0x{enc_mask:x}"
+            })
+            if insn_class.startswith('INSN_CLASS_') and not is_user_defined_class(insn_class):
+                if not hasattr(generate_binutils_opcodes, 'custom_class_extensions'):
+                    generate_binutils_opcodes.custom_class_extensions = {}
+                generate_binutils_opcodes.custom_class_extensions[insn_class] = defined_by
+            stats['success'] += 1
+        except Exception as e:
+            stats['errors'] += 1
+            logging.error(f"Error processing {name}: {e}")
+            continue
+
+    prelude = f"/* Code generated by {args}; DO NOT EDIT. */\n"
+    prelude += "/* This file should be placed at: binutils-gdb/opcodes/riscv-opc.c */\n\n"
+    prelude += """#include "opcode/riscv.h"
+
+const struct riscv_opcode riscv_opcodes[] = {
+"""
+    opcodes_str = ",\n".join(opcode_entries)
+    postlude = "\n};\n"
+    full_output = prelude + opcodes_str + postlude
+    with open(output_file, "w", encoding="utf-8") as f:
+        f.write(full_output)
+
+    generate_header_file(output_file, args)
+    generate_subset_support(output_file, args)
+
+    header_file = output_file.replace('.c', '.h')
+    support_file = 'elfxx-riscv.c'
+    logging.info(f"Generated files:")
+    logging.info(f"  Opcode table:    {output_file}")
+    logging.info(f"  Header file:     {header_file}")
+    if hasattr(generate_binutils_opcodes, 'custom_class_extensions') and generate_binutils_opcodes.custom_class_extensions:
+        logging.info(f"  Subset support:  {support_file}")
+    logging.info(f"Statistics:")
+    logging.info(f"  Total instructions: {stats['total']}")
+    logging.info(f"  Successfully processed: {stats['success']}")
+    logging.info(f"  Non-defined operands: {stats['non_defined_operands']}")
+    logging.info(f"  Non-defined extensions: {stats['non_defined_extensions']}")
+    logging.info(f"  Errors: {stats['errors']}")
+
+
+def generate_header_file(output_file, args):
+    if not hasattr(generate_binutils_opcodes, 'constants'):
+        logging.warning("No constants collected for header generation")
+        return
+    header_file = output_file.replace('.c', '.h')
+    args_str = " ".join(sys.argv)
+    header_content = f"""/* Code generated by {args_str}; DO NOT EDIT. */
+/* This file should be placed at: binutils-gdb/include/opcode/riscv.h (append to existing file) */
+
+#ifndef RISCV_OPC_H
+#define RISCV_OPC_H
+
+/* RISC-V opcode constants for {len(generate_binutils_opcodes.constants)} instructions */
+
+"""
+    custom_classes = set()
+    if hasattr(generate_binutils_opcodes, 'custom_classes'):
+        custom_classes = generate_binutils_opcodes.custom_classes
+    if custom_classes:
+        header_content += "/* Custom instruction class definitions */\n"
+        header_content += "/* Add these to your binutils enum riscv_insn_class in include/opcode/riscv.h */\n"
+        for class_name in sorted(custom_classes):
+            header_content += f"/* {class_name}, */\n"
+        header_content += "\n"
+    header_content += "/* MATCH constants */\n"
+    for const in sorted(generate_binutils_opcodes.constants, key=lambda x: x['name']):
+        header_content += f"#define {const['match_const']} {const['match_value']}\n"
+    header_content += "\n/* MASK constants */\n"
+    for const in sorted(generate_binutils_opcodes.constants, key=lambda x: x['name']):
+        header_content += f"#define {const['mask_const']} {const['mask_value']}\n"
+    header_content += "\n#endif /* RISCV_OPC_H */\n"
+    with open(header_file, "w", encoding="utf-8") as f:
+        f.write(header_content)
+    stats_msg = f"  MATCH/MASK constants: {len(generate_binutils_opcodes.constants) * 2}"
+    if custom_classes:
+        stats_msg += f", Custom classes: {len(custom_classes)}"
+    logging.info(f"Generated header file: {header_file}")
+    logging.info(stats_msg)
+
+
+def generate_subset_support(output_file, args):
+    if not hasattr(generate_binutils_opcodes, 'custom_class_extensions'):
+        return
+    custom_class_extensions = generate_binutils_opcodes.custom_class_extensions
+    if not custom_class_extensions:
+        return
+    support_file = 'elfxx-riscv.c'
+    args_str = " ".join(sys.argv)
+    content = f"""/* Code generated by {args_str}; DO NOT EDIT. */
+/* This file contains code snippets that should be added to: binutils-gdb/bfd/elfxx-riscv.c */
+
+/* Add these cases to riscv_multi_subset_supports() in bfd/elfxx-riscv.c */
+
+"""
+    content += "/* Cases for riscv_multi_subset_supports() switch statement */\n"
+    for class_name in sorted(custom_class_extensions.keys()):
+        extension_def = custom_class_extensions[class_name]
+        case_code = generate_subset_support_case_from_udb(class_name, extension_def)
+        content += case_code
+    content += "\n/* Cases for riscv_multi_subset_supports_ext() switch statement */\n"
+    for class_name in sorted(custom_class_extensions.keys()):
+        extension_def = custom_class_extensions[class_name]
+        case_code = generate_subset_support_ext_case_from_udb(class_name, extension_def)
+        content += case_code
+    content += f"""
+
+/* Instructions for integration:
+ * 
+ * 1. Add the instruction classes to include/opcode/riscv.h:
+ *    (Already listed in the generated .h file)
+ *
+ * 2. Add these cases to the switch statement in bfd/elfxx-riscv.c:
+ *    - Find function riscv_multi_subset_supports()
+ *    - Add the cases above to the switch statement
+ *    - Find function riscv_multi_subset_supports_ext()  
+ *    - Add the ext cases above to the switch statement
+ *
+ * 3. Extension names are converted to lowercase in subset support functions
+ */
+"""
+    with open(support_file, "w", encoding="utf-8") as f:
+        f.write(content)
+    logging.info(f"Generated subset support file: {support_file}")
+    logging.info(f"  Custom classes: {len(custom_class_extensions)}")
+
+
+def generate_subset_support_case_from_udb(class_name, extension_def):
+    logic = generate_extension_logic(extension_def)
+    return f"""    case {class_name}:
+      {logic}
+"""
+
+
+def generate_subset_support_ext_case_from_udb(class_name, extension_def):
+    ext_message = generate_extension_error_message(extension_def)
+    if isinstance(ext_message, str) and ext_message.startswith('_('):
+        return f"""    case {class_name}:
+      return {ext_message};
+"""
+    else:
+        return f"""    case {class_name}:
+      return \"{ext_message}\";
+"""
+
+
+def generate_extension_logic(extension_def):
+    if isinstance(extension_def, str):
+        return f'return riscv_subset_supports (rps, "{extension_def.lower()}");'
+    elif isinstance(extension_def, dict):
+        if "anyOf" in extension_def:
+            extensions = extension_def["anyOf"]
+            checks = [f'riscv_subset_supports (rps, "{ext.lower()}")' for ext in extensions]
+            return f"return ({' || '.join(checks)});"
+        elif "allOf" in extension_def:
+            extensions = extension_def["allOf"]
+            checks = [f'riscv_subset_supports (rps, "{ext.lower()}")' for ext in extensions]
+            return f"return ({' && '.join(checks)});"
+        else:
+            return 'return false; /* TODO: Complex extension logic */'
+    else:
+        return 'return false; /* TODO: Unknown extension type */'
+
+
+def generate_extension_error_message(extension_def):
+    if isinstance(extension_def, str):
+        return extension_def.lower()
+    elif isinstance(extension_def, dict):
+        if "anyOf" in extension_def:
+            extensions = [ext.lower() for ext in extension_def["anyOf"]]
+            ext_list = "' or `".join(extensions)
+            return f'_("{ext_list}")'
+        elif "allOf" in extension_def:
+            extensions = [ext.lower() for ext in extension_def["allOf"]]
+            ext_list = "' and `".join(extensions)
+            return f'_("{ext_list}")'
+        else:
+            return f'TODO: {extension_def}'
+    else:
+        return f'TODO: {extension_def}'
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate binutils RISC-V opcode table from UDB instruction definitions"
+    )
+    parser.add_argument("--inst-dir", default="../../../spec/std/isa/inst/", help="Directory containing instruction YAML files")
+    parser.add_argument("--output", default="riscv-opc.c", help="Output C file name (corresponding .h file will be generated automatically)")
+    parser.add_argument("--extensions", default="I,M,A,F,D,C,Zba,Zbb,Zbs,Zca", help="Comma-separated list of enabled extensions")
+    parser.add_argument("--arch", default="RV64", choices=["RV32", "RV64", "BOTH"], help="Target architecture")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging")
+    parser.add_argument("--include-all", "-a", action="store_true", help="Include all instructions, ignoring extension filtering")
+    parser.add_argument("--binutils-path", default="../binutils-gdb/", help="Path to binutils-gdb source directory for operand reference")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+    include_all = args.include_all or not args.extensions
+    if include_all:
+        enabled_extensions = []
+        logging.info("Including all instructions (extension filtering disabled)")
+    else:
+        enabled_extensions = [ext.strip() for ext in args.extensions.split(",") if ext.strip()]
+        logging.info(f"Enabled extensions: {', '.join(enabled_extensions)}")
+    logging.info(f"Target architecture: {args.arch}")
+    extension_mapper = ExtensionMapper()
+    logging.info("Using user-defined names from insn_class_config.py or auto-generated defaults")
+    if not os.path.isdir(args.inst_dir):
+        logging.error(f"Instruction directory not found: {args.inst_dir}")
+        sys.exit(1)
+    instr_dict = load_full_instructions(args.inst_dir, enabled_extensions, include_all, args.arch)
+    if not instr_dict:
+        logging.error("No instructions found or all were filtered out.")
+        sys.exit(1)
+    logging.info(f"Loaded {len(instr_dict)} instructions")
+    generate_binutils_opcodes(instr_dict, args.output, extension_mapper, args.binutils_path)
+    warning = extension_mapper.get_defaults_warning()
+    if warning:
+        print(warning)
+
+
+if __name__ == "__main__":
+    main()

--- a/backends/generators/binutils/binutils_parser.py
+++ b/backends/generators/binutils/binutils_parser.py
@@ -1,0 +1,436 @@
+"""
+Binutils Source Parser for RISC-V Operand Definitions
+
+Houses both:
+- A small API (BinutilsParser) used by the generator to discover operand tokens
+  and their bit positions; and
+- The underlying extractor helpers (parse_op_fields, parse_encode_macros,
+  extract_operand_mapping, derive_bits_for_token) so logic lives in one place.
+
+This keeps behavior identical while reducing duplication, and allows other
+tools (like the standalone extractor script) to import the same helpers.
+"""
+
+import os
+import logging
+import re
+from pathlib import Path
+from collections import OrderedDict
+from typing import Dict, List, Tuple, Optional, NamedTuple
+
+
+# ----------------------------
+# Extractor helper functions
+# ----------------------------
+
+def parse_op_fields(riscv_h: str):
+    """Parse OP_SH_* and OP_MASK_* into a field->bits map.
+
+    Returns dict FIELD -> {shift, mask, width, bits:[int...]}
+    """
+    sh_re = re.compile(r"#define\s+OP_SH_([A-Z0-9_]+)\s+(\d+)")
+    mask_re = re.compile(r"#define\s+OP_MASK_([A-Z0-9_]+)\s+((?:0x[0-9A-Fa-f]+|\d+)[Uu]?)")
+
+    shifts = {}
+    masks = {}
+    for m in sh_re.finditer(riscv_h):
+        shifts[m.group(1)] = int(m.group(2))
+    for m in mask_re.finditer(riscv_h):
+        raw = m.group(2)
+        if raw.endswith(('U', 'u')):
+            raw = raw[:-1]
+        masks[m.group(1)] = int(raw, 0)
+
+    fields = {}
+    for name, sh in shifts.items():
+        if name not in masks:
+            continue
+        mask = masks[name]
+        width = mask.bit_count()
+        bits = []
+        local = mask
+        bit_index = 0
+        while local:
+            if local & 1:
+                bits.append(sh + bit_index)
+            local >>= 1
+            bit_index += 1
+        if width and len(bits) != width:
+            bits = sorted(bits)
+        elif width:
+            bits = list(range(sh, sh + width))
+        fields[name] = {
+            "shift": sh,
+            "mask": mask,
+            "width": width,
+            "bits": bits,
+        }
+    return fields
+
+
+def parse_encode_macros(riscv_h: str):
+    """Parse ENCODE_* macros to compute instruction bit destinations for immediates."""
+    define_re = re.compile(r"^#define\s+ENCODE_([A-Z0-9_]+)\(x\)\s+(.*)$", re.M)
+    lines = riscv_h.splitlines()
+    macros = {}
+    for m in define_re.finditer(riscv_h):
+        name = m.group(1)
+        start_pos = m.start()
+        start_line = riscv_h.count('\n', 0, start_pos)
+        body_lines = []
+        i = start_line
+        while i < len(lines):
+            body_lines.append(lines[i])
+            if not lines[i].rstrip().endswith('\\'):
+                break
+            i += 1
+        body = " ".join([bl.rstrip(' \\') for bl in body_lines])
+        segs = []
+        for sm in re.finditer(r"RV_X\(x,\s*(\d+),\s*(\d+)\)\s*<<\s*(\d+)", body):
+            src_start = int(sm.group(1))
+            width = int(sm.group(2))
+            dst_start = int(sm.group(3))
+            segs.append({"src_start": src_start, "width": width, "dst_start": dst_start})
+        if not segs:
+            continue
+        bits = []
+        for seg in segs:
+            bits.extend(range(seg["dst_start"], seg["dst_start"] + seg["width"]))
+        macros[name] = {"segments": segs, "bits": sorted(set(bits))}
+    return macros
+
+
+case_re = re.compile(r"^\s*case\s*'(.?)':\s*(?:/\*\s*(.*?)\s*\*/)?")
+switch_start_re = re.compile(r"^\s*switch\s*\(\*[+]*oparg\)\s*")
+INSERT_RE = re.compile(r"INSERT_OPERAND\s*\(\s*([A-Z0-9_]+)")
+EXTRACT_ANY_RE = re.compile(r"\bEXTRACT_([A-Z0-9_]+)\s*\(")
+ENCODE_ANY_RE = re.compile(r"\bENCODE_([A-Z0-9_]+)\s*\(")
+
+
+def parse_operand_switch(lines, start_idx=0):
+    """Parse the switch(*oparg) table capturing top-level cases and nested C/V/X/W."""
+    entries = []
+    i = start_idx
+    n = len(lines)
+    while i < n and not switch_start_re.search(lines[i]):
+        i += 1
+    if i >= n:
+        return entries
+    i += 1
+    while i < n:
+        line = lines[i]
+        m = case_re.match(line)
+        if m:
+            ch, cmt = m.group(1), (m.group(2) or '').strip()
+            if ch in ('C', 'V', 'X', 'W'):
+                j = i + 1
+                while j < n and not switch_start_re.search(lines[j]):
+                    if case_re.match(lines[j]):
+                        break
+                    j += 1
+                if j >= n or not switch_start_re.search(lines[j]):
+                    i += 1
+                    continue
+                depth = 0
+                seen_brace = False
+                k = j + 1
+                while k < n:
+                    l2 = lines[k]
+                    if '{' in l2 or '}' in l2:
+                        depth += l2.count('{') - l2.count('}')
+                        if l2.count('{'):
+                            seen_brace = True
+                        if seen_brace and depth < 0:
+                            break
+                        if seen_brace and depth == 0:
+                            k += 1
+                            break
+                    mm = case_re.match(l2)
+                    if mm and (not seen_brace or depth > 0):
+                        subch, subcmt = mm.group(1), (mm.group(2) or '').strip()
+                        key = f"{ch}.{subch}"
+                        inserts, extracts, encodes = set(), set(), set()
+                        la = 0
+                        kk = k + 1
+                        local_depth = 0
+                        while kk < n and la < 30:
+                            if case_re.match(lines[kk]) and local_depth == 0:
+                                break
+                            local_depth += lines[kk].count('{') - lines[kk].count('}')
+                            inserts.update(INSERT_RE.findall(lines[kk]))
+                            extracts.update(EXTRACT_ANY_RE.findall(lines[kk]))
+                            encodes.update(ENCODE_ANY_RE.findall(lines[kk]))
+                            kk += 1
+                            la += 1
+                        entries.append((key, subcmt, sorted(inserts), sorted(extracts), sorted(encodes)))
+                    k += 1
+                i = k
+                continue
+            else:
+                key = ch
+                inserts, extracts, encodes = set(), set(), set()
+                la = 0
+                j = i + 1
+                local_depth = 0
+                while j < n and la < 30:
+                    if case_re.match(lines[j]) and local_depth == 0:
+                        break
+                    local_depth += lines[j].count('{') - lines[j].count('}')
+                    inserts.update(INSERT_RE.findall(lines[j]))
+                    extracts.update(EXTRACT_ANY_RE.findall(lines[j]))
+                    encodes.update(ENCODE_ANY_RE.findall(lines[j]))
+                    j += 1
+                    la += 1
+                entries.append((key, cmt, sorted(inserts), sorted(extracts), sorted(encodes)))
+        i += 1
+    return entries
+
+
+def extract_operand_mapping(tc_riscv_c: str, riscv_dis_c: str):
+    """Return an ordered mapping of operand token -> macro usage from asm+dis."""
+    asm_lines = tc_riscv_c.splitlines()
+    dis_lines = riscv_dis_c.splitlines()
+    def start_idx(lines):
+        for idx, ln in enumerate(lines):
+            if 'The operand string defined in the riscv_opcodes' in ln:
+                return idx
+        for idx, ln in enumerate(lines):
+            if 'switch (*oparg)' in ln:
+                return idx
+        return 0
+    asm_entries = parse_operand_switch(asm_lines, start_idx(asm_lines))
+    dis_entries = parse_operand_switch(dis_lines, start_idx(dis_lines))
+
+    merged = OrderedDict()
+    for key, cmt, ins, ex, en in asm_entries:
+        merged[key] = {
+            'asm': {'comment': cmt, 'inserts': ins, 'encodes': en},
+            'dis': {'comment': '', 'extracts': []},
+        }
+    for key, cmt, ins, ex, en in dis_entries:
+        d = merged.setdefault(key, {'asm': {'comment': '', 'inserts': [], 'encodes': []},
+                                    'dis': {'comment': '', 'extracts': []}})
+        d['dis']['comment'] = cmt
+        d['dis']['extracts'] = ex
+    return merged
+
+
+def derive_bits_for_token(token, macro_use, fields_map, enc_map):
+    """Given a token's asm/dis macro usage, compute bit positions and notes."""
+    bits = set()
+    notes = []
+    inserts = macro_use.get('asm', {}).get('inserts', [])
+    encodes = macro_use.get('asm', {}).get('encodes', [])
+    extracts = macro_use.get('dis', {}).get('extracts', [])
+
+    for fld in inserts:
+        if fld in fields_map:
+            bits.update(fields_map[fld]['bits'])
+
+    for enc in encodes:
+        if enc in enc_map:
+            bits.update(enc_map[enc]['bits'])
+
+    if not bits and extracts:
+        for ex in extracts:
+            if ex in fields_map:
+                bits.update(fields_map[ex]['bits'])
+                continue
+            alias = None
+            if ex.endswith('_IMM'):
+                alias = ex.replace('EXTRACT_', 'ENCODE_')
+            elif ex.startswith('RVV_V') or ex.startswith('ZCB') or ex.startswith('ZCM') or ex.startswith('CV_') or ex.startswith('MIPS_'):
+                alias = ex.replace('EXTRACT_', 'ENCODE_')
+            if alias and alias in enc_map:
+                bits.update(enc_map[alias]['bits'])
+
+    if not bits:
+        fallback = {
+            'd': 'RD', 's': 'RS1', 't': 'RS2', 'r': 'RS3',
+            'm': 'RM', 'E': 'CSR', 'P': 'PRED', 'Q': 'SUCC',
+            '>': 'SHAMT', '<': 'SHAMTW', 'Z': 'RS1',
+            'C.s': 'CRS1S', 'C.t': 'CRS2S', 'C.V': 'CRS2',
+            'V.d': 'VD', 'V.s': 'VS1', 'V.t': 'VS2', 'V.m': 'VMASK', 'V.i': 'VIMM', 'V.j': 'VIMM',
+        }
+        fld = fallback.get(token)
+        if fld and fld in fields_map:
+            bits.update(fields_map[fld]['bits'])
+
+    if token == '0':
+        notes.append('constant-zero; bits reported when context provides an immediate encoder')
+
+    return sorted(bits), notes
+
+# Reuse the proven extractor implementation in this directory.
+# We import its helpers instead of re-implementing parsing here.
+from extract_riscv_operand_bits import (
+    parse_op_fields,
+    parse_encode_macros,
+    extract_operand_mapping,
+    derive_bits_for_token,
+)
+
+
+class OperandInfo(NamedTuple):
+    """Information about a binutils operand character."""
+    char: str
+    bit_start: int
+    bit_end: int
+    operand_type: str  # 'register', 'immediate', 'address', 'special'
+    semantic_role: str  # 'destination', 'source1', 'source2', 'immediate', etc.
+    description: str
+    constraints: str  # Any special constraints or notes
+
+
+class BinutilsParser:
+    """Parses binutils source files to extract RISC-V operand definitions using binutils' own logic."""
+    
+    def __init__(self, binutils_path: str):
+        self.binutils_path = binutils_path
+        self.operand_info: Dict[str, OperandInfo] = {}
+        self.parsed = False
+        # Keep only operand_info; generator/Matcher don't need raw bit lists here
+        
+    def validate_binutils_path(self) -> bool:
+        """Check if binutils path exists and contains required files."""
+        if not os.path.isdir(self.binutils_path):
+            return False
+            
+        required_files = [
+            "gas/config/tc-riscv.c",
+            "opcodes/riscv-dis.c", 
+            "include/opcode/riscv.h"
+        ]
+        
+        for file_path in required_files:
+            full_path = os.path.join(self.binutils_path, file_path)
+            if not os.path.isfile(full_path):
+                logging.warning(f"Required binutils file not found: {full_path}")
+                return False
+                
+        return True
+
+    def read_file(self, path: str) -> str:
+        """Read file with proper encoding handling."""
+        full_path = os.path.join(self.binutils_path, path)
+        return Path(full_path).read_text(encoding="utf-8", errors="ignore")
+
+    # All parsing helpers are imported from extract_riscv_operand_bits
+
+    def parse_operand_definitions(self) -> bool:
+        """Parse binutils source files to extract operand definitions using binutils' own logic."""
+        if not self.validate_binutils_path():
+            logging.error(f"Invalid binutils path: {self.binutils_path}")
+            return False
+            
+        try:
+            # Read source files
+            riscv_h = self.read_file("include/opcode/riscv.h")
+            tc_riscv_c = self.read_file("gas/config/tc-riscv.c")
+            riscv_dis_c = self.read_file("opcodes/riscv-dis.c")
+
+            # Parse using the shared extractor helpers
+            fields_map = parse_op_fields(riscv_h)
+            enc_map = parse_encode_macros(riscv_h)
+            op_token_map = extract_operand_mapping(tc_riscv_c, riscv_dis_c)
+
+            # Convert to our operand info format
+            for token, macro_use in op_token_map.items():
+                bits, _notes = derive_bits_for_token(token, macro_use, fields_map, enc_map)
+                if bits:
+                    bit_start, bit_end = min(bits), max(bits)
+                else:
+                    bit_start, bit_end = -1, -1
+                
+                # Infer operand type and semantic role
+                operand_type = self._infer_operand_type_from_token(token, macro_use)
+                semantic_role = self._infer_semantic_role_from_token(token, macro_use)
+                
+                self.operand_info[token] = OperandInfo(
+                    char=token,
+                    bit_start=bit_start,
+                    bit_end=bit_end,
+                    operand_type=operand_type,
+                    semantic_role=semantic_role,
+                    description=f"Operand character '{token}'",
+                    constraints=""
+                )
+            
+            self.parsed = True
+            logging.info(f"Parsed {len(self.operand_info)} operand definitions from binutils using superior parsing")
+            
+            # Debug: show what operands we found
+            if logging.getLogger().isEnabledFor(logging.DEBUG):
+                logging.debug("Found operand definitions:")
+                for char, info in self.operand_info.items():
+                    logging.debug(f"  '{char}': bits {info.bit_start}-{info.bit_end}, type={info.operand_type}, role={info.semantic_role}")
+            
+            return True
+        except Exception as e:
+            logging.error(f"Error parsing binutils source: {e}")
+            return False
+
+    def _infer_operand_type_from_token(self, token: str, macro_use: dict) -> str:
+        """Infer operand type from token name and macro usage."""
+        if token.startswith('V.') or 'VD' in str(macro_use) or 'VS' in str(macro_use):
+            return 'vector'
+        elif token.startswith('C.'):
+            return 'compressed'
+        elif token in ['d', 's', 't', 'r', 'D', 'S', 'T', 'R']:
+            return 'register'
+        elif token in ['j', 'i', 'o', 'u', 'a', 'p', 'q'] or 'IMM' in str(macro_use):
+            return 'immediate'
+        elif token in ['>', '<']:
+            return 'shift'
+        elif token in ['P', 'Q', 'p', 'q'] and 'PRED' in str(macro_use) or 'SUCC' in str(macro_use):
+            return 'fence'
+        elif token in ['E', 'm']:
+            return 'special'
+        else:
+            return 'unknown'
+
+    def _infer_semantic_role_from_token(self, token: str, macro_use: dict) -> str:
+        """Infer semantic role from token name and macro usage."""
+        if token in ['d', 'D', 'V.d']:
+            return 'destination'
+        elif token in ['s', 'S', 'V.s']:
+            return 'source1'
+        elif token in ['t', 'T', 'V.t']:
+            return 'source2'
+        elif token in ['r', 'R']:
+            return 'source3'
+        elif token in ['j', 'i', 'o', 'u', 'a', 'p', 'q', '>', '<']:
+            return 'immediate'
+        elif token in ['P', 'Q']:
+            return 'fence_pred_succ'
+        elif token == 'E':
+            return 'csr'
+        elif token == 'm':
+            return 'rounding_mode'
+        else:
+            return 'unknown'
+    
+    # Interface methods for compatibility
+    def get_operand_info(self, char: str) -> Optional[OperandInfo]:
+        """Get information about a specific operand character."""
+        return self.operand_info.get(char)
+    
+    def get_all_operands(self) -> Dict[str, OperandInfo]:
+        """Get all parsed operand information."""
+        return self.operand_info.copy()
+    
+    def find_matching_operands(self, bit_start: int, bit_end: int, 
+                             operand_type: str = None) -> List[OperandInfo]:
+        """Find operand characters that match given bit positions and type."""
+        matches = []
+        
+        for info in self.operand_info.values():
+            # Check bit position overlap
+            if (info.bit_start <= bit_end and info.bit_end >= bit_start):
+                # Check type compatibility if specified
+                if operand_type is None or info.operand_type == operand_type:
+                    matches.append(info)
+        
+        # Sort by how well the bit positions match
+        matches.sort(key=lambda x: abs((x.bit_start + x.bit_end) - (bit_start + bit_end)))
+        return matches

--- a/backends/generators/binutils/extract_riscv_operand_bits.py
+++ b/backends/generators/binutils/extract_riscv_operand_bits.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Extract RISC-V operand tokens and bit positions (JSON/Markdown).
+
+Thin wrapper that reuses helpers in binutils_parser.py (single source of truth).
+"""
+
+import json
+import argparse
+import sys
+from pathlib import Path
+from collections import OrderedDict
+
+from binutils_parser import (
+    parse_op_fields,
+    parse_encode_macros,
+    extract_operand_mapping,
+    derive_bits_for_token,
+)
+
+ROOT = (Path(__file__).resolve().parents[1] / "binutils-gdb").resolve()
+RISCV_H = ROOT / "include" / "opcode" / "riscv.h"
+ASM = ROOT / "gas" / "config" / "tc-riscv.c"
+DIS = ROOT / "opcodes" / "riscv-dis.c"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def _bit_ranges(bits):
+    if not bits:
+        return []
+    bits = sorted(bits)
+    ranges = []
+    start = prev = bits[0]
+    for b in bits[1:]:
+        if b == prev + 1:
+            prev = b
+            continue
+        ranges.append((start, prev))
+        start = prev = b
+    ranges.append((start, prev))
+    return [f"{a}" if a == b else f"{a}..{b}" for a, b in ranges]
+
+
+def _emit_markdown(out_obj, fp):
+    tokens = out_obj.get('tokens', {})
+    fp.write("RISC-V Operand Bit Positions (from binutils)\n")
+    fp.write("\n")
+    fp.write("- Bit indices are instruction bit positions with LSB = 0.\n")
+    fp.write("- Fields come from OP_MASK_*/OP_SH_*; immediates from ENCODE_* macros.\n")
+    fp.write("\n")
+
+    def grp(tok):
+        if tok.startswith('C.'):
+            return (1, tok)
+        if tok.startswith('V.'):
+            return (2, tok)
+        if tok.startswith('X.') or tok.startswith('W.'):
+            return (3, tok)
+        return (0, tok)
+
+    for tok in sorted(tokens.keys(), key=grp):
+        data = tokens[tok]
+        bits = data.get('bits', [])
+        ranges = _bit_ranges(bits)
+        fields = data.get('asm_inserts', [])
+        encs = data.get('asm_encodes', [])
+        exts = data.get('dis_extracts', [])
+        fp.write(f"- {tok}\n")
+        fp.write(f"  - bits: {', '.join(ranges) if ranges else '(none)'}\n")
+        if fields:
+            fp.write(f"  - fields: {', '.join(fields)}\n")
+        if encs:
+            fp.write(f"  - encodes: {', '.join(encs)}\n")
+        if exts:
+            fp.write(f"  - extracts: {', '.join(exts)}\n")
+        notes = data.get('notes') or []
+        if notes:
+            fp.write(f"  - notes: {'; '.join(notes)}\n")
+        fp.write("\n")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Extract RISC-V operand bit positions from binutils sources")
+    ap.add_argument('--format', '-f', choices=['json', 'markdown', 'md', 'text'], default='json',
+                    help='Output format (default: json)')
+    ap.add_argument('--out', '-o', default='-', help='Output file path or - for stdout')
+    args = ap.parse_args()
+    if not (RISCV_H.exists() and ASM.exists() and DIS.exists()):
+        print("error: missing binutils sources next to this script", file=sys.stderr)
+        sys.exit(1)
+
+    riscv_h = read(RISCV_H)
+    tc_riscv_c = read(ASM)
+    riscv_dis_c = read(DIS)
+
+    fields_map = parse_op_fields(riscv_h)
+    enc_map = parse_encode_macros(riscv_h)
+    op_token_map = extract_operand_mapping(tc_riscv_c, riscv_dis_c)
+
+    results = OrderedDict()
+    for token, macro_use in op_token_map.items():
+        bits, notes = derive_bits_for_token(token, macro_use, fields_map, enc_map)
+        results[token] = {
+            'bits': bits,
+            'asm_inserts': macro_use.get('asm', {}).get('inserts', []),
+            'asm_encodes': macro_use.get('asm', {}).get('encodes', []),
+            'dis_extracts': macro_use.get('dis', {}).get('extracts', []),
+            'notes': notes,
+        }
+
+    # Enrich with a simple dictionary of OP fields and ENCODE immediates for reference
+    ref = {
+        'op_fields': {k: {'bits': v['bits'], 'shift': v['shift'], 'mask': v['mask'], 'width': v['width']}
+                       for k, v in sorted(fields_map.items())},
+        'encode_immediates': {k: {'bits': v['bits'], 'segments': v['segments']}
+                              for k, v in sorted(enc_map.items())},
+    }
+
+    out = {
+        'tokens': results,
+        'reference': ref,
+    }
+
+    # Emit in the requested format
+    out_path = args.out
+    fmt = args.format
+    if out_path == '-':
+        fp = sys.stdout
+        close_fp = False
+    else:
+        fp = open(out_path, 'w', encoding='utf-8')
+        close_fp = True
+
+    try:
+        if fmt in ('markdown', 'md', 'text'):
+            _emit_markdown(out, fp)
+        else:
+            json.dump(out, fp, indent=2, sort_keys=False)
+            fp.write('\n')
+    finally:
+        if close_fp:
+            fp.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/backends/generators/binutils/insn_class_config.py
+++ b/backends/generators/binutils/insn_class_config.py
@@ -1,0 +1,13 @@
+"""
+User configuration for instruction class names.
+
+Define custom names for extensions here, e.g.:
+  USER_DEFINED_INSN_NAMES = { 'Zbb': 'INSN_CLASS_ZBB' }
+"""
+
+USER_DEFINED_INSN_NAMES = {}
+
+
+def is_user_defined_class(class_name: str) -> bool:
+    return class_name in set(USER_DEFINED_INSN_NAMES.values())
+

--- a/backends/generators/binutils/naming_config.py
+++ b/backends/generators/binutils/naming_config.py
@@ -1,0 +1,21 @@
+"""
+Naming configuration for binutils generation.
+
+- USER_DEFINED_INSN_NAMES: map extension identifiers (e.g., 'Zbb', 'CustomTest')
+  to explicit INSN_CLASS_* names. If not set, generator uses INSN_CLASS_<EXT>.
+
+- USER_DEFINED_OPERAND_PREFERENCES: for ambiguous or custom operands, map a
+  (operand_name, bit_range_string) pair to a binutils operand token (e.g., 'u').
+  Example: { ('imm', '31-12'): 'u' }
+"""
+
+USER_DEFINED_INSN_NAMES = {}
+
+# Example preference:
+# USER_DEFINED_OPERAND_PREFERENCES = { ('imm', '31-12'): 'u' }
+USER_DEFINED_OPERAND_PREFERENCES = {}
+
+
+def is_user_defined_class(class_name: str) -> bool:
+    return class_name in set(USER_DEFINED_INSN_NAMES.values())
+


### PR DESCRIPTION
**IMPORTANT**: The scope of this PR is not to fully generate Binutils, rather to make the development of new/custom extensions much faster as it automates a big chunk of that process.

Implement a binutils generator that creates binutils-compatible opcode table entries from RISC-V UDB instruction definitions. The generator produces C source files and headers following the binutils-gdb format used in opcodes/riscv-opc.c.

Key features:
- Extension-aware instruction class mapping with built-in and custom support
- Operand format conversion from UDB assembly syntax to binutils format
- MATCH/MASK constant generation with proper bit manipulation
- Configurable architecture support (RV32, RV64, BOTH)
- Comprehensive documentation and integration guidelines

Components:
- binutils_generator.py: Main generator with CLI interface
- binutils_parser.py: Core parsing and conversion logic
- extract_riscv_operand_bits.py: Operand bit extraction utilities
- insn_class_config.py: Extension to instruction class mappings
- naming_config.py: User-defined naming and preference configurations
- README.md: Comprehensive documentation and usage examples



This is a WiP PR and I know I am creating tech debt on my own PRs, but I guess I am more keen on creating new solutions than finishing 