### PR TITLE
fix(data): change Zic64b extension type to unprivileged

### DIFF
--- a/spec/std/isa/ext/Zic64b.yaml
+++ b/spec/std/isa/ext/Zic64b.yaml
@@ -12,7 +12,7 @@ description: |
 
   [NOTE]
   This extension was ratified with the RVA20 profiles.
-type: privileged
+type: unprivileged
 versions:
   - version: "1.0.0"
     state: ratified


### PR DESCRIPTION
## Summary

The Zic64b extension is currently marked as `type: privileged`, but this appears to be incorrect.

Zic64b only defines that cache blocks must be 64 bytes in size - it doesn't add any CSRs, instructions, or interact with privileged state in any way. It simply constrains the `CACHE_BLOCK_SIZE` parameter to 64, which is a hardware property that applies uniformly across all privilege levels.

As noted in the issue, this would also make Zic64b the only "Z" extension marked as privileged, which is inconsistent with the naming convention where "Z" extensions are typically unprivileged and "S" extensions are privileged.

## Changes

- Changed `type: privileged` to `type: unprivileged` in `spec/std/isa/ext/Zic64b.yaml`

## Test plan

- [x] Pre-commit hooks pass
- [x] YAML schema validation passes

Closes #1350