### PR TITLE
feat: add additional ecosystems to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,28 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "docker"
+    directory: ".devcontainer"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Adds the following ecosystems to Dependabot for automatic dependency updates:

- [ ] npm
- [ ] pip
- [ ] bundler
- [ ] 3rd party GitHub Actions
- [ ] Docker