### PR TITLE
feat: add Sstvecv extension definition

### DIFF
--- a/spec/std/isa/ext/Sstvecv.yaml
+++ b/spec/std/isa/ext/Sstvecv.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) Ishaan Arora
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# yaml-language-server: $schema=../../../schemas/ext_schema.json
+
+$schema: "ext_schema.json#"
+kind: extension
+name: Sstvecv
+long_name: Vectored exception handling
+description: |
+  `stvec.MODE` must be capable of holding the value 1 (Vectored).
+  When `stvec.MODE`=Vectored, interrupts set `pc` to `stvec.BASE + 4 * cause`,
+  allowing each interrupt source to have its own entry point.
+  Synchronous exceptions still use the base address regardless of the mode.
+type: privileged
+versions:
+  - version: "1.0.0"
+    state: ratified
+    ratification_date: 2023-03
+    url: https://github.com/riscv/riscv-profiles/releases/tag/v1.0
+    repositories:
+      - url: https://github.com/riscv/riscv-profiles
+        branch: main
+    contributors:
+      - name: Krste Asanovic
+        company: SiFive, Inc.
+requirements:
+  param:
+    name: STVEC_MODE_VECTORED
+    equal: true


### PR DESCRIPTION
## Summary

Add the Sstvecv (Vectored exception handling) extension definition.

## What is Sstvecv?

Sstvecv indicates that the `stvec.MODE` field is capable of holding the value 1 (Vectored), enabling vectored interrupt handling.

When `stvec.MODE` = Vectored:
- Interrupts set `pc` to `stvec.BASE + 4 * cause`
- Each interrupt source has its own dedicated entry point
- Synchronous exceptions still use the base address regardless of mode

## Relationship to Sstvecd

This extension is the companion to the existing Sstvecd extension:
- **Sstvecd**: Indicates support for Direct mode (`MODE=0`)
- **Sstvecv**: Indicates support for Vectored mode (`MODE=1`)

## Requirements

The extension requires the `STVEC_MODE_VECTORED` parameter to be `true`.

## Reference

Based on the same ratification as Sstvecd from the RISC-V Profiles specification (ratified March 2023).

## Test plan

- [x] YAML schema validation passes
- [x] Pre-commit hooks pass

Closes #1201