### PR TITLE
fix(data): update extension ratification dates

### DIFF
--- a/spec/std/isa/ext/Q.yaml
+++ b/spec/std/isa/ext/Q.yaml
@@ -19,7 +19,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2019-04
     requires: D
 params:
   MUTABLE_MISA_Q:

--- a/spec/std/isa/ext/S.yaml
+++ b/spec/std/isa/ext/S.yaml
@@ -23,7 +23,7 @@ versions:
     version: "= 1.0.0"
 - version: "1.13.0"
   state: ratified
-  ratification_date: null
+  ratification_date: 2024-10
   requires:
     name: U
     version: "= 1.0.0"

--- a/spec/std/isa/ext/Sdtrig.yaml
+++ b/spec/std/isa/ext/Sdtrig.yaml
@@ -88,4 +88,4 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2025-02

--- a/spec/std/isa/ext/Sha.yaml
+++ b/spec/std/isa/ext/Sha.yaml
@@ -47,7 +47,7 @@ description: |
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-10
     implies:
       - name: H
         version: "1.0.0"

--- a/spec/std/isa/ext/Shgatpa.yaml
+++ b/spec/std/isa/ext/Shgatpa.yaml
@@ -18,7 +18,7 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03
     param_constraints:
       SV32X4_TRANSLATION:
         extra_validation: |

--- a/spec/std/isa/ext/Shtvala.yaml
+++ b/spec/std/isa/ext/Shtvala.yaml
@@ -21,7 +21,7 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03
     param_constraints:
       REPORT_GPA_IN_HTVAL_ON_GUEST_PAGE_FAULT:
         schema:

--- a/spec/std/isa/ext/Shvsatpa.yaml
+++ b/spec/std/isa/ext/Shvsatpa.yaml
@@ -16,4 +16,4 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03

--- a/spec/std/isa/ext/Shvstvala.yaml
+++ b/spec/std/isa/ext/Shvstvala.yaml
@@ -21,7 +21,7 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03
     param_constraints:
       REPORT_VA_IN_VSTVAL_ON_BREAKPOINT:
         schema:

--- a/spec/std/isa/ext/Shvstvecd.yaml
+++ b/spec/std/isa/ext/Shvstvecd.yaml
@@ -18,7 +18,7 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03
     param_constraints:
       VSTVEC_MODE_DIRECT:
         schema:

--- a/spec/std/isa/ext/Smcdeleg.yaml
+++ b/spec/std/isa/ext/Smcdeleg.yaml
@@ -19,7 +19,7 @@ doc_license:
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-03
     repositories:
       - url: https://github.com/riscvarchive/riscv-smcdeleg-ssccfg
     url: https://github.com/riscvarchive/riscv-smcdeleg-ssccfg/releases/download/v1.0.0/riscv-smcdeleg-ssccfg-v1.0.0.pdf

--- a/spec/std/isa/ext/Smdbltrp.yaml
+++ b/spec/std/isa/ext/Smdbltrp.yaml
@@ -22,4 +22,4 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-08

--- a/spec/std/isa/ext/Smmpm.yaml
+++ b/spec/std/isa/ext/Smmpm.yaml
@@ -13,7 +13,7 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-10
 params:
   PMLEN:
     description: |

--- a/spec/std/isa/ext/Smnpm.yaml
+++ b/spec/std/isa/ext/Smnpm.yaml
@@ -14,7 +14,7 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-10
 params:
   PMLEN:
     description: |

--- a/spec/std/isa/ext/Smrnmi.yaml
+++ b/spec/std/isa/ext/Smrnmi.yaml
@@ -21,4 +21,4 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-06

--- a/spec/std/isa/ext/Smstateen.yaml
+++ b/spec/std/isa/ext/Smstateen.yaml
@@ -25,4 +25,4 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-03

--- a/spec/std/isa/ext/Ssccfg.yaml
+++ b/spec/std/isa/ext/Ssccfg.yaml
@@ -12,5 +12,5 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-03
     url: https://docs.google.com/document/d/1s-GeH5XpHBLzbQZucA8DPA7vvF7Xvf_nrPbrU2YLBcE/edit#heading=h.yyrgtolcaczx

--- a/spec/std/isa/ext/Ssccptr.yaml
+++ b/spec/std/isa/ext/Ssccptr.yaml
@@ -16,7 +16,7 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03
     url: https://github.com/riscv/riscv-profiles/releases/tag/v1.0
     repositories:
       - url: https://github.com/riscv/riscv-profiles

--- a/spec/std/isa/ext/Ssnpm.yaml
+++ b/spec/std/isa/ext/Ssnpm.yaml
@@ -14,7 +14,7 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-10
 params:
   PMLEN:
     description: |

--- a/spec/std/isa/ext/Sspm.yaml
+++ b/spec/std/isa/ext/Sspm.yaml
@@ -20,4 +20,4 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-10

--- a/spec/std/isa/ext/Ssstateen.yaml
+++ b/spec/std/isa/ext/Ssstateen.yaml
@@ -27,5 +27,5 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-03
     # TODO: add param_constraints

--- a/spec/std/isa/ext/Ssstrict.yaml
+++ b/spec/std/isa/ext/Ssstrict.yaml
@@ -39,4 +39,4 @@ description: |
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-10

--- a/spec/std/isa/ext/Sstc.yaml
+++ b/spec/std/isa/ext/Sstc.yaml
@@ -12,5 +12,5 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-03
     url: https://drive.google.com/file/d/1m84Re2yK8m_vbW7TspvevCDR82MOBaSX/view?usp=drive_link

--- a/spec/std/isa/ext/Sstvala.yaml
+++ b/spec/std/isa/ext/Sstvala.yaml
@@ -22,7 +22,7 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03
     url: https://github.com/riscv/riscv-profiles/releases/tag/v1.0
     repositories:
       - url: https://github.com/riscv/riscv-profiles

--- a/spec/std/isa/ext/Sstvecd.yaml
+++ b/spec/std/isa/ext/Sstvecd.yaml
@@ -15,7 +15,7 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03
     url: https://github.com/riscv/riscv-profiles/releases/tag/v1.0
     repositories:
       - url: https://github.com/riscv/riscv-profiles

--- a/spec/std/isa/ext/Ssu64xl.yaml
+++ b/spec/std/isa/ext/Ssu64xl.yaml
@@ -16,7 +16,7 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03
     param_constraints:
       UXLEN:
         schema:

--- a/spec/std/isa/ext/Supm.yaml
+++ b/spec/std/isa/ext/Supm.yaml
@@ -20,4 +20,4 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-10

--- a/spec/std/isa/ext/Sv32.yaml
+++ b/spec/std/isa/ext/Sv32.yaml
@@ -12,11 +12,11 @@ type: privileged
 versions:
   - version: "1.11.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2019-05
   - version: "1.12.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
     url: https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf
   - version: "1.13.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-10

--- a/spec/std/isa/ext/Sv39.yaml
+++ b/spec/std/isa/ext/Sv39.yaml
@@ -12,11 +12,11 @@ type: privileged
 versions:
   - version: "1.11.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2019-05
   - version: "1.12.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
     url: https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf
   - version: "1.13.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-10

--- a/spec/std/isa/ext/Sv48.yaml
+++ b/spec/std/isa/ext/Sv48.yaml
@@ -12,20 +12,20 @@ type: privileged
 versions:
   - version: "1.11.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2019-05
     requires:
       name: Sv39
       version: ">= 1.11"
   - version: "1.12.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
     url: https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf
     requires:
       name: Sv39
       version: ">= 1.12"
   - version: "1.13.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-10
     requires:
       name: Sv39
       version: ">= 1.13"

--- a/spec/std/isa/ext/Sv57.yaml
+++ b/spec/std/isa/ext/Sv57.yaml
@@ -10,22 +10,16 @@ long_name: 57-bit virtual address translation (5 level)
 description: 57-bit virtual address translation (5 level)
 type: privileged
 versions:
-  - version: "1.11.0"
-    state: ratified
-    ratification_date: null
-    requires:
-      name: Sv48
-      version: ">= 1.11"
   - version: "1.12.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
     url: https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf
     requires:
       name: Sv48
       version: ">= 1.12"
   - version: "1.13.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-10
     requires:
       name: Sv48
       version: ">= 1.13"

--- a/spec/std/isa/ext/Svbare.yaml
+++ b/spec/std/isa/ext/Svbare.yaml
@@ -17,7 +17,7 @@ description: |
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03
     requires:
       name: S
     param_constraints:

--- a/spec/std/isa/ext/Svpbmt.yaml
+++ b/spec/std/isa/ext/Svpbmt.yaml
@@ -10,14 +10,11 @@ long_name: Page-based memory types
 description: |
   This extension mandates that the `satp` mode Bare must
   be supported.
-
-  [NOTE]
-  This extension was ratified as part of the RVA22 profile.
 type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
     requires:
       name: Sv39
     param_constraints:

--- a/spec/std/isa/ext/Svvptc.yaml
+++ b/spec/std/isa/ext/Svvptc.yaml
@@ -34,4 +34,4 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-06

--- a/spec/std/isa/ext/V.yaml
+++ b/spec/std/isa/ext/V.yaml
@@ -11,7 +11,7 @@ long_name: Variable-length vector
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-11
 description: |
   TODO
 params:

--- a/spec/std/isa/ext/Za128rs.yaml
+++ b/spec/std/isa/ext/Za128rs.yaml
@@ -20,7 +20,7 @@ description: |
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03
     param_constraints:
       LRSC_RESERVATION_STRATEGY:
         schema:

--- a/spec/std/isa/ext/Za64rs.yaml
+++ b/spec/std/isa/ext/Za64rs.yaml
@@ -20,7 +20,7 @@ description: |
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03
     implies:
       - name: Za128rs
         version: "1.0.0"

--- a/spec/std/isa/ext/Zabha.yaml
+++ b/spec/std/isa/ext/Zabha.yaml
@@ -13,5 +13,5 @@ description: |
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-04
     requires: Zaamo

--- a/spec/std/isa/ext/Zacas.yaml
+++ b/spec/std/isa/ext/Zacas.yaml
@@ -13,5 +13,5 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-11
     requires: Zaamo

--- a/spec/std/isa/ext/Zama16b.yaml
+++ b/spec/std/isa/ext/Zama16b.yaml
@@ -21,4 +21,4 @@ description: |
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-10

--- a/spec/std/isa/ext/Zbkb.yaml
+++ b/spec/std/isa/ext/Zbkb.yaml
@@ -12,4 +12,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
+  - version: "1.0.1"
+    state: ratified
+    ratification_date: 2022-02

--- a/spec/std/isa/ext/Zbkc.yaml
+++ b/spec/std/isa/ext/Zbkc.yaml
@@ -17,4 +17,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
+  - version: "1.0.1"
+    state: ratified
+    ratification_date: 2022-02

--- a/spec/std/isa/ext/Zbkx.yaml
+++ b/spec/std/isa/ext/Zbkx.yaml
@@ -18,4 +18,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
+  - version: "1.0.1"
+    state: ratified
+    ratification_date: 2022-02

--- a/spec/std/isa/ext/Zcmop.yaml
+++ b/spec/std/isa/ext/Zcmop.yaml
@@ -52,5 +52,5 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-03
     requires: C

--- a/spec/std/isa/ext/Zfa.yaml
+++ b/spec/std/isa/ext/Zfa.yaml
@@ -18,5 +18,5 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09
     requires: F

--- a/spec/std/isa/ext/Zfbfmin.yaml
+++ b/spec/std/isa/ext/Zfbfmin.yaml
@@ -19,7 +19,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-06
     requires:
       allOf:
         - name: F

--- a/spec/std/isa/ext/Zfh.yaml
+++ b/spec/std/isa/ext/Zfh.yaml
@@ -18,4 +18,4 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-11

--- a/spec/std/isa/ext/Zic64b.yaml
+++ b/spec/std/isa/ext/Zic64b.yaml
@@ -16,7 +16,7 @@ type: privileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03
     url: https://github.com/riscv/riscv-profiles/releases/tag/v1.0
     repositories:
       - url: https://github.com/riscv/riscv-profiles

--- a/spec/std/isa/ext/Ziccamoa.yaml
+++ b/spec/std/isa/ext/Ziccamoa.yaml
@@ -16,4 +16,4 @@ description: |
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03

--- a/spec/std/isa/ext/Ziccamoc.yaml
+++ b/spec/std/isa/ext/Ziccamoc.yaml
@@ -20,4 +20,4 @@ description: |
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-10

--- a/spec/std/isa/ext/Ziccif.yaml
+++ b/spec/std/isa/ext/Ziccif.yaml
@@ -18,4 +18,4 @@ description: |
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03

--- a/spec/std/isa/ext/Zicclsm.yaml
+++ b/spec/std/isa/ext/Zicclsm.yaml
@@ -24,7 +24,7 @@ description: |
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03
     param_constraints:
       MISALIGNED_LDST:
         schema:

--- a/spec/std/isa/ext/Ziccrse.yaml
+++ b/spec/std/isa/ext/Ziccrse.yaml
@@ -16,4 +16,4 @@ description: |
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03

--- a/spec/std/isa/ext/Zicond.yaml
+++ b/spec/std/isa/ext/Zicond.yaml
@@ -21,4 +21,4 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-11

--- a/spec/std/isa/ext/Zicsr.yaml
+++ b/spec/std/isa/ext/Zicsr.yaml
@@ -12,4 +12,4 @@ type: unprivileged
 versions:
   - version: "2.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2019-04

--- a/spec/std/isa/ext/Zifencei.yaml
+++ b/spec/std/isa/ext/Zifencei.yaml
@@ -72,4 +72,4 @@ type: unprivileged
 versions:
   - version: "2.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2019-04

--- a/spec/std/isa/ext/Zihintntl.yaml
+++ b/spec/std/isa/ext/Zihintntl.yaml
@@ -198,4 +198,4 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-05

--- a/spec/std/isa/ext/Zihintpause.yaml
+++ b/spec/std/isa/ext/Zihintpause.yaml
@@ -73,4 +73,4 @@ type: unprivileged
 versions:
   - version: "2.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-02

--- a/spec/std/isa/ext/Zihpm.yaml
+++ b/spec/std/isa/ext/Zihpm.yaml
@@ -12,6 +12,6 @@ type: unprivileged
 versions:
   - version: "2.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-03
     requires:
       name: Smhpm

--- a/spec/std/isa/ext/Zimop.yaml
+++ b/spec/std/isa/ext/Zimop.yaml
@@ -67,4 +67,4 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-03

--- a/spec/std/isa/ext/Zk.yaml
+++ b/spec/std/isa/ext/Zk.yaml
@@ -18,7 +18,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
     implies:
       - name: "Zkn"
         version: "1.0.0"
@@ -26,3 +26,13 @@ versions:
         version: "1.0.0"
       - name: "Zkt"
         version: "1.0.0"
+  - version: "1.0.1"
+    state: ratified
+    ratification_date: 2022-02
+    implies:
+      - name: "Zkn"
+        version: "1.0.1"
+      - name: "Zkr"
+        version: "1.0.1"
+      - name: "Zkt"
+        version: "1.0.1"

--- a/spec/std/isa/ext/Zkn.yaml
+++ b/spec/std/isa/ext/Zkn.yaml
@@ -21,7 +21,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
     implies:
       - name: "Zbkb"
         version: "1.0.0"
@@ -35,3 +35,19 @@ versions:
         version: "1.0.0"
       - name: "Zknh"
         version: "1.0.0"
+  - version: "1.0.1"
+    state: ratified
+    ratification_date: 2022-02
+    implies:
+      - name: "Zbkb"
+        version: "1.0.1"
+      - name: "Zbkc"
+        version: "1.0.1"
+      - name: "Zbkx"
+        version: "1.0.1"
+      - name: "Zkne"
+        version: "1.0.1"
+      - name: "Zknd"
+        version: "1.0.1"
+      - name: "Zknh"
+        version: "1.0.1"

--- a/spec/std/isa/ext/Zknd.yaml
+++ b/spec/std/isa/ext/Zknd.yaml
@@ -13,4 +13,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
+  - version: "1.0.1"
+    state: ratified
+    ratification_date: 2022-02

--- a/spec/std/isa/ext/Zkne.yaml
+++ b/spec/std/isa/ext/Zkne.yaml
@@ -13,4 +13,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
+  - version: "1.0.1"
+    state: ratified
+    ratification_date: 2022-02

--- a/spec/std/isa/ext/Zknh.yaml
+++ b/spec/std/isa/ext/Zknh.yaml
@@ -13,4 +13,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
+  - version: "1.0.1"
+    state: ratified
+    ratification_date: 2022-02

--- a/spec/std/isa/ext/Zkr.yaml
+++ b/spec/std/isa/ext/Zkr.yaml
@@ -14,4 +14,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
+  - version: "1.0.1"
+    state: ratified
+    ratification_date: 2022-02

--- a/spec/std/isa/ext/Zks.yaml
+++ b/spec/std/isa/ext/Zks.yaml
@@ -20,7 +20,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
     implies:
       - name: Zbkb
         version: "1.0.0"
@@ -34,3 +34,19 @@ versions:
         version: "1.0.0"
       - name: Zknh
         version: "1.0.0"
+  - version: "1.0.1"
+    state: ratified
+    ratification_date: 2022-02
+    implies:
+      - name: Zbkb
+        version: "1.0.1"
+      - name: Zbkc
+        version: "1.0.1"
+      - name: Zbkx
+        version: "1.0.1"
+      - name: Zkne
+        version: "1.0.1"
+      - name: Zknd
+        version: "1.0.1"
+      - name: Zknh
+        version: "1.0.1"

--- a/spec/std/isa/ext/Zksed.yaml
+++ b/spec/std/isa/ext/Zksed.yaml
@@ -14,4 +14,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
+  - version: "1.0.1"
+    state: ratified
+    ratification_date: 2022-02

--- a/spec/std/isa/ext/Zksh.yaml
+++ b/spec/std/isa/ext/Zksh.yaml
@@ -13,4 +13,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-12
+  - version: "1.0.1"
+    state: ratified
+    ratification_date: 2022-02

--- a/spec/std/isa/ext/Zkt.yaml
+++ b/spec/std/isa/ext/Zkt.yaml
@@ -340,7 +340,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: 2021-11
+    ratification_date: 2021-12
     contributors:
       - name: Alexander Zeh
       - name: Andy Glew
@@ -355,9 +355,9 @@ versions:
       - name: L Peter Deutsch
       - name: Richard Newell
       - name: Claire Wolf
-  - version: 1.0.1
+  - version: "1.0.1"
     state: ratified
-    ratification_date: null
+    ratification_date: 2022-02
     changes:
       - Fix typos to show that `c.srli`, `c.srai`, and `c.slli` are Zkt instructions in RV64.
 company:

--- a/spec/std/isa/ext/Zvbb.yaml
+++ b/spec/std/isa/ext/Zvbb.yaml
@@ -13,7 +13,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09
     implies:
       name: Zvkb
       version: "1.0.0"

--- a/spec/std/isa/ext/Zvbc.yaml
+++ b/spec/std/isa/ext/Zvbc.yaml
@@ -16,4 +16,4 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09

--- a/spec/std/isa/ext/Zve32f.yaml
+++ b/spec/std/isa/ext/Zve32f.yaml
@@ -13,5 +13,5 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2021-11
     requires: F

--- a/spec/std/isa/ext/Zvfbfmin.yaml
+++ b/spec/std/isa/ext/Zvfbfmin.yaml
@@ -17,7 +17,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-06
     requires:
       anyOf:
         - V

--- a/spec/std/isa/ext/Zvfbfwma.yaml
+++ b/spec/std/isa/ext/Zvfbfwma.yaml
@@ -15,7 +15,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2024-06
     requires:
       allOf:
         - Zvfbfmin

--- a/spec/std/isa/ext/Zvfh.yaml
+++ b/spec/std/isa/ext/Zvfh.yaml
@@ -35,7 +35,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-06
     requires:
       allOf:
         - Zve32f

--- a/spec/std/isa/ext/Zvfhmin.yaml
+++ b/spec/std/isa/ext/Zvfhmin.yaml
@@ -20,5 +20,5 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-06
     requires: Zve32f

--- a/spec/std/isa/ext/Zvkb.yaml
+++ b/spec/std/isa/ext/Zvkb.yaml
@@ -13,4 +13,4 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09

--- a/spec/std/isa/ext/Zvkg.yaml
+++ b/spec/std/isa/ext/Zvkg.yaml
@@ -23,4 +23,4 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09

--- a/spec/std/isa/ext/Zvkn.yaml
+++ b/spec/std/isa/ext/Zvkn.yaml
@@ -18,7 +18,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09
     implies:
       - name: Zvkned
         version: "1.0.0"

--- a/spec/std/isa/ext/Zvknc.yaml
+++ b/spec/std/isa/ext/Zvknc.yaml
@@ -17,7 +17,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09
     implies:
       - name: Zvkn
         version: "1.0.0"

--- a/spec/std/isa/ext/Zvkned.yaml
+++ b/spec/std/isa/ext/Zvkned.yaml
@@ -19,4 +19,4 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09

--- a/spec/std/isa/ext/Zvkng.yaml
+++ b/spec/std/isa/ext/Zvkng.yaml
@@ -17,7 +17,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09
     implies:
       - name: Zvkn
         version: "1.0.0"

--- a/spec/std/isa/ext/Zvknha.yaml
+++ b/spec/std/isa/ext/Zvknha.yaml
@@ -14,4 +14,4 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09

--- a/spec/std/isa/ext/Zvknhb.yaml
+++ b/spec/std/isa/ext/Zvknhb.yaml
@@ -14,7 +14,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09
     implies:
       name: Zvknha
       version: "1.0.0"

--- a/spec/std/isa/ext/Zvks.yaml
+++ b/spec/std/isa/ext/Zvks.yaml
@@ -18,7 +18,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09
     implies:
       - name: Zvksed
         version: "1.0.0"

--- a/spec/std/isa/ext/Zvksc.yaml
+++ b/spec/std/isa/ext/Zvksc.yaml
@@ -17,7 +17,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09
     implies:
       - name: Zvks
         version: "1.0.0"

--- a/spec/std/isa/ext/Zvksed.yaml
+++ b/spec/std/isa/ext/Zvksed.yaml
@@ -21,4 +21,4 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09

--- a/spec/std/isa/ext/Zvksg.yaml
+++ b/spec/std/isa/ext/Zvksg.yaml
@@ -17,7 +17,7 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09
     implies:
       - name: Zvks
         version: "1.0.0"

--- a/spec/std/isa/ext/Zvksh.yaml
+++ b/spec/std/isa/ext/Zvksh.yaml
@@ -17,4 +17,4 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09

--- a/spec/std/isa/ext/Zvkt.yaml
+++ b/spec/std/isa/ext/Zvkt.yaml
@@ -25,4 +25,4 @@ type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified
-    ratification_date: null
+    ratification_date: 2023-09


### PR DESCRIPTION
Gleaned from a various places:
- "Profiles & Bases & Extensions" spreadsheet
- "RISC-V GB Minutes - Approved Resolutions decision log" Google Doc
- "RISC-V Technical Specifications" wiki page
- Various versions of the RISC-V ISA specifications
- "RISC-V Profiles", version 1.0, April 2, 2023
- "RVA23 Profiles", version 1.0, 2024-10-17
- Various RISC-V GitHub repositories
- Various RISC-V extension documents

The goal was to be at least as good as the "Profiles & Bases & Extensions" spreadsheet, and hopefully much better. Some errors were fixed with the best information available, although transcription errors are certainly possible.