### PR TITLE
fix: set owner of Node.js dependencies

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -216,7 +216,12 @@ if [[ ! -z "$DEVELOPMENT" && $DEVELOPMENT -eq 1 ]]; then
 fi
 
 if [ ! -d ${ROOT}/node_modules ]; then
-    ${RUN} npm i
+    ${RUN} sh -c '
+      npm i
+      npm_res=$?
+      chown -R "$(whoami):$(whoami)" ./node_modules
+      exit $npm_res
+    '
 fi
 
 if [ "${CONTAINER_TYPE}" == "devcontainer" ]; then


### PR DESCRIPTION
Few files in a node_modules/ folder belongs to user who doesn’t exist in a host environmnet when `npm` installs external packages inside container. This change explicitly sets the owner for these files.

### Steps to reproduce the issue

```shell
$ git clone https://github.com/riscv-software-src/riscv-unified-db.git
$ cd riscv-unified-db
$ export DOCKER=1
$ ./do test:smoke
Fetching gem metadata from https://rubygems.org/......
$ ls -l node_modules/min-document/dom-fragment.js
-rw-r--r-- 1 100999 100999 876 Oct 23 12:07 node_modules/min-document/dom-fragment.js
# "100999" IS UNKNOWN OWNER OUTSIDE CONTAINER
```