### PR TITLE
feat: add Ssube extension definition

### DIFF
--- a/spec/std/isa/ext/Ssube.yaml
+++ b/spec/std/isa/ext/Ssube.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) Ishaan Arora
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/ext_schema.json
+
+$schema: "ext_schema.json#"
+kind: extension
+name: Ssube
+long_name: Big-endian User Mode
+description: |
+  `sstatus.UBE` must be capable of holding the value 1 (i.e., big-endian user mode must be supported).
+
+  When `sstatus.UBE` is set to 1, data accesses in U-mode use big-endian byte ordering.
+  Instructions are always fetched as little-endian regardless of this setting.
+type: privileged
+versions:
+  - version: "1.0.0"
+    state: ratified
+    ratification_date: 2021-12
+requirements:
+  param:
+    name: U_MODE_ENDIANNESS
+    oneOf:
+      - big
+      - dynamic


### PR DESCRIPTION
## Summary

Add YAML definition for the Ssube (Big-endian User Mode) extension.

The Ssube extension indicates that the implementation supports big-endian user mode, meaning `sstatus.UBE` can be set to 1. When enabled, data accesses in U-mode use big-endian byte ordering. Instructions are always fetched as little-endian regardless of this setting.

This extension requires the `U_MODE_ENDIANNESS` parameter to be either `big` or `dynamic`.

## Test plan

- [x] YAML syntax valid
- [x] Validates against `ext_schema.json`
- [x] Pre-commit hooks pass

Closes #1203