### PR TITLE
fix: sync `Gemfile.lock` `BUNDLED_WTH` version to match new Ruby version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,4 +369,4 @@ RUBY VERSION
    ruby 3.2.3p157
 
 BUNDLED WITH
-   2.4.20
+   2.6.9


### PR DESCRIPTION
Avoids the following new warning introduced in #1301:
```
Bundler 2.6.9 is running, but your lockfile was generated with 2.4.20. Installing Bundler 2.4.20 and restarting using that version.
```