### PR TITLE
feat: map docker home to local folder instead of tmpfs

### DIFF
--- a/bin/clobber
+++ b/bin/clobber
@@ -5,6 +5,7 @@ ROOT=$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")
 rm -rf                   \
   "${ROOT}"/.stamps      \
   "${ROOT}"/.home        \
+  "${ROOT}"/.docker-home \
   "${ROOT}"/.bundle      \
   "${ROOT}"/.singularity \
   "${ROOT}"/.cache       \

--- a/bin/setup
+++ b/bin/setup
@@ -113,8 +113,11 @@ elif [ "${CONTAINER_TYPE}" == "docker" ] || [ "${CONTAINER_TYPE}" == "podman" ];
     fi
     if ! [ -v GITHUB_ACTIONS ]; then
       # create empty home directory (used as location to cache files by several tools)
+      if ! [ -d "${ROOT}"/.docker-home ]; then
+        mkdir "${ROOT}"/.docker-home
+      fi
       CONTAINER_RUN_FLAGS="${CONTAINER_RUN_FLAGS} -e HOME"
-      CONTAINER_RUN_FLAGS="${CONTAINER_RUN_FLAGS} --tmpfs ${HOME}"
+      CONTAINER_RUN_FLAGS="${CONTAINER_RUN_FLAGS} -v ${ROOT}/.docker-home:${HOME}"
     fi
 
     mkdir -p "${ROOT}/.cache"


### PR DESCRIPTION
Since tmpfs was destroyed after every run, things like pre-commit that cache under $HOME had to go through initialization every time