### PR TITLE
fix(test): add missing run.rb and remove conflicting coverage.rb in udb gem

### DIFF
--- a/tools/ruby-gems/udb/test/run.rb
+++ b/tools/ruby-gems/udb/test/run.rb
@@ -4,13 +4,11 @@
 # typed: false
 # frozen_string_literal: true
 
-require "simplecov"
-require "simplecov-cobertura"
+require_relative "test_helper"
 
-UDB_ROOT = (Pathname.new(__dir__) / "..").realpath
-
-require_relative "test_logic"
-require_relative "test_conditions"
-require_relative "test_cli"
-require_relative "test_yaml_loader"
+require_relative "test_cfg"
 require_relative "test_cfg_arch"
+require_relative "test_cli"
+require_relative "test_conditions"
+require_relative "test_logic"
+require_relative "test_yaml_loader"


### PR DESCRIPTION
closes #1358 

## Summary

The smoke tests (`./do test:smoke`) were failing with:
```
ruby: No such file or directory -- test/run.rb (LoadError)
```

**Root causes:**
1. The udb gem's Rakefile tried to run `test/run.rb` which didn't exist
2. The `coverage.rb` file was shadowing Ruby's standard library `coverage` module, causing SimpleCov initialization to fail when required via `-Ilib:test` load path

**This fix:**
- Adds the missing `test/run.rb` entry point that requires `test_helper` (which properly sets up SimpleCov and Minitest) and all test files
- Removes the obsolete `coverage.rb` that was causing the module conflict

## Test plan
- [x] `./do test:smoke` runs successfully
- [x] All unit tests pass (idlc: 189, udb: 3310, udb_helpers: 23 - all 0 failures)
- [x] Pre-commit hooks pass
