### PR TITLE
feat: treat wheel group as sudo

### DIFF
--- a/bin/build_container
+++ b/bin/build_container
@@ -36,7 +36,7 @@ if [ $NEED_SUDO -eq 0 ]; then
   FAKEROOT=--fakeroot
   echo "Using fakeroot"
 else
-  if [[ ! -z "$GITHUB_RUN_ID" || `groups` == *"sudo"* || `groups` == *"wheel"* ]]; then
+  if [[ ! -z "$GITHUB_RUN_ID" || $(groups) =~ (^|[[:space:]])(sudo|wheel)([[:space:]]|$) ]]; then
     # user has sudo permission
     SUDO=sudo
     FAKEROOT=""


### PR DESCRIPTION
Many distros use `wheel` as the group that grants sudo permissions. Check for it in addition to the `sudo` group in the `build_container` script.