### PR TITLE
docs: fix spelling typos in documentation

### DIFF
--- a/doc/HOW-DO-I.adoc
+++ b/doc/HOW-DO-I.adoc
@@ -37,4 +37,4 @@ Install it on the host:
 bundle install
 ```
 
-Then follow the proceedure in <<Update Ruby gems>>.
+Then follow the procedure in <<Update Ruby gems>>.

--- a/doc/ci.adoc
+++ b/doc/ci.adoc
@@ -5,7 +5,7 @@
 
 The UnifiedDB project uses continuous integration (CI) to improve quality and automate artifact creation.
 
-We use two framworks for CI:
+We use two frameworks for CI:
 
 - https://pre-commit.com[pre-commit]
 - https://docs.github.com/en/actions[GitHub Actions]


### PR DESCRIPTION
## Summary
Fix two spelling errors in documentation files.

## Changes
- [doc/ci.adoc](doc/ci.adoc): Fixed 'framworks' → 'frameworks' (line 8)
- [doc/HOW-DO-I.adoc](doc/HOW-DO-I.adoc): Fixed 'proceedure' → 'procedure' (line 40)

## Testing
These are simple documentation typo fixes with no functional impact.