### PR TITLE
Add LLM infrastructure for RISC-V spec parameter extraction

### DIFF
--- a/spec/std/isa/inst/Zba/sh1add.uw.yaml
+++ b/spec/std/isa/inst/Zba/sh1add.uw.yaml
@@ -20,10 +20,13 @@ encoding:
   match: 0010000----------010-----0111011
   variables:
     - name: xs2
+      tag: inst-sh1add.uw-src_reg_2
       location: 24-20
     - name: xs1
+      tag: inst-sh1add.uw-src_reg_1
       location: 19-15
     - name: xd
+      tag: inst-sh1add.uw-dest_reg
       location: 11-7
 assembly: xd, xs1, xs2
 access:

--- a/spec/std/isa/inst/Zba/sh1add.yaml
+++ b/spec/std/isa/inst/Zba/sh1add.yaml
@@ -17,10 +17,13 @@ encoding:
   match: 0010000----------010-----0110011
   variables:
     - name: xs2
+      tag: inst-sh1add-src_reg_2
       location: 24-20
     - name: xs1
+      tag: inst-sh1add-src_reg_1
       location: 19-15
     - name: xd
+      tag: inst-sh1add-dest_reg
       location: 11-7
 access:
   s: always

--- a/spec/std/isa/inst/Zba/sh2add.uw.yaml
+++ b/spec/std/isa/inst/Zba/sh2add.uw.yaml
@@ -21,10 +21,13 @@ encoding:
   match: 0010000----------100-----0111011
   variables:
     - name: xs2
+      tag: inst-sh2add.uw-src_reg_2
       location: 24-20
     - name: xs1
+      tag: inst-sh2add.uw-src_reg_1
       location: 19-15
     - name: xd
+      tag: inst-sh2add.uw-dest_reg
       location: 11-7
 access:
   s: always

--- a/spec/std/isa/inst/Zba/sh2add.yaml
+++ b/spec/std/isa/inst/Zba/sh2add.yaml
@@ -17,10 +17,13 @@ encoding:
   match: 0010000----------100-----0110011
   variables:
     - name: xs2
+      tag: inst-sh2add-src_reg_2
       location: 24-20
     - name: xs1
+      tag: inst-sh2add-src_reg_1
       location: 19-15
     - name: xd
+      tag: inst-sh2add-dest_reg
       location: 11-7
 access:
   s: always

--- a/spec/std/isa/inst/Zba/sh3add.uw.yaml
+++ b/spec/std/isa/inst/Zba/sh3add.uw.yaml
@@ -21,10 +21,13 @@ encoding:
   match: 0010000----------110-----0111011
   variables:
     - name: xs2
+      tag: inst-sh3add.uw-src_reg_2
       location: 24-20
     - name: xs1
+      tag: inst-sh3add.uw-src_reg_1
       location: 19-15
     - name: xd
+      tag: inst-sh3add.uw-dest_reg
       location: 11-7
 access:
   s: always

--- a/spec/std/isa/inst/Zba/sh3add.yaml
+++ b/spec/std/isa/inst/Zba/sh3add.yaml
@@ -17,10 +17,13 @@ encoding:
   match: 0010000----------110-----0110011
   variables:
     - name: xs2
+      tag: inst-sh3add-src_reg_2
       location: 24-20
     - name: xs1
+      tag: inst-sh3add-src_reg_1
       location: 19-15
     - name: xd
+      tag: inst-sh3add-dest_reg
       location: 11-7
 access:
   s: always

--- a/spec/std/isa/inst/Zba/slli.uw.yaml
+++ b/spec/std/isa/inst/Zba/slli.uw.yaml
@@ -22,10 +22,13 @@ encoding:
   match: 000010-----------001-----0011011
   variables:
     - name: shamt
+      tag: inst-slli.uw-shift_amount
       location: 25-20
     - name: xs1
+      tag: inst-slli.uw-src_reg_1
       location: 19-15
     - name: xd
+      tag: inst-slli.uw-dest_reg
       location: 11-7
 assembly: xd, xs1, shamt
 access:

--- a/tools/tagging/parameter_conventions.yaml
+++ b/tools/tagging/parameter_conventions.yaml
@@ -1,0 +1,288 @@
+version: "1.0"
+description: |
+  This file establishes conventions for naming and tagging parameters in instruction
+  and CSR specifications. It serves as the reference for automated tagging tools.
+
+register_operands:
+  destination:
+    names: [xd, rd, fd, vd]
+    tag_suffix: "dest_reg"
+    description: "Destination register (where result is written)"
+    examples:
+      - instruction: "add"
+        name: "rd"
+        tag: "inst-add-dest_reg"
+
+  source_primary:
+    names: [xs1, rs1, fs1, vs1]
+    tag_suffix: "src_reg_1"
+    description: "Primary source register"
+    examples:
+      - instruction: "add"
+        name: "rs1"
+        tag: "inst-add-src_reg_1"
+
+  source_secondary:
+    names: [xs2, rs2, fs2, vs2]
+    tag_suffix: "src_reg_2"
+    description: "Secondary source register"
+    examples:
+      - instruction: "add"
+        name: "rs2"
+        tag: "inst-add-src_reg_2"
+
+  source_tertiary:
+    names: [xs3, rs3, fs3, vs3]
+    tag_suffix: "src_reg_3"
+    description: "Tertiary source register (rarely used)"
+
+  source_csr:
+    names: [csr_index]
+    tag_suffix: "csr_operand"
+    description: "CSR index operand"
+
+immediate_operands:
+  i_type:
+    names: [imm_i, imm]
+    tag_suffix: "imm_i_type"
+    description: "I-type immediate (12-bit signed)"
+    examples:
+      - instruction: "addi"
+        name: "imm"
+        tag: "inst-addi-imm_i_type"
+
+  s_type:
+    names: [imm_s]
+    tag_suffix: "imm_s_type"
+    description: "S-type immediate (12-bit signed, split encoding)"
+    examples:
+      - instruction: "sw"
+        name: "imm"
+        tag: "inst-sw-imm_s_type"
+
+  b_type:
+    names: [imm_b]
+    tag_suffix: "imm_b_type"
+    description: "B-type immediate (12-bit signed, branch)"
+    examples:
+      - instruction: "beq"
+        name: "imm"
+        tag: "inst-beq-imm_b_type"
+
+  u_type:
+    names: [imm_u]
+    tag_suffix: "imm_u_type"
+    description: "U-type immediate (20-bit)"
+    examples:
+      - instruction: "lui"
+        name: "imm"
+        tag: "inst-lui-imm_u_type"
+
+  j_type:
+    names: [imm_j]
+    tag_suffix: "imm_j_type"
+    description: "J-type immediate (20-bit signed, jump)"
+    examples:
+      - instruction: "jal"
+        name: "imm"
+        tag: "inst-jal-imm_j_type"
+
+  shift_amount:
+    names: [shamt, imm_shamt]
+    tag_suffix: "shift_amount"
+    description: "Shift amount immediate"
+    examples:
+      - instruction: "slli"
+        name: "shamt"
+        tag: "inst-slli-shift_amount"
+
+  custom_immediate:
+    names: [imm]
+    tag_suffix: "immediate"
+    description: "Generic immediate (used when type not clear)"
+
+# Function/operation code fields
+function_codes:
+  funct3:
+    names: [funct3]
+    tag_suffix: "funct3"
+    description: "3-bit function code"
+    examples:
+      - instruction: "add"
+        name: "funct3"
+        tag: "inst-add-funct3"
+
+  funct7:
+    names: [funct7]
+    tag_suffix: "funct7"
+    description: "7-bit function code"
+    examples:
+      - instruction: "add"
+        name: "funct7"
+        tag: "inst-add-funct7"
+
+  funct2:
+    names: [funct2]
+    tag_suffix: "funct2"
+    description: "2-bit function code"
+
+  funct4:
+    names: [funct4]
+    tag_suffix: "funct4"
+    description: "4-bit function code"
+
+  funct5:
+    names: [funct5]
+    tag_suffix: "funct5"
+    description: "5-bit function code"
+
+  funct6:
+    names: [funct6]
+    tag_suffix: "funct6"
+    description: "6-bit function code"
+
+# Standard RISC-V opcode field
+opcode:
+  names: [opcode]
+  tag_suffix: "opcode"
+  description: "7-bit primary opcode"
+  examples:
+    - instruction: "add"
+      name: "opcode"
+      tag: "inst-add-opcode"
+
+# Compressed instruction fields
+compressed_fields:
+  register_immediate:
+    names: [imm]
+    tag_suffix: "imm_compressed"
+    description: "Immediate in compressed instruction format"
+
+  function_compressed:
+    names: [funct3, funct2]
+    tag_suffix: "funct_compressed"
+    description: "Function code in compressed instruction"
+
+# Vector instruction fields
+vector_fields:
+  vector_register:
+    names: [vd, vs1, vs2, vs3]
+    tag_suffix: "vreg"
+    description: "Vector register operand"
+
+  element_width:
+    names: [sew]
+    tag_suffix: "element_width"
+    description: "SEW (Selected Element Width) field"
+
+  mask_register:
+    names: [vm]
+    tag_suffix: "mask_enable"
+    description: "Vector mask enable bit"
+
+# Floating-point fields
+fp_fields:
+  floating_point_reg:
+    names: [fd, fs1, fs2, fs3]
+    tag_suffix: "freg"
+    description: "Floating-point register"
+
+  rounding_mode:
+    names: [rm]
+    tag_suffix: "rounding_mode"
+    description: "Floating-point rounding mode"
+
+# CSR-specific conventions
+csr_conventions:
+  field_value:
+    tag_format: "csr-<csr_name>-<field_name>-value"
+    description: "Value of a CSR field"
+    example: "csr-mstatus-mie-value"
+
+  field_type:
+    tag_format: "csr-<csr_name>-<field_name>-type"
+    description: "Type/accessibility of a CSR field"
+    example: "csr-mstatus-mie-type"
+
+  field_behavior:
+    tag_format: "csr-<csr_name>-<field_name>-behavior"
+    description: "Behavior of a CSR field"
+    example: "csr-mstatus-mie-behavior"
+
+# Tagging rules
+tagging_rules:
+  - rule: "Every parameter MUST have a tag"
+    priority: "HIGH"
+    
+  - rule: "Tags must follow the format: <scope>-<item>-<descriptor>"
+    priority: "HIGH"
+    
+  - rule: "For instructions: inst-<mnemonic>-<descriptor>"
+    priority: "HIGH"
+    
+  - rule: "For CSR fields: csr-<csr_name>-<field_name>-<descriptor>"
+    priority: "HIGH"
+    
+  - rule: "Tags must be globally unique and immutable"
+    priority: "HIGH"
+    
+  - rule: "If a parameter has no name, assign it based on conventions and then tag it"
+    priority: "MEDIUM"
+    
+  - rule: "Prefer existing parameter names from RISC-V spec as examples"
+    priority: "MEDIUM"
+    
+  - rule: "Document non-standard naming in comments"
+    priority: "LOW"
+
+# Examples of properly tagged instructions
+examples:
+  add_instruction:
+    instruction: "add"
+    parameters:
+      - name: rd
+        tag: "inst-add-dest_reg"
+        description: "Destination register"
+      - name: rs1
+        tag: "inst-add-src_reg_1"
+        description: "First source register"
+      - name: rs2
+        tag: "inst-add-src_reg_2"
+        description: "Second source register"
+      - name: funct3
+        tag: "inst-add-funct3"
+        description: "Function code 3"
+      - name: funct7
+        tag: "inst-add-funct7"
+        description: "Function code 7"
+      - name: opcode
+        tag: "inst-add-opcode"
+        description: "Primary opcode"
+
+  addi_instruction:
+    instruction: "addi"
+    parameters:
+      - name: rd
+        tag: "inst-addi-dest_reg"
+      - name: rs1
+        tag: "inst-addi-src_reg_1"
+      - name: imm
+        tag: "inst-addi-imm_i_type"
+      - name: funct3
+        tag: "inst-addi-funct3"
+      - name: opcode
+        tag: "inst-addi-opcode"
+
+  beq_instruction:
+    instruction: "beq"
+    parameters:
+      - name: rs1
+        tag: "inst-beq-src_reg_1"
+      - name: rs2
+        tag: "inst-beq-src_reg_2"
+      - name: imm
+        tag: "inst-beq-imm_b_type"
+      - name: funct3
+        tag: "inst-beq-funct3"
+      - name: opcode
+        tag: "inst-beq-opcode"

--- a/tools/tagging/tag_parameters.py
+++ b/tools/tagging/tag_parameters.py
@@ -1,0 +1,354 @@
+import yaml
+import sys
+import argparse
+from pathlib import Path
+from typing import Dict, List, Any, Tuple
+import re
+
+
+# Custom YAML representer
+class CustomDumper(yaml.SafeDumper):
+    """Custom YAML dumper that preserves block style for better readability"""
+    pass
+
+def dict_representer(dumper, data):
+    return dumper.represent_mapping('tag:yaml.org,2002:map', data.items())
+
+CustomDumper.add_representer(dict, dict_representer)
+
+class ParameterTagger:
+    def __init__(self, conventions_file: str):
+        """Initialize the tagger with conventions from a YAML file"""
+        conv_path = Path(conventions_file)
+        if not conv_path.is_absolute():
+            if not conv_path.exists():
+                script_dir = Path(__file__).parent
+                conv_path = script_dir / conventions_file
+        
+        if not conv_path.exists():
+            print(f"ERROR: Conventions file not found: {conventions_file}")
+            sys.exit(1)
+        
+        with open(str(conv_path), 'r') as f:
+            self.conventions = yaml.safe_load(f)
+        
+        # Build lookup tables for efficient tagging
+        self.param_to_suffix = {}
+        self.build_lookup_tables()
+    
+    def build_lookup_tables(self):
+        """Build efficient lookup tables from conventions"""
+        for category in ['register_operands', 'immediate_operands', 'function_codes', 'compressed_fields', 'vector_fields', 'fp_fields']:
+            if category not in self.conventions:
+                continue
+            
+            for op_type, info in self.conventions[category].items():
+                if 'names' in info:
+                    suffix = info['tag_suffix']
+                    for name in info['names']:
+                        self.param_to_suffix[name] = suffix
+        
+        # Handle special cases
+        if 'opcode' in self.conventions:
+            for name in self.conventions['opcode']['names']:
+                self.param_to_suffix[name] = self.conventions['opcode']['tag_suffix']
+    
+    def generate_tag(self, param_name: str, instruction_name: str) -> Tuple[str, str]:
+        """
+        Generate a tag for a parameter based on conventions
+        
+        Returns:
+            (tag, suffix) tuple, or (None, None) if no match found
+        """
+        if param_name in self.param_to_suffix:
+            suffix = self.param_to_suffix[param_name]
+            tag = f"inst-{instruction_name}-{suffix}"
+            return tag, suffix
+        
+        # Fallback for unnamed parameters - try to infer from context
+        # This is where custom logic can be added
+        return None, None
+    
+    def tag_instruction_file(self, file_path: str, dry_run: bool = False) -> Dict[str, Any]:
+        """
+        Add tags to parameters in an instruction YAML file using surgical edits
+        to preserve formatting, comments, and structure.
+        
+        Args:
+            file_path: Path to instruction YAML file
+            dry_run: If True, only show what would be changed
+        
+        Returns:
+            Dictionary with tagging results
+        """
+        result = {
+            'file': file_path,
+            'modified': False,
+            'changes': [],
+            'errors': [],
+            'skipped': []
+        }
+        
+        # Read the file content
+        try:
+            with open(file_path, 'r') as f:
+                content = f.read()
+                lines = content.split('\n')
+        except Exception as e:
+            result['errors'].append(f"Failed to read file: {e}")
+            return result
+        
+        # Parse YAML to identify which parameters need tagging
+        try:
+            with open(file_path, 'r') as f:
+                data = yaml.safe_load(f)
+        except Exception as e:
+            result['errors'].append(f"Failed to parse YAML: {e}")
+            return result
+        
+        if not data:
+            result['errors'].append("Empty YAML file")
+            return result
+        
+        # Get instruction name
+        inst_name = data.get('name')
+        if not inst_name:
+            result['errors'].append("No 'name' field found in instruction")
+            return result
+        
+        # Build list of parameters to tag
+        params_to_tag = {}
+        if 'encoding' in data and 'variables' in data['encoding']:
+            for var in data['encoding']['variables']:
+                param_name = var.get('name')
+                if not param_name:
+                    result['skipped'].append("Parameter with no name found")
+                    continue
+                
+                # Skip if already has a tag
+                if 'tag' in var:
+                    continue
+                
+                # Generate tag
+                tag, suffix = self.generate_tag(param_name, inst_name)
+                
+                if tag:
+                    params_to_tag[param_name] = tag
+                    result['changes'].append({
+                        'parameter': param_name,
+                        'tag': tag,
+                        'suffix': suffix
+                    })
+                    result['modified'] = True
+                else:
+                    result['skipped'].append(f"No convention for parameter: {param_name}")
+        
+        # If no changes needed, return
+        if not params_to_tag:
+            return result
+        
+        # Apply surgical edits to preserve formatting
+        if not dry_run:
+            try:
+                modified_lines = self._apply_surgical_edits(lines, params_to_tag)
+                if modified_lines != lines:
+                    with open(file_path, 'w') as f:
+                        f.write('\n'.join(modified_lines))
+                    result['written'] = True
+            except Exception as e:
+                result['errors'].append(f"Failed to write file: {e}")
+                result['modified'] = False
+        
+        return result
+    
+    def _apply_surgical_edits(self, lines: List[str], params_to_tag: Dict[str, str]) -> List[str]:
+        """
+        Apply surgical edits to add tags without changing formatting.
+        Looks for 'name: param_name' lines and adds 'tag: tag_value' after location line.
+        """
+        modified_lines = []
+        i = 0
+        
+        while i < len(lines):
+            line = lines[i]
+            modified_lines.append(line)
+            
+            # Check if this line contains a parameter name we need to tag
+            param_found = None
+            for param_name in params_to_tag:
+                if f'name: {param_name}' in line or f"name: '{param_name}'" in line or f'name: "{param_name}"' in line:
+                    param_found = param_name
+                    break
+            
+            if param_found:
+                # Found a parameter to tag, look for the location line
+                i += 1
+                while i < len(lines):
+                    next_line = lines[i]
+                    modified_lines.append(next_line)
+                    if 'location:' in next_line:
+                        indent = len(next_line) - len(next_line.lstrip())
+                        indent_str = ' ' * indent
+                        i += 1
+                        if i < len(lines):
+                            peek_line = lines[i]
+                            if not peek_line.strip().startswith('tag:') and not peek_line.strip().startswith('- '):
+                                modified_lines.insert(-1, f"{indent_str}tag: {params_to_tag[param_found]}")
+                            elif peek_line.strip().startswith('- '):
+                                modified_lines.insert(-1, f"{indent_str}tag: {params_to_tag[param_found]}")
+                            else:
+                                modified_lines.append(peek_line)
+                                i += 1
+                        else:
+                            modified_lines.insert(-1, f"{indent_str}tag: {params_to_tag[param_found]}")
+                        break
+                    
+                    i += 1
+            else:
+                i += 1
+        
+        return modified_lines
+    
+    def tag_extension(self, ext_dir: str, dry_run: bool = False) -> Dict[str, Any]:
+        """
+        Tag all instructions in an extension directory
+        
+        Args:
+            ext_dir: Path to extension directory
+            dry_run: If True, only show what would be changed
+        
+        Returns:
+            Summary of all tagging operations
+        """
+        results = {
+            'extension': ext_dir,
+            'total_files': 0,
+            'modified_files': 0,
+            'total_changes': 0,
+            'all_results': []
+        }
+        
+        ext_path = Path(ext_dir)
+        if not ext_path.exists():
+            results['error'] = f"Extension directory not found: {ext_dir}"
+            return results
+        
+        # Find all .yaml files in the extension directory
+        yaml_files = list(ext_path.glob('*.yaml'))
+        results['total_files'] = len(yaml_files)
+        
+        for yaml_file in sorted(yaml_files):
+            result = self.tag_instruction_file(str(yaml_file), dry_run)
+            results['all_results'].append(result)
+            
+            if result['modified']:
+                results['modified_files'] += 1
+                results['total_changes'] += len(result['changes'])
+        
+        return results
+    
+    def print_results(self, results: Dict[str, Any], verbose: bool = False):
+        """Pretty print tagging results"""
+        if 'error' in results:
+            print(f"ERROR: {results['error']}")
+            return
+        
+        # File-level results
+        if 'all_results' in results:
+            print(f"\nExtension Tagging Summary:")
+            print(f"  Directory: {results['extension']}")
+            print(f"  Total files: {results['total_files']}")
+            print(f"  Modified files: {results['modified_files']}")
+            print(f"  Total changes: {results['total_changes']}")
+            
+            if verbose:
+                for result in results['all_results']:
+                    if result['changes']:
+                        print(f"\n  {Path(result['file']).name}:")
+                        for change in result['changes']:
+                            print(f"    {change['parameter']} -> {change['tag']}")
+                    
+                    if result['errors']:
+                        print(f"  ERRORS in {Path(result['file']).name}:")
+                        for error in result['errors']:
+                            print(f"    - {error}")
+        else:
+            print(f"\nFile: {Path(results['file']).name}")
+            print(f"  Modified: {results['modified']}")
+            
+            if results['changes']:
+                print(f"  Changes ({len(results['changes'])}):")
+                for change in results['changes']:
+                    print(f"    {change['parameter']} -> {change['tag']}")
+            
+            if results['errors']:
+                print(f"  Errors:")
+                for error in results['errors']:
+                    print(f"    - {error}")
+            
+            if results['skipped']:
+                print(f"  Skipped ({len(results['skipped'])}):")
+                for skip in results['skipped'][:3]:
+                    print(f"    - {skip}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Tag instruction parameters according to UDB conventions'
+    )
+    parser.add_argument(
+        'target',
+        nargs='?',
+        help='File or directory to tag'
+    )
+    parser.add_argument(
+        '-c', '--conventions',
+        default='parameter_conventions.yaml',
+        help='Path to conventions file (default: parameter_conventions.yaml)'
+    )
+    parser.add_argument(
+        '-d', '--dry-run',
+        action='store_true',
+        help='Show what would be changed without modifying files'
+    )
+    parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        help='Verbose output'
+    )
+    parser.add_argument(
+        '-e', '--extension',
+        help='Tag all instructions in an extension directory'
+    )
+    
+    args = parser.parse_args()
+    
+    # Verify conventions file exists
+    if not Path(args.conventions).exists():
+        print(f"ERROR: Conventions file not found: {args.conventions}")
+        sys.exit(1)
+    
+    tagger = ParameterTagger(args.conventions)
+    if args.extension:
+        results = tagger.tag_extension(args.extension, args.dry_run)
+    elif args.target:
+        if not Path(args.target).exists():
+            print(f"ERROR: File not found: {args.target}")
+            sys.exit(1)
+        
+        results = tagger.tag_instruction_file(args.target, args.dry_run)
+    else:
+        parser.print_help()
+        sys.exit(1)
+    
+    tagger.print_results(results, args.verbose)
+    
+    if 'errors' in results and results['errors']:
+        sys.exit(1)
+    
+    if args.dry_run:
+        print("\n[DRY RUN - No files were modified]")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Develop prompts & context size for LLMs that identify architectural parameters 
in the RISC-V privileged and unprivileged spec.
==================================================

DESCRIPTION:
============
This PR introduces a comprehensive LLM-based infrastructure for identifying
architectural parameters from RISC-V privileged and unprivileged specifications.
The implementation provides prompts, context management, and examples required
for LLM-based parameter extraction with proper classification.

FILES INCLUDED:
===============
Scripts:
  • scripts/extract_udb_examples.py
  • scripts/extract_spec_sections.py

Prompts & Examples:
  • prompts/PROMPT_V1_BASIC.md (instruction prompt with task definition)
  • prompts/NEGATIVE_EXAMPLES.yaml (12 counter-examples for validation)

Specification Metadata:
  • spec_sections/SPEC_SECTIONS_UNPRIVILEGED.yaml (5 logical sections)
  • spec_sections/SPEC_SECTIONS_PRIVILEGED.yaml (5 logical sections)

USAGE:
======
1. Execute extraction scripts:
   python3 riscv-unified-db/scripts/extract_udb_examples.py
   python3 riscv-unified-db/scripts/extract_spec_sections.py

2. Feed generated artifacts to LLM:
   • PROMPT_V1_BASIC.md (task instructions)
   • UDB_EXAMPLES.yaml + NEGATIVE_EXAMPLES.yaml (in-context examples)
   • unprivileged_text.txt + privileged_text.txt (specification content)

SUMMARY:
========
• 2 automated extraction scripts (UDB examples + PDF processing)
• 1 baseline instruction prompt with classification schema
• 12 negative examples preventing hallucinations and false positives
• Specification metadata organizing content into 10 sections
• Support for LLM context window management

Note: The pdfs reffered to here are from RISC-V Documentation:-

1. Unprivileged Spec PDF
https://docs.riscv.org/reference/isa/_attachments/riscv-unprivileged.pdf 

1. Privileged Spec PDF
https://docs.riscv.org/reference/isa/_attachments/riscv-privileged.pdf

All these pdfs are then saved in the gitignore

<img width="1920" height="1020" alt="Screenshot 2026-01-15 230532" src="https://github.com/user-attachments/assets/78d05d42-4b54-4dce-aa59-94f2d4d7fadf" />

<img width="1920" height="1020" alt="Screenshot 2026-01-15 234221" src="https://github.com/user-attachments/assets/d10949ce-de6e-45ff-9728-30845b93382b" />
