### PR TITLE
fix: Rename 'Option Extensions' to 'Optional Extensions' in CRD

### DIFF
--- a/backends/proc_crd/templates/proc_crd.adoc.erb
+++ b/backends/proc_crd/templates/proc_crd.adoc.erb
@@ -147,13 +147,13 @@ The <%= proc_cert_model.name %> certificate doesn't cover their behaviors.
 
 <% [Udb::Presence::Mandatory, Udb::Presence::Option].each do |presence_obj| -%>
 
-=== <%= presence_obj.to_s.capitalize %> Extensions
+=== <%= presence_obj.to_s_concise.capitalize %> Extensions
 
 <% ext_reqs = proc_cert_model.in_scope_ext_reqs(presence_obj) -%>
 <% if ext_reqs.empty? -%>
 None
 <% else -%>
-The <%= proc_cert_model.name %> certificate has <%= ext_reqs.size %> <%= presence_obj.to_s %> extensions.
+The <%= proc_cert_model.name %> certificate has <%= ext_reqs.size %> <%= presence_obj.to_s_concise %> extensions.
 
 [%autowidth]
 |===


### PR DESCRIPTION
## Summary
This PR fixes a typo in the CRD (Certification Requirements Document) template where 'Option Extensions' was displayed instead of 'Optional Extensions'.

## Changes
- Changed `to_s` to `to_s_concise` in `backends/proc_crd/templates/proc_crd.adoc.erb`
- This affects both the section header and the description text

## Before
- Section header: 'Option Extensions'
- Text: '...has X option extensions'

## After
- Section header: 'Optional Extensions'
- Text: '...has X optional extensions'

Fixes #1389

@lfx