### PR TITLE
feat: add Ssu32xl extension definition

### DIFF
--- a/spec/std/isa/ext/Ssu32xl.yaml
+++ b/spec/std/isa/ext/Ssu32xl.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) Ishaan Arora
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/ext_schema.json
+
+$schema: "ext_schema.json#"
+kind: extension
+name: Ssu32xl
+long_name: 32-bit UXLEN
+description: |
+  `sstatus.UXL` must be capable of holding the value 1 (i.e., UXLEN=32 must be supported).
+
+  This allows U-mode to run 32-bit code on a 64-bit machine by setting `sstatus.UXL` to 1.
+type: privileged
+versions:
+  - version: "1.0.0"
+    state: ratified
+    ratification_date: 2021-12
+requirements:
+  param:
+    name: UXLEN
+    includes: 32


### PR DESCRIPTION
## Summary

Add YAML definition for the Ssu32xl (32-bit UXLEN) extension.

The Ssu32xl extension indicates that the implementation supports 32-bit user mode, meaning `sstatus.UXL` can be set to 1 (UXLEN=32). This allows U-mode to run 32-bit code on a 64-bit machine.

This is the complementary extension to Ssu64xl (which requires UXLEN=64 support).

## Test plan

- [x] YAML syntax valid
- [x] Validates against `ext_schema.json`
- [x] Pre-commit hooks pass

Closes #1202