### PR TITLE
docs: fix typos in documentation and comments

### DIFF
--- a/doc/idl.adoc
+++ b/doc/idl.adoc
@@ -559,7 +559,7 @@ Bits<8> ary[2];                 # declare ary, initialized to [8'd0, 8'd0]
 # Bits<8> d$_line;  # compilation error: '$' is not a valid variable name character
 ----
 
-The general-purpose RISC-V x registers are builtin state for IDL (rather than being declared state). This is to accommodate special-cases regarding the x registers without without needing special language support (e.g., operator overloading) or ugly function calls on every X register access (_e.g._, set_xreg(index, value)):
+The general-purpose RISC-V x registers are builtin state for IDL (rather than being declared state). This is to accommodate special-cases regarding the x registers without needing special language support (e.g., operator overloading) or ugly function calls on every X register access (_e.g._, set_xreg(index, value)):
 
  . The x0 register is hardwired to 0
  . All writes to an x register when MXLEN != the current XLEN are sign-extended to MXLEN.
@@ -988,7 +988,7 @@ IDL is used in several places of a CSR definition in `arch/csr`:
 
 sw_read()::
 
-The "sw_read()" function executes when a software read (via a `Zicsr` instruction) occurs. It executes in Csr scope, takes no arguments, and must return a `Bits<N>` value, where N is the width of the CSR. If a CSR does not specify a "sw_read()", then the value of CSR is formed directly from it's field values.
+The "sw_read()" function executes when a software read (via a `Zicsr` instruction) occurs. It executes in Csr scope, takes no arguments, and must return a `Bits<N>` value, where N is the width of the CSR. If a CSR does not specify a "sw_read()", then the value of CSR is formed directly from its field values.
 
 .Example sw_read()
 [source,yaml]

--- a/tools/ruby-gems/udb-gen/sorbet/rbi/gems/udb@0.1.0.rbi
+++ b/tools/ruby-gems/udb-gen/sorbet/rbi/gems/udb@0.1.0.rbi
@@ -1342,7 +1342,7 @@ class Udb::AbstractCondition
   sig { params(other_condition: ::Udb::AbstractCondition).returns(T::Boolean) }
   def always_implies?(other_condition); end
 
-  # is is possible for this condition and other to be simultaneously true?
+  # is it possible for this condition and other to be simultaneously true?
   #
   # source://udb//../../udb/lib/udb/condition.rb#213
   sig { params(other: ::Udb::AbstractCondition).returns(T::Boolean) }

--- a/tools/ruby-gems/udb/lib/udb/condition.rb
+++ b/tools/ruby-gems/udb/lib/udb/condition.rb
@@ -208,13 +208,13 @@ module Udb
       end
     end
 
-    # is is possible for this condition and other to be simultaneously true?
+    # is it possible for this condition and other to be simultaneously true?
     sig { params(other: AbstractCondition).returns(T::Boolean) }
     def compatible?(other)
       (self & other).satisfiable?
     end
 
-    # @return if the condition is, possibly is, or is definately not satisfied by cfg_arch
+    # @return if the condition is, possibly is, or is definitely not satisfied by cfg_arch
     sig { abstract.params(_cfg_arch: ConfiguredArchitecture).returns(SatisfiedResult) }
     def satisfied_by_cfg_arch?(_cfg_arch); end
 


### PR DESCRIPTION
## Summary
This PR fixes several typos found in documentation and code comments.

### Changes

#### doc/idl.adoc
1. **Line 562**: Fixed duplicate word "without without" → "without"
2. **Line 991**: Fixed incorrect possessive "it's" → "its" ("it's" = "it is", "its" = possessive)

#### tools/ruby-gems/udb/lib/udb/condition.rb  
1. **Line 211**: Fixed typo "is is" → "is it" in comment
2. **Line 217**: Fixed spelling "definately" → "definitely"

#### tools/ruby-gems/udb-gen/sorbet/rbi/gems/udb@0.1.0.rbi
- Updated generated RBI file to reflect the comment fix in condition.rb

### Testing
- No functional changes - documentation and comments only
- No conflicts with other open PRs (verified that no other PRs touch these files)