### PR TITLE
fix(data): fix schema paths in layout files

### DIFF
--- a/spec/std/isa/csr/I/mcounteren.layout
+++ b/spec/std/isa/csr/I/mcounteren.layout
@@ -1,7 +1,7 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# yaml-language-server: $schema=../../schemas/csr_schema.json
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
 
 $schema: csr_schema.json#
 kind: csr

--- a/spec/std/isa/csr/S/scounteren.layout
+++ b/spec/std/isa/csr/S/scounteren.layout
@@ -1,7 +1,7 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# yaml-language-server: $schema=../../schemas/csr_schema.json
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
 
 $schema: csr_schema.json#
 kind: csr

--- a/spec/std/isa/csr/Sscofpmf/scountovf.layout
+++ b/spec/std/isa/csr/Sscofpmf/scountovf.layout
@@ -1,7 +1,7 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# yaml-language-server: $schema=../../../schemas/csr_schema.json
+# yaml-language-server: $schema=../../../../schemas/csr_schema.json
 
 $schema: csr_schema.json#
 kind: csr

--- a/spec/std/isa/csr/dcsr.yaml
+++ b/spec/std/isa/csr/dcsr.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) Katherine Hsu
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# yaml-language-server: $schema=../../schemas/csr_schema.json
+# yaml-language-server: $schema=../../../schemas/csr_schema.json
 
 $schema: "csr_schema.json#"
 kind: csr

--- a/spec/std/isa/csr/dpc.yaml
+++ b/spec/std/isa/csr/dpc.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) Katherine Hsu
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# yaml-language-server: $schema=../../schemas/csr_schema.json
+# yaml-language-server: $schema=../../../schemas/csr_schema.json
 
 $schema: "csr_schema.json#"
 kind: csr

--- a/spec/std/isa/csr/jvt.yaml
+++ b/spec/std/isa/csr/jvt.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) Katherine Hsu
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# yaml-language-server: $schema=../../schemas/csr_schema.json
+# yaml-language-server: $schema=../../../schemas/csr_schema.json
 
 $schema: "csr_schema.json#"
 kind: csr


### PR DESCRIPTION
Commit fe86e703431c9 fixed schema paths in YAML files, but also needed to fix the paths in the layout files which are used to generate some of those YAML files, or the paths get changed back to incorrect values.

Fix those layout files and a few lingering incorrect schema paths.