### PR TITLE
fix(vector): implement vsetvli model and tests

### DIFF
--- a/cfgs/rv64-vector.yaml
+++ b/cfgs/rv64-vector.yaml
@@ -21,6 +21,7 @@ implemented_extensions:
   - [Zifencei, "2.0.0"]
   - [Sv39, "1.11.0"]
   - [V, "1.0.0"]
+  - [F, "2.2"]
 
 params:
   MXLEN: 64
@@ -192,10 +193,8 @@ params:
   TRAP_ON_ECALL_FROM_S: true
   TRAP_ON_ECALL_FROM_U: true
   TRAP_ON_SFENCE_VMA_WHEN_SATP_MODE_IS_READ_ONLY: false
-  # MSTATUS_FS_WRITABLE: false
-  # MSTATUS_VS_WRITABLE: false
   MSTATUS_VS_LEGAL_VALUES: [0, 1, 2, 3]
-  MSTATUS_FS_LEGAL_VALUES: [0]
+  MSTATUS_FS_LEGAL_VALUES: [0, 1, 2, 3]
   MSTATUS_TVM_IMPLEMENTED: false
   NUM_PMP_ENTRIES: 16
   PMP_GRANULARITY: 12
@@ -209,3 +208,5 @@ params:
   FOLLOW_VTYPE_RESET_RECOMMENDATION: true
   VLEN: 128
   ELEN: 64
+  HW_MSTATUS_FS_DIRTY_UPDATE: never
+  MUTABLE_MISA_F: false

--- a/spec/std/isa/inst/V/vsetvli.yaml
+++ b/spec/std/isa/inst/V/vsetvli.yaml
@@ -57,25 +57,10 @@ operation(): |
       XReg avl = X[xs1];
       XReg ceil_avl_over_two = (avl + 1) / 2;
 
-      if (xs1 == 0 && xd != 0) {
+      if (xs1 == 0)
+      {
         CSR[vl].VALUE = vlmax;
-      }
-      if (xs1 == 0 && xd == 0) {
-        XReg vl = CSR[vl].VALUE;
-      }
-      # Sighting of a potential spec bug:
-      # Chapter 30, Section 6.2 says:
-      # "When rs1 is not x0, the AVL is an unsigned integer held in the
-      # x register specied by rs1, and the new vl value is also written
-      # to the x register specied by rd." (Below the table)
-      #
-      # Expected:
-      # Additional check for rd != 0 since for the case rd == x0 the new
-      # value should *not* be written because x0 is the zero register.
-      # The first row of the table should be split into two rows, one for
-      # rd == x0 and one for rd != x0.
-
-      if (xs1 != 0)
+      } else
       {
         if (avl <= vlmax)
         {
@@ -96,10 +81,9 @@ operation(): |
               {
                 CSR[vl].VALUE = vlmax;
               }
-        }
+      }
     }
-  # See comment above re destination register being x0
-  if (xd != 0) { X[xd] = CSR[vl].VALUE; }
+  X[xd] = CSR[vl].VALUE;
   CSR[vstart].VALUE = 0;
 
 # SPDX-SnippetBegin

--- a/tests/isa/rv64uv/vsetivli.S
+++ b/tests/isa/rv64uv/vsetivli.S
@@ -15,7 +15,7 @@
 #include "riscv_test.h"
 #include "test_macros.h"
 
-RVTEST_RV64U
+RVTEST_RV64UV
 RVTEST_CODE_BEGIN
 
 # tests for VLEN=128bits, AVL < VLMAX

--- a/tests/isa/rv64uv/vsetvl.S
+++ b/tests/isa/rv64uv/vsetvl.S
@@ -15,7 +15,7 @@
 #include "riscv_test.h"
 #include "test_macros.h"
 
-RVTEST_RV64U
+RVTEST_RV64UV
 RVTEST_CODE_BEGIN
 
 # tests for VLEN=128bits, AVL < VLMAX

--- a/tests/isa/rv64uv/vsetvli_rs1_eq_zero.S
+++ b/tests/isa/rv64uv/vsetvli_rs1_eq_zero.S
@@ -13,7 +13,7 @@
 #include "riscv_test.h"
 #include "test_macros.h"
 
-RVTEST_RV64U
+RVTEST_RV64UV
 RVTEST_CODE_BEGIN
 
 # tests for VLEN=128bits, AVL = ~0 (rs1 = x0)

--- a/tests/isa/rv64uv/vsetvli_vl_lt_vlmax.S
+++ b/tests/isa/rv64uv/vsetvli_vl_lt_vlmax.S
@@ -13,11 +13,12 @@
 #include "riscv_test.h"
 #include "test_macros.h"
 
-RVTEST_RV64U
+RVTEST_RV64UV
 RVTEST_CODE_BEGIN
 
 # tests for VLEN=128bits, AVL < VLMAX
-
+  # vtypei = 0x03 -> VMA_VTA_VSEW_VLMUL == 0_0_000_011 -> SEW=8, LMUL=8
+  # VLMAX=LMUL*VLEN/SEW = 8*128/8 = 128
   TEST_CASE(1, x5, 0x2, \
     li x4, 0x2; \
     vsetvli x5, x4, 0x3; \


### PR DESCRIPTION
- Updated model according to spec for the cases of `rs1==0` and for a `Reserved` value of VSEW
- Added 64 bit vector config with "F" extension to enable the UV TVM of `riscv-tests` 
- Filed Sail-RISC-V [Issue #1434 ](https://github.com/riscv/sail-riscv/issues/1434)