### PR TITLE
fix: trailing newline in `container.yml`

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -165,4 +165,3 @@ jobs:
       - name: Remove intermediate containers
         run: |
           docker image rm ${{ env.CONTAINER_NAME }}
-


### PR DESCRIPTION
Not sure how this got in, but it is breaking CI for all other PRs.