### PR TITLE
Add missing CSRs

### DIFF
--- a/spec/std/isa/csr/dscratch0.yaml
+++ b/spec/std/isa/csr/dscratch0.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) Salil Mittal
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: dscratch0
+long_name: Debug scratch register
+address: 0x7B2
+priv_mode: D
+definedBy:
+  extension:
+    name: Sdext
+length: MXLEN
+description: |
+  Optional scratch register that can be used by implementations that need it. A debugger must
+  not write to this register unless hartinfo explicitly mentions it (the Debug Module may use this
+  register internally).
+writable: true
+fields:
+  VALUE:
+    location_rv32: 31-0
+    location_rv64: 63-0
+    description: |
+      Scratch field to hold a value used by debug routines.
+    type: RW-H
+    reset_value: 0

--- a/spec/std/isa/csr/dscratch1.yaml
+++ b/spec/std/isa/csr/dscratch1.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) Salil Mittal
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: dscratch1
+long_name: Debug scratch register
+address: 0x7B3
+priv_mode: D
+definedBy:
+  extension:
+    name: Sdext
+length: MXLEN
+description: |
+  Optional scratch register that can be used by implementations that need it. A debugger must
+  not write to this register unless hartinfo explicitly mentions it (the Debug Module may use this
+  register internally).
+writable: true
+fields:
+  VALUE:
+    location_rv32: 31-0
+    location_rv64: 63-0
+    description: |
+      Scratch field to hold a value used by debug routines.
+    type: RW-H
+    reset_value: 0

--- a/spec/std/isa/csr/mie.yaml
+++ b/spec/std/isa/csr/mie.yaml
@@ -18,12 +18,8 @@ description: "mip.yaml#/description"
 fields:
   SSIE:
     location: 1
-    alias:
-      - sie.SSIE
     description: |
       Enables Supervisor Software Interrupts.
-
-      Alias of `sie.SSIE` when `mideleg.SSI` is set. Otherwise, `sie.SSIE` is read-only 0.
     type: RW
     definedBy:
       extension:
@@ -31,19 +27,8 @@ fields:
     reset_value: 0
   VSSIE:
     location: 2
-    alias:
-      - hie.VSSIE
-      - vsie.SSIE
-      - sie.SSIE
     description: |
       Enables Virtual Supervisor Software Interrupts.
-
-      Alias of `hie.VSSIE`.
-
-      Alias of `vsie.SSIE` when `hideleg.VSSI` is set. Otherwise, `vseie.SSIE` is read-only 0.
-
-      Alias of `sie.SSIE` when `hideleg.VSSI` is set and the current mode is VS or VU
-      (Because `mie` is inaccessible in VS or VU mode, this alias can never be observed by software).
     type: RW
     definedBy:
       extension:
@@ -56,11 +41,8 @@ fields:
     reset_value: 0
   STIE:
     location: 5
-    alias: sip.STIE
     description: |
       Enables Supervisor Timer Interrupts.
-
-      Alias of `sip.STIE` when `mideleg.STI` is set. Otherwise, `sip.STIE` is read-only 0.
     type: RW
     definedBy:
       extension:
@@ -68,19 +50,8 @@ fields:
     reset_value: 0
   VSTIE:
     location: 6
-    alias:
-      - hie.VSTIE
-      - vsie.STIE
-      - sie.STIE
     description: |
       Enables Virtual Supervisor Timer Interrupts.
-
-      Alias of `hie.VSTIE`.
-
-      Alias of `vsie.STIE` when `hideleg.VSTI` is set. Otherwise, `vseie.STIE` is read-only 0.
-
-      Alias of `sie.STIE` when `hideleg.VSTI` is set and the current mode is VS or VU
-      (Because `mie` is inaccessible in VS or VU mode, this alias can never be observed by software).
     type: RW
     definedBy:
       extension:
@@ -93,11 +64,8 @@ fields:
     reset_value: 0
   SEIE:
     location: 9
-    alias: sip.SEIE
     description: |
       Enables Supervisor External Interrupts.
-
-      Alias of `sie.SEIE` when `mideleg.SEI` is set. Otherwise, `sie.SEIE` is read-only 0.
     type: RW
     definedBy:
       extension:
@@ -105,19 +73,8 @@ fields:
     reset_value: 0
   VSEIE:
     location: 10
-    alias:
-      - hie.VSEIE
-      - vsie.SEIE
-      - sie.SEIE
     description: |
       Enables Virtual Supervisor External Interrupts.
-
-      Alias of `hie.VSEIE`.
-
-      Alias of `vsie.SEIE` when `hideleg.VSEI` is set. Otherwise, `vseie.SEIE` is read-only 0.
-
-      Alias of `sie.SEIE` when `hideleg.VSEI` is set and the current mode is VS or VU
-      (Because `mie` is inaccessible in VS or VU mode, this alias can never be observed by software).
     type: RW
     definedBy:
       extension:
@@ -130,11 +87,8 @@ fields:
     reset_value: 0
   SGEIE:
     location: 12
-    alias: hie.SGEIE
     description: |
       Enables Supervisor Guest External Interrupts
-
-      Alias of `hie.SGEIE`.
     type: RW
     definedBy:
       extension:
@@ -142,15 +96,8 @@ fields:
     reset_value: 0
   LCOFIE:
     location: 13
-    alias:
-      - sie.LCOFIE
-      - vsie.LCOFIE
     description: |
       Enables Local Counter Overflow Interrupts.
-
-      Alias of `sie.LCOFIE` when `mideleg.LCOFI` is set. Otherwise, `sie.LCOFIE` is an independent writable bit when `mvien.LCOFI` is set or is read-only 0.
-
-      Alias of `vsip.LCOFIE` when `hideleg.LCOFI` is set. Otherwise, `vsip.LCOFIE` is read-only 0.
     type: RW
     definedBy:
       extension:

--- a/spec/std/isa/csr/sie.yaml
+++ b/spec/std/isa/csr/sie.yaml
@@ -1,0 +1,49 @@
+# Copyright (c) Salil Mittal
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/csr_schema.json
+
+$schema: "csr_schema.json#"
+kind: csr
+name: sie
+long_name: Supervisor interrupt-enable register
+address: 0x104
+priv_mode: S
+definedBy:
+  extension:
+    name: S
+length: SXLEN
+description: Supervisor interrupt-enable register.
+writable: true
+fields:
+  SSIE:
+    location: 1
+    alias: mie.SSIE
+    description: |
+      Supervisor Software Interrupt Enable
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  STIE:
+    location: 5
+    alias: mie.STIE
+    description: |
+      Supervisor Timer Interrupt Enable
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  SEIE:
+    location: 9
+    alias: mie.SEIE
+    description: |
+      Supervisor External Interrupt Enable
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+  LCOFIE:
+    location: 13
+    alias: mie.LCOFIE
+    description: |
+      Local Counter Overflow Interrupt Enable
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+    definedBy:
+      extension:
+        name: Sscofpmf


### PR DESCRIPTION
Adds basic information for missing CSRs necessary for #1209. List of CSRs: sie, dscratch0, dscratch1

Based on:
- https://people.eecs.berkeley.edu/~krste/papers/riscv-privileged-v1.9.1.pdf
- https://github.com/riscv/riscv-isa-manual/commit/87a1e5f400f989467831a9352265c82b4a1848aa