### PR TITLE
feat: add a custom_* field to extend instruction's schema

### DIFF
--- a/spec/schemas/inst_schema.json
+++ b/spec/schemas/inst_schema.json
@@ -504,6 +504,9 @@
             }
           ]
         }
+      },
+      "patternProperties": {
+        "^custom_[A-Za-z0-9_]+$": {}
       }
     }
   },


### PR DESCRIPTION
This adds a way of adding _custom_*_  fields into instructions. It's very handy to describe data UDB doesn't support.