### PR TITLE
fix(generators): exclude mock instructions and CSRs by default

### DIFF
--- a/backends/generators/Go/go_generator.py
+++ b/backends/generators/Go/go_generator.py
@@ -108,6 +108,11 @@ def parse_args():
         action="store_true",
         help="Include all instructions, ignoring extension filtering",
     )
+    parser.add_argument(
+        "--include-mock",
+        action="store_true",
+        help="Include mock/test instructions and CSRs (excluded by default)",
+    )
     return parser.parse_args()
 
 
@@ -143,9 +148,16 @@ def main():
     if not os.path.isdir(args.csr_dir):
         logging.warning(f"CSR directory not found: {args.csr_dir}")
 
+    # By default, mock items are excluded unless --include-mock is specified
+    exclude_mock = not args.include_mock
+
     # Load instructions filtered by extensions or all instructions
     instr_dict = load_instructions(
-        args.inst_dir, enabled_extensions, include_all, args.arch
+        args.inst_dir,
+        enabled_extensions,
+        include_all,
+        args.arch,
+        exclude_mock=exclude_mock,
     )
     if not instr_dict:
         logging.error("No instructions found or all were filtered out.")
@@ -156,7 +168,13 @@ def main():
     logging.info(f"Loaded {len(instr_dict)} instructions")
 
     # Load CSRs filtered by extensions or all CSRs
-    csrs = load_csrs(args.csr_dir, enabled_extensions, include_all, args.arch)
+    csrs = load_csrs(
+        args.csr_dir,
+        enabled_extensions,
+        include_all,
+        args.arch,
+        exclude_mock=exclude_mock,
+    )
     if not csrs:
         logging.warning("No CSRs found or all were filtered out.")
     else:

--- a/backends/generators/c_header/generate_encoding.py
+++ b/backends/generators/c_header/generate_encoding.py
@@ -224,6 +224,11 @@ def main():
         "--resolved-codes",
         help="JSON file containing pre-resolved exception codes",
     )
+    parser.add_argument(
+        "--include-mock",
+        action="store_true",
+        help="Include mock/test instructions and CSRs (excluded by default)",
+    )
 
     args = parser.parse_args()
 
@@ -234,14 +239,25 @@ def main():
     output_file = os.path.join(this_dir, args.output)
 
     # Load instructions and CSRs
+    # By default, mock items are excluded unless --include-mock is specified
+    exclude_mock = not args.include_mock
+
     logging.info(f"Loading instructions from {args.inst_dir}")
     instructions = load_instructions(
-        args.inst_dir, args.extensions, include_all=args.include_all, target_arch="BOTH"
+        args.inst_dir,
+        args.extensions,
+        include_all=args.include_all,
+        target_arch="BOTH",
+        exclude_mock=exclude_mock,
     )
 
     logging.info(f"Loading CSRs from {args.csr_dir}")
     csrs = load_csrs(
-        args.csr_dir, args.extensions, include_all=args.include_all, target_arch="BOTH"
+        args.csr_dir,
+        args.extensions,
+        include_all=args.include_all,
+        target_arch="BOTH",
+        exclude_mock=exclude_mock,
     )
 
     # Load exception codes

--- a/backends/generators/sverilog/sverilog_generator.py
+++ b/backends/generators/sverilog/sverilog_generator.py
@@ -61,6 +61,11 @@ def parse_args():
         "--resolved-codes",
         help="JSON file containing pre-resolved exception codes",
     )
+    parser.add_argument(
+        "--include-mock",
+        action="store_true",
+        help="Include mock/test instructions and CSRs (excluded by default)",
+    )
     return parser.parse_args()
 
 
@@ -174,14 +179,27 @@ def main():
 
     logging.info(f"Target architecture: {args.arch}")
 
+    # By default, mock items are excluded unless --include-mock is specified
+    exclude_mock = not args.include_mock
+
     # Load instructions
     instructions = load_instructions(
-        args.inst_dir, enabled_extensions, args.include_all, args.arch
+        args.inst_dir,
+        enabled_extensions,
+        args.include_all,
+        args.arch,
+        exclude_mock=exclude_mock,
     )
     logging.info(f"Loaded {len(instructions)} instructions")
 
     # Load CSRs
-    csrs = load_csrs(args.csr_dir, enabled_extensions, args.include_all, args.arch)
+    csrs = load_csrs(
+        args.csr_dir,
+        enabled_extensions,
+        args.include_all,
+        args.arch,
+        exclude_mock=exclude_mock,
+    )
     logging.info(f"Loaded {len(csrs)} CSRs")
 
     # Load exception codes


### PR DESCRIPTION
## Summary

Mock/test data (like the `mock` instruction from the `Xmock` extension) was appearing in generated artifacts such as `encoding.h`. This is problematic because downstream consumers like Spike, ACTs, and the Sail model should not include test-only data in their production artifacts.

## Problem

As reported in the issue:
```bash
$ ./do gen:c_header
$ grep -i mock gen/c_header/encoding.out.h
#define MATCH_MOCK 0x200000b
#define MASK_MOCK 0xfe00707f
DECLARE_INSN(mock, MATCH_MOCK, MASK_MOCK)
```

Mock instructions should not appear in standard artifacts and should be filtered out by default.

## Solution

This PR adds filtering logic to exclude mock items by default:

1. **New helper function `is_mock_item()`** in `generator.py` that detects mock items by:
   - Name containing 'mock' (case-insensitive)
   - Being defined by an extension containing 'mock' in its name

2. **New `exclude_mock` parameter** added to:
   - `load_instructions()` - defaults to `True`
   - `load_csrs()` - defaults to `True`

3. **New `--include-mock` CLI flag** added to all generators:
   - `c_header/generate_encoding.py`
   - `Go/go_generator.py`
   - `sverilog/sverilog_generator.py`

4. **Logging** to report how many mock items were filtered

## Usage

By default, mock items are now excluded:
```bash
./do gen:c_header  # mock items filtered out
```

To include mock items (for testing purposes):
```bash
python3 backends/generators/c_header/generate_encoding.py --include-mock
```

## Test plan

- [x] Pre-commit hooks pass (black, pyupgrade, etc.)
- [x] Code follows existing patterns in the codebase
- [ ] Manual testing: run `gen:c_header` and verify no mock items in output
- [ ] Manual testing: run with `--include-mock` and verify mock items present

Closes #1148