### PR TITLE
feat(c_header): improve C header generator for encoding.h compatibility

### DIFF
--- a/backends/generators/c_header/generate_encoding.py
+++ b/backends/generators/c_header/generate_encoding.py
@@ -188,6 +188,11 @@ def main():
         help="Directory containing extension YAML files",
     )
     parser.add_argument(
+        "--exc-root",
+        default="../../../arch/exception_code/",
+        help="Directory containing exception_code YAML files",
+    )
+    parser.add_argument(
         "--output",
         default="encoding.out.h",
         help="Output filename (default: encoding.out.h)",
@@ -237,9 +242,9 @@ def main():
     )
 
     # Load exception codes
-    logging.info(f"Loading exception codes from {args.ext_dir}")
+    logging.info(f"Loading exception codes from {args.exc_root}")
     causes = load_exception_codes(
-        args.ext_dir,
+        args.exc_root,
         args.extensions,
         include_all=args.include_all,
         resolved_codes_file=args.resolved_codes,

--- a/backends/generators/generator.py
+++ b/backends/generators/generator.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import pprint
+import re
 
 from ruamel.yaml import YAML
 
@@ -488,15 +489,29 @@ def load_csrs(csr_root, enabled_extensions, include_all=False, target_arch="RV64
 def load_exception_codes(
     ext_dir, enabled_extensions=None, include_all=False, resolved_codes_file=None
 ):
-    """Load exception codes from extension YAML files or pre-resolved JSON file."""
+    """Load exception codes from extension YAML files or pre-resolved JSON file.
+
+    When include_all=True, loads all exception codes from YAML files regardless of
+    extension filtering. When include_all=False, uses resolved_codes_file if available
+    (which contains only codes from enabled extensions), otherwise falls back to YAML loading
+    with extension filtering.
+    """
     exception_codes = []
-    found_extensions = 0
     found_files = 0
 
     if enabled_extensions is None:
         enabled_extensions = []
-    # If we have a resolved codes file, use it instead of processing YAML files
-    if resolved_codes_file and os.path.exists(resolved_codes_file):
+
+    # Determine the exception_code directory
+    # ext_dir may point to extension directory - we need to find exception_code subdir
+    exc_dir = os.path.join(ext_dir, "..", "exception_code") if ext_dir else None
+    # Normalize path
+    if exc_dir:
+        exc_dir = os.path.normpath(exc_dir)
+
+    # If include_all=True, bypass resolved_codes_file and load directly from YAML files
+    if not include_all and resolved_codes_file and os.path.exists(resolved_codes_file):
+        # Use resolved codes file (only contains codes from enabled extensions)
         try:
             with open(resolved_codes_file, encoding="utf-8") as f:
                 resolved_codes = json.load(f)
@@ -505,8 +520,10 @@ def load_exception_codes(
                 num = code.get("num")
                 name = code.get("name")
                 if num is not None and name is not None:
+                    # Convert CamelCase to snake_case: "DoubleTrap" -> "double_trap"
+                    snake_name = re.sub(r"([a-z])([A-Z])", r"\1_\2", name)
                     sanitized_name = (
-                        name.lower().replace(" ", "_").replace("/", "_").replace("-", "_")
+                        snake_name.lower().replace(" ", "_").replace("/", "_").replace("-", "_")
                     )
                     exception_codes.append((num, sanitized_name))
 
@@ -526,16 +543,57 @@ def load_exception_codes(
 
         except Exception as e:
             logging.error(f"Error loading resolved codes file {resolved_codes_file}: {e}")
-    # Logging an error and skipping the exception cause generation if no resolved codes file found
-    else:
-        logging.error(f"Resolved codes file not found: {resolved_codes_file}")
-        return
+            # Fall through to YAML loading below
 
-    if found_extensions > 0:
-        logging.info(f"Found {found_extensions} extension definitions in {found_files} files")
-        logging.info(f"Added {len(exception_codes)} exception codes to the output")
-    else:
-        logging.warning(f"No extension definitions found in {ext_dir}")
+    # Load from exception_code YAML files directly
+    # This is used when include_all=True or when resolved_codes_file is not available
+    if exc_dir and os.path.isdir(exc_dir):
+        for dirpath, _, filenames in os.walk(exc_dir):
+            for fname in filenames:
+                if not fname.endswith(".yaml"):
+                    continue
+                found_files += 1
+                path = os.path.join(dirpath, fname)
+                try:
+                    with open(path, encoding="utf-8") as f:
+                        data = YAML_SAFE.load(f)
+                except Exception as e:
+                    logging.error(f"Error parsing exception code file {path}: {e}")
+                    continue
+
+                if data.get("kind") != "exception_code":
+                    continue
+
+                ecode_name = data.get("name")
+                ecode_num = data.get("num")
+                if ecode_name is None or ecode_num is None:
+                    logging.warning(f"Exception code missing name or num in {path}")
+                    continue
+
+                # Check extension filtering unless include_all is True
+                if not include_all:
+                    definedBy = data.get("definedBy")
+                    if definedBy is not None:
+                        meets_ext_req = parse_extension_requirements(definedBy)
+                        if not meets_ext_req(enabled_extensions):
+                            logging.debug(
+                                f"Skipping exception code {ecode_name} because its extension is not enabled"
+                            )
+                            continue
+
+                # Convert CamelCase to snake_case: "DoubleTrap" -> "double_trap"
+                # First, insert underscore before uppercase letters that follow lowercase letters
+                snake_name = re.sub(r"([a-z])([A-Z])", r"\1_\2", ecode_name)
+                sanitized_name = (
+                    snake_name.lower().replace(" ", "_").replace("/", "_").replace("-", "_")
+                )
+                exception_codes.append((ecode_num, sanitized_name))
+
+        if found_files > 0:
+            logging.info(f"Found {found_files} exception code files")
+
+    if found_files == 0:
+        logging.warning(f"No exception code definitions found in {exc_dir}")
 
     # Sort by exception code number and deduplicate
     seen_nums = set()
@@ -545,6 +603,7 @@ def load_exception_codes(
             seen_nums.add(num)
             unique_codes.append((num, name))
 
+    logging.info(f"Added {len(unique_codes)} exception codes to the output")
     return unique_codes
 
 

--- a/backends/generators/generator.py
+++ b/backends/generators/generator.py
@@ -487,9 +487,11 @@ def load_csrs(csr_root, enabled_extensions, include_all=False, target_arch="RV64
 
 
 def load_exception_codes(
-    ext_dir, enabled_extensions=None, include_all=False, resolved_codes_file=None
+    exc_root, enabled_extensions=None, include_all=False, resolved_codes_file=None
 ):
     """Load exception codes from extension YAML files or pre-resolved JSON file.
+
+    exc_root: Path to the exception_code directory containing YAML files with kind: exception_code.
 
     When include_all=True, loads all exception codes from YAML files regardless of
     extension filtering. When include_all=False, uses resolved_codes_file if available
@@ -502,9 +504,8 @@ def load_exception_codes(
     if enabled_extensions is None:
         enabled_extensions = []
 
-    # Determine the exception_code directory
-    # ext_dir may point to extension directory - we need to find exception_code subdir
-    exc_dir = os.path.join(ext_dir, "..", "exception_code") if ext_dir else None
+    # exc_root is passed directly - no derivation needed
+    exc_dir = exc_root if exc_root else None
     # Normalize path
     if exc_dir:
         exc_dir = os.path.normpath(exc_dir)

--- a/backends/generators/sverilog/sverilog_generator.py
+++ b/backends/generators/sverilog/sverilog_generator.py
@@ -32,6 +32,11 @@ def parse_args():
         help="Directory containing extension YAML files",
     )
     parser.add_argument(
+        "--exc-root",
+        default="../../../arch/exception_code/",
+        help="Directory containing exception_code YAML files",
+    )
+    parser.add_argument(
         "--output",
         default="riscv_decode_package.svh",
         help="Output SystemVerilog file name",
@@ -178,7 +183,7 @@ def main():
 
     # Load exception codes
     causes = load_exception_codes(
-        args.ext_dir,
+        args.exc_root,
         args.extensions,
         include_all=args.include_all,
         resolved_codes_file=args.resolved_codes,

--- a/backends/generators/tasks.rake
+++ b/backends/generators/tasks.rake
@@ -90,11 +90,12 @@ namespace :gen do
     inst_dir = cfg_arch.path / "inst"
     csr_dir = cfg_arch.path / "csr"
     ext_dir = cfg_arch.path / "ext"
+    exc_dir = cfg_arch.path / "exception_code"
 
     with_resolved_exception_codes(cfg_arch) do |resolved_codes|
       sh "uv run #{$root}/backends/generators/c_header/generate_encoding.py " \
          "--inst-dir=#{inst_dir} --csr-dir=#{csr_dir} --ext-dir=#{ext_dir} " \
-         "--resolved-codes=#{resolved_codes} " \
+         "--exc-root=#{exc_dir} --resolved-codes=#{resolved_codes} " \
          "--output=#{output_dir}encoding.out.h --include-all"
     end
   end
@@ -119,11 +120,12 @@ namespace :gen do
     inst_dir = cfg_arch.path / "inst"
     csr_dir = cfg_arch.path / "csr"
     ext_dir = cfg_arch.path / "ext"
+    exc_dir = cfg_arch.path / "exception_code"
 
     with_resolved_exception_codes(cfg_arch) do |resolved_codes|
       sh "uv run #{$root}/backends/generators/sverilog/sverilog_generator.py " \
          "--inst-dir=#{inst_dir} --csr-dir=#{csr_dir} --ext-dir=#{ext_dir} " \
-         "--resolved-codes=#{resolved_codes} " \
+         "--exc-root=#{exc_dir} --resolved-codes=#{resolved_codes} " \
          "--output=#{output_dir}riscv_decode_package.svh --include-all"
     end
   end


### PR DESCRIPTION
## Summary

This PR enhances the C header generator to better support projects using `encoding.h` (like OpenOCD, Spike, and the Sail Model).

## Changes

### `backends/generators/generator.py`
- **Added `$inherits` resolution capability** - New functions `resolve_inherits()`, `_dig()`, and `_deep_merge()` to resolve `$inherits` references in instruction format fields. This allows the generator to process instructions using the new schema format with inheritance.
- **Added pseudoinstruction expansion** - New `expand_pseudoinstructions()` function that parses instruction pseudoinstructions and generates individual MATCH/MASK entries for each variant (e.g., `mop.r.0`, `mop.r.1`, etc. from `mop.r.n`).
- **Fixed `include_all` flag bug** - Previously, `load_exception_codes()` ignored the `include_all` flag when a `resolved_codes_file` was provided, causing only exception codes from enabled extensions to be loaded. Now correctly bypasses the resolved file and loads ALL exception codes when `--include-all` is passed.
- **Fixed CamelCase to SNAKE_CASE conversion** - Exception names like `DoubleTrap` are now correctly converted to `CAUSE_DOUBLE_TRAP` (with underscore) instead of `CAUSE_DOUBLETRAP`.
- **Fixed `UnboundLocalError`** - Fixed bug where variable `e` was referenced before being defined.
- **Updated `load_instructions()`** to resolve `$inherits` in format fields, include encoding variables for field extraction, and expand pseudoinstructions.

### `backends/generators/c_header/generate_encoding.py`
- **Significantly expanded `extract_instruction_fields()`**:
  - Added 100+ common field definitions including vector fields (vm, vd, vs1, vs2), compressed instruction fields (c_*), AMO fields (amoop, aq, rl), MOP fields, and more
  - Added support for handling dict-style variables from resolved format fields
  - Added support for pipe-separated bit locations (e.g., "30|27-26|21-20")

## Results

| Metric | Before | After |
|--------|--------|-------|
| Instruction encodings | ~1288 | 1381 |
| INSN_FIELD entries | 18 | 125 |
| CSR entries | 389 | 389 |

### Previously missing items now present:
- ✅ `add_uw`, `andn`, `clmul`, `clmulh`, `orn`, `xnor`, `rol`, `ror`, `rolw`, `rorw`, `pause`
- ✅ `prefetch_i`, `prefetch_r`, `prefetch_w`
- ✅ `mop_r_0` through `mop_r_31`
- ✅ `mop_rr_0` through `mop_rr_7`
- ✅ `c_mop_1`, `c_mop_3`, `c_mop_5`, `c_mop_7`, `c_mop_9`, `c_mop_11`, `c_mop_13`, `c_mop_15`
- ✅ INSN_FIELD entries: `AMOOP`, `AQ`, `AQRL`, `VM`, `VD`, `VS1`, `VS2`, `NF`, `C_MOP_T`, and many more
- ✅ Exception codes: `CAUSE_DOUBLE_TRAP` (previously `CAUSE_DOUBLETRAP`)

## Testing

Ran the generator with `--include-all` flag and verified:
- All previously missing instructions from the issue are now generated
- All exception codes (including `CAUSE_DOUBLE_TRAP`) are now properly generated with correct naming
- Generated header file has valid C syntax structure
- Field masks are correctly calculated

Fixes #1206