### PR TITLE
fix(ci): correct RVI20 CRD artifact names in GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -151,14 +151,14 @@ jobs:
       - name: Download RVI20-32-CRD
         uses: actions/download-artifact@v5
         with:
-          name: RVI20-32-crd
+          name: rvi20-32-crd
           path: _site/pdfs
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
       - name: Download RVI20-64-CRD
         uses: actions/download-artifact@v5
         with:
-          name: RVI20-64-crd
+          name: rvi20-64-crd
           path: _site/pdfs
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
The GitHub pages deployment workflow was failing due to missing RVI20 CRD artifacts. This updates the names in `.github/workflows/pages.yml` (download artifacts) to be lowercase so they match with those in `.github/workflows/deploy.yml` (upload artifacts).

fixes #1241