### PR TITLE
fix(data): update `mseccfg` requirements

### DIFF
--- a/spec/std/isa/csr/mseccfg.yaml
+++ b/spec/std/isa/csr/mseccfg.yaml
@@ -14,6 +14,12 @@ length: 64
 description: Machine Security Configuration
 definedBy:
   extension:
-    name: Sm
-    version: ">= 1.12"
+    allOf:
+      - name: Sm
+        version: ">= 1.12"
+      - anyOf:
+          - name: Zkr
+          - name: Smmpm
+          - name: Zicfilp
+          - name: Zicfilp
 fields: {}

--- a/spec/std/isa/csr/mseccfgh.yaml
+++ b/spec/std/isa/csr/mseccfgh.yaml
@@ -16,6 +16,12 @@ definedBy:
   allOf:
     - xlen: 32
     - extension:
-        name: Sm
-        version: ">= 1.12"
+        allOf:
+          - name: Sm
+            version: ">= 1.12"
+          - anyOf:
+              - name: Zkr
+              - name: Smmpm
+              - name: Zicfilp
+              - name: Zicfilp
 fields: {}

--- a/spec/std/isa/ext/Sm.yaml
+++ b/spec/std/isa/ext/Sm.yaml
@@ -49,8 +49,7 @@ versions:
         the same fields as the upper 32 bits of RV64's `mstatus`.
       - Defined the mandatory CSR `mconfigptr`, which if nonzero contains the
         address of a configuration data structure.
-      - Defined optional `mseccfg` and `mseccfgh` CSRs, which control the
-        machine's security configuration.
+      - Defined `mseccfg` and `mseccfgh` CSRs, which control the machine's security configuration.
       - Defined `menvcfg` CSR (and RV32-only `menvcfgh`), which control various characteristics
         of the execution environment.
       - Designated part of SYSTEM major opcode for custom use.


### PR DESCRIPTION
`mseccfg` was confusingly referred to as optional, but it really meant that it exists if and only if any extension that adds a field to it is implemented.

See https://github.com/riscv/riscv-isa-manual/issues/2549 and https://github.com/riscv/riscv-isa-manual/pull/2550 .