### PR TITLE
fix: remove docker container after exit

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -130,9 +130,9 @@ elif [ "${CONTAINER_TYPE}" == "docker" -o "${CONTAINER_TYPE}" == "podman" ]; the
       SELINUX_LABEL=""
     fi
     if [ -t 1 -a -t 0 ]; then
-      CONTAINER_BASE="${CONTAINER_TYPE} run -it -v ${ROOT}:${ROOT}${SELINUX_LABEL} -w ${ROOT} riscvintl/udb:${CONTAINER_TAG}"
+      CONTAINER_BASE="${CONTAINER_TYPE} run --rm -it -v ${ROOT}:${ROOT}${SELINUX_LABEL} -w ${ROOT} riscvintl/udb:${CONTAINER_TAG}"
     else
-      CONTAINER_BASE="${CONTAINER_TYPE} run -v ${ROOT}:${ROOT}${SELINUX_LABEL} -w ${ROOT} riscvintl/udb:${CONTAINER_TAG}"
+      CONTAINER_BASE="${CONTAINER_TYPE} run --rm -v ${ROOT}:${ROOT}${SELINUX_LABEL} -w ${ROOT} riscvintl/udb:${CONTAINER_TAG}"
     fi
 elif [ "${CONTAINER_TYPE}" == "singularity" ]; then
     CONTAINER_PATH=${ROOT}/.singularity/image-$CONTAINER_TAG.sif


### PR DESCRIPTION
The build script leaves multiple containers in a host environment. This update adds an `--rm` option to remove a Docker container after a command is executed.

### Steps to reproduce the issue

```shell
$ git clone https://github.com/riscv-software-src/riscv-unified-db.git
$ cd riscv-unified-db
$ export DOCKER=1
$ ./do test:smoke
Fetching gem metadata from https://rubygems.org/......
$ docker container ls -a
Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
CONTAINER ID  IMAGE                        COMMAND               CREATED         STATUS                     PORTS       NAMES
b49df1bcbc2c  docker.io/riscvintl/udb:0.9  bundle config set...  11 minutes ago  Exited (0) 11 minutes ago              quirky_swirles
28b906b730bf  docker.io/riscvintl/udb:0.9  bundle config set...  11 minutes ago  Exited (0) 11 minutes ago              amazing_goldberg
e189ebdd5e27  docker.io/riscvintl/udb:0.9  bundle config set...  11 minutes ago  Exited (0) 11 minutes ago              optimistic_kowalevski
9c34939c2770  docker.io/riscvintl/udb:0.9  bundle install        11 minutes ago  Exited (0) 10 minutes ago              magical_murdock
c118fdd21182  docker.io/riscvintl/udb:0.9  /usr/bin/python3 ...  10 minutes ago  Exited (0) 10 minutes ago              intelligent_margulis
bad9ac0863cf  docker.io/riscvintl/udb:0.9  /home/q/workspace...  10 minutes ago  Exited (0) 10 minutes ago              blissful_keller
c53716cb242a  docker.io/riscvintl/udb:0.9  npm i                 10 minutes ago  Exited (0) 10 minutes ago              cranky_colden
4eb3b575a6df  docker.io/riscvintl/udb:0.9  bundle exec --gem...  10 minutes ago  Exited (0) 5 minutes ago               nervous_germain
```