### PR TITLE
fix(vector): handle xd==0 case correctly in vsetvli

### DIFF
--- a/spec/std/isa/inst/V/vsetvli.yaml
+++ b/spec/std/isa/inst/V/vsetvli.yaml
@@ -28,6 +28,9 @@ access:
   vu: always
 data_independent_timing: false
 operation(): |
+  # Save old vector state for ratio comparison (needed for xs1==0 && xd==0 case)
+  VectorState old_state = vector_state();
+
   XReg new_vtype = vtypei;
   if ((new_vtype[xlen() - 1] == 1'b1) # software is setting the illegal bit
       || ((new_vtype & 8'd0) != 0)    # reserved bits
@@ -42,47 +45,55 @@ operation(): |
     CSR[vtype].VSEW = 0;
     CSR[vtype].VLMUL = 0;
     CSR[vl].VALUE = 0;
-  } else
-    {
-      # valid, do the write
-      CSR[vtype].VILL = 0;
-      CSR[vtype].VMA = new_vtype[7];
-      CSR[vtype].VTA = new_vtype[6];
-      CSR[vtype].VSEW = new_vtype[5:3];
-      CSR[vtype].VLMUL = new_vtype[2:0];
+  } else {
+    # valid, do the write
+    CSR[vtype].VILL = 0;
+    CSR[vtype].VMA = new_vtype[7];
+    CSR[vtype].VTA = new_vtype[6];
+    CSR[vtype].VSEW = new_vtype[5:3];
+    CSR[vtype].VLMUL = new_vtype[2:0];
 
-      VectorState state = vector_state();
-      XReg vlen = VLEN;
-      XReg vlmax = (vlen << state.log2_lmul) >> state.log2_sew;
-      XReg avl = X[xs1];
-      XReg ceil_avl_over_two = (avl + 1) / 2;
+    VectorState state = vector_state();
+    XReg vlen = VLEN;
+    XReg vlmax = (vlen << state.log2_lmul) >> state.log2_sew;
+    XReg avl = X[xs1];
+    XReg ceil_avl_over_two = (avl + 1) / 2;
 
-      if (xs1 == 0)
-      {
+    if (xs1 == 0) {
+      if (xd != 0) {
+        # rs1 == x0, rd != x0: set vl to VLMAX
         CSR[vl].VALUE = vlmax;
-      } else
-      {
-        if (avl <= vlmax)
-        {
-          CSR[vl].VALUE = avl;
-        } else if (avl < 2*vlmax)
-            {
-              if (RVV_VL_WHEN_AVL_LT_DOUBLE_VLMAX == "ceil(AVL/2)")
-              {
-                CSR[vl].VALUE = ceil_avl_over_two;
-              } else if (RVV_VL_WHEN_AVL_LT_DOUBLE_VLMAX == "VLMAX")
-                {
-                  CSR[vl].VALUE = vlmax;
-                } else
-                  {
-                    unpredictable("Implementations may choose a custom value for vl in the case AVL < (2*VLMAX), so long as ceil(AVL/2) <= vl <= VLMAX");
-                  }
-            } else
-              {
-                CSR[vl].VALUE = vlmax;
-              }
+      } else {
+        # rs1 == x0, rd == x0: keep existing vl, but check LMUL/SEW ratio
+        XReg old_ratio = old_state.log2_sew - old_state.log2_lmul;
+        XReg new_ratio = state.log2_sew - state.log2_lmul;
+        if (new_ratio != old_ratio) {
+          # Ratio changed - set vill and clear vl
+          CSR[vtype].VILL = 1;
+          CSR[vtype].VMA = 0;
+          CSR[vtype].VTA = 0;
+          CSR[vtype].VSEW = 0;
+          CSR[vtype].VLMUL = 0;
+          CSR[vl].VALUE = 0;
+        }
+        # else: keep vl unchanged
+      }
+    } else {
+      if (avl <= vlmax) {
+        CSR[vl].VALUE = avl;
+      } else if (avl < 2*vlmax) {
+        if (RVV_VL_WHEN_AVL_LT_DOUBLE_VLMAX == "ceil(AVL/2)") {
+          CSR[vl].VALUE = ceil_avl_over_two;
+        } else if (RVV_VL_WHEN_AVL_LT_DOUBLE_VLMAX == "VLMAX") {
+          CSR[vl].VALUE = vlmax;
+        } else {
+          unpredictable("Implementations may choose a custom value for vl in the case AVL < (2*VLMAX), so long as ceil(AVL/2) <= vl <= VLMAX");
+        }
+      } else {
+        CSR[vl].VALUE = vlmax;
       }
     }
+  }
   X[xd] = CSR[vl].VALUE;
   CSR[vstart].VALUE = 0;
 


### PR DESCRIPTION
## Summary

This fix addresses the incorrect handling of the `rs1 == x0, rd == x0` case in the vsetvli instruction's IDL implementation.

According to the RISC-V Vector specification, vsetvli has three distinct cases:

1. **rs1 != x0**: Normal stripmining - AVL from X[rs1], write vl to rd
2. **rs1 == x0, rd != x0**: Set vl to VLMAX, write VLMAX to rd  
3. **rs1 == x0, rd == x0**: Keep existing vl unchanged (used to change vtype without disturbing vl)

The previous implementation only handled cases 1 and 2, incorrectly setting vl to VLMAX whenever `xs1 == 0` regardless of the value of `xd`.

## Changes

- Save the old vector state (LMUL/SEW ratio) before modifying vtype
- Add proper condition check for `xd != 0` vs `xd == 0` when `xs1 == 0`
- Implement the "keep vl" behavior for case 3, including the ratio change check that sets vill=1 and vl=0 if the LMUL/SEW ratio changes

## Alignment with Sail model

The fix aligns the IDL `operation()` implementation with the Sail reference model's `sail()` section (lines 137-161), which already correctly implements all three cases.

## Test plan

- [x] Pre-commit hooks pass
- [x] IDL implementation now matches Sail reference model behavior
- [ ] Vector instruction tests exercise all three vsetvli cases

Closes #1269