### PR TITLE
feat: attempt to pull docker image before building it

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -115,9 +115,13 @@ if [ -v GITHUB_ACTIONS ]; then
     sudo sysctl --system
 elif [ "${CONTAINER_TYPE}" == "docker" -o "${CONTAINER_TYPE}" == "podman" ]; then
     if ! ${CONTAINER_TYPE} images riscvintl/udb:${CONTAINER_TAG} | grep -q udb ; then
-        # TODO: pull the image if it can be found
-        echo "Building ${CONTAINER_TYPE} image..."
-        ${CONTAINER_TYPE} build -t riscvintl/udb:${CONTAINER_TAG} -f .devcontainer/Dockerfile .
+        echo "Image not found locally. Attempting to pull from registry..."
+        if ${CONTAINER_TYPE} pull docker.io/riscvintl/udb:${CONTAINER_TAG} 2>/dev/null; then
+            echo "Successfully pulled image from registry."
+        else
+            echo "Could not pull image from registry. Building locally..."
+            ${CONTAINER_TYPE} build -t riscvintl/udb:${CONTAINER_TAG} -f .devcontainer/Dockerfile .
+        fi
     fi
     if [ ${CONTAINER_TYPE} == "podman" ]; then
       # Podman requires extra flags to handle SELinux


### PR DESCRIPTION
The docker/podman image was always built from scratch before even though a precompiled version is automatically uploaded to Docker Hub. This attempts to pull the prebuilt image and only builds it from scratch if that fails.