### PR TITLE
fix(vector): handle rs1==x0 case in vsetvli

### DIFF
--- a/spec/std/isa/inst/V/vsetvli.yaml
+++ b/spec/std/isa/inst/V/vsetvli.yaml
@@ -68,7 +68,7 @@ operation(): |
           unpredictable("Implementations may choose a custom value for vl in the case AVL < (2*VLMAX), so long as ceil(AVL/2) <= vl <= VLMAX");
       }
   } else {
-     CSR[vl].VALUE = vlmax;
+      CSR[vl].VALUE = vlmax;
   }
 
   X[xd] = CSR[vl].VALUE;


### PR DESCRIPTION
The following comments refer to "the way we test" and may not be relevant to the PR itself.
- Added vsetvli_rs1_eq_zero test to verify that vl is set to vlmax when rs1 is x0 for cases of SEW=8,32,64 and LMUL=8.
- Also renamed the old vsetvli test to vsetvli_vl_lt_vlmax to reflect the intent better.