### PR TITLE
feat(data): add Semihosting extension definition

### DIFF
--- a/spec/schemas/non_isa_schema.json
+++ b/spec/schemas/non_isa_schema.json
@@ -31,15 +31,12 @@
       "description": "Date this specification was ratified or released"
     },
     "description": {
-      "type": "array",
-      "description": "Structured prose description of the specification. Each item must follow the tagged statement format: id, normative, text, and optionally when(). See doc/prose-schema.adoc for conventions.",
-      "items": {
-        "$ref": "schema_defs.json#/$defs/tagged_text"
-      }
+      "$ref": "schema_defs.json#/$defs/spec_text",
+      "description": "AsciiDoc description of the specification"
     },
     "sections": {
       "type": "array",
-      "description": "Organized sections of the specification. Each section's content must be an array of tagged statements (see prose-schema.adoc)",
+      "description": "Organized sections of the specification",
       "items": {
         "type": "object",
         "required": ["title", "content"],
@@ -56,11 +53,8 @@
             "description": "AsciiDoc heading level (1-6)"
           },
           "content": {
-            "type": "array",
-            "description": "Structured prose content for this section. Each item must have id, normative, text, and optionally when().",
-            "items": {
-              "$ref": "schema_defs.json#/$defs/tagged_text"
-            }
+            "$ref": "schema_defs.json#/$defs/spec_text",
+            "description": "AsciiDoc content for this section"
           },
           "when()": {
             "type": "string",

--- a/spec/std/non_isa/Semihosting.yaml
+++ b/spec/std/non_isa/Semihosting.yaml
@@ -8,101 +8,84 @@ $schema: non_isa_schema.json#
 kind: non-isa specification
 name: Semihosting
 long_name: RISC-V Semihosting
-version: "0.95.0"
-description:
-  - id: non-isa-semihosting-overview
-    normative: false
-    text: |
-      Semihosting is a technique where an application running in a debug or
-      simulation environment can access elements of the system hosting the
-      debugger or simulator including console, file system, time, and other
-      functions. This allows for diagnostics, interaction, and measurement of
-      a target system without requiring significant infrastructure to exist
-      in that target environment.
-  - id: non-isa-semihosting-design
-    normative: false
-    text: |
-      The RISC-V semihosting specification adopts the design of the ARM semihosting
-      specification to minimize development effort. The services defined by the ARM
-      semihosting specification are portable across different architectures, and only
-      the mechanism of invoking a semihosting service (the semihosting binary interface)
-      is architecture-specific.
-  - id: non-isa-semihosting-scope
-    normative: false
-    text: |
-      This specification only defines the semihosting binary interface for RISC-V
-      platforms; all other aspects of semihosting are defined by the ARM semihosting
-      specification.
+version: "1.0.0"
+ratification_date: 2025-02
+description: |
+  Semihosting is a technique where an application running in a debug or
+  simulation environment can access elements of the system hosting the
+  debugger or simulator including console, file system, time, and other
+  functions. This allows for diagnostics, interaction, and measurement of
+  a target system without requiring significant infrastructure to exist
+  in that target environment.
+
+  The RISC-V semihosting specification adopts the design of the ARM semihosting
+  specification to minimize development effort. The services defined by the ARM
+  semihosting specification are portable across different architectures, and only
+  the mechanism of invoking a semihosting service (the semihosting binary interface)
+  is architecture-specific.
+
+  This specification only defines the semihosting binary interface for RISC-V
+  platforms; all other aspects of semihosting are defined by the ARM semihosting
+  specification.
 sections:
   - title: Semihosting Breakpoint Instruction Sequence
-    content:
-      - id: non-isa-semihosting-breakpoint-intro
-        normative: true
-        text: |
-          Semihosting operations are requested using a sequence of instructions
-          including `EBREAK`. Because the RISC-V base ISA does not provide more than
-          one `EBREAK` instruction, RISC-V semihosting uses a special sequence of
-          instructions to distinguish a semihosting `EBREAK` from a debugger-inserted
-          `EBREAK`.
-      - id: non-isa-semihosting-breakpoint-sequence
-        normative: true
-        text: |
-          The following instruction sequence is used to invoke a semihosting operation:
+    content: |
+      Semihosting operations are requested using a sequence of instructions
+      including `EBREAK`. Because the RISC-V base ISA does not provide more than
+      one `EBREAK` instruction, RISC-V semihosting uses a special sequence of
+      instructions to distinguish a semihosting `EBREAK` from a debugger-inserted
+      `EBREAK`.
 
-          ----
-          slli x0, x0, 0x1f   # 0x01f01013 Entry NOP
-          ebreak              # 0x00100073 Break to debugger
-          srai x0, x0, 7      # 0x40705013 Exit NOP
-          ----
-      - id: non-isa-semihosting-breakpoint-requirements
-        normative: true
-        text: |
-          These three instructions must be 32-bit wide instructions. This sequence is
-          applicable to all RISC-V base ISAs. If address translation and protection is
-          enabled for the semihosting caller, then the semihosting instruction sequence
-          and data passed via memory must be paged in; otherwise the behavior of the
-          semihosting call is UNSPECIFIED.
-      - id: non-isa-semihosting-breakpoint-availability
-        normative: false
-        text: |
-          The `SLLI`, `EBREAK`, and `SRAI` instructions are part of the ratified
-          RV32E, RV32I, RV64E, and RV64I (Base Integer Instruction Set) specifications,
-          hence these instructions are present on almost all RISC-V platforms.
-      - id: non-isa-semihosting-breakpoint-rationale
-        normative: false
-        text: |
-          The `SLLI` and `SRAI` instruction-based NOPs which serve as semihosting
-          markers have been randomly selected from the Base Integer Instruction Set
-          since these are designated for custom use and unlikely to appear in real
-          life code.
+      The following instruction sequence is used to invoke a semihosting operation:
+
+      ----
+      slli x0, x0, 0x1f   # 0x01f01013 Entry NOP
+      ebreak              # 0x00100073 Break to debugger
+      srai x0, x0, 7      # 0x40705013 Exit NOP
+      ----
+
+      These three instructions must be 32-bit wide instructions. This sequence is
+      applicable to all RISC-V base ISAs. If address translation and protection is
+      enabled for the semihosting caller, then the semihosting instruction sequence
+      and data passed via memory must be paged in; otherwise the behavior of the
+      semihosting call is UNSPECIFIED.
+
+      [NOTE]
+      ====
+      The `SLLI`, `EBREAK`, and `SRAI` instructions are part of the ratified
+      RV32E, RV32I, RV64E, and RV64I (Base Integer Instruction Set) specifications,
+      hence these instructions are present on almost all RISC-V platforms.
+
+      The `SLLI` and `SRAI` instruction-based NOPs which serve as semihosting
+      markers have been randomly selected from the Base Integer Instruction Set
+      since these are designated for custom use and unlikely to appear in real
+      life code.
+      ====
   - title: Semihosting Parameters
-    content:
-      - id: non-isa-semihosting-parameters
-        normative: true
-        text: |
-          The type of semihosting operation and its parameters are specified using
-          general purpose registers:
+    content: |
+      The type of semihosting operation and its parameters are specified using
+      general purpose registers:
 
-          * The OPERATION NUMBER is specified in the `a0` register
-          * The PARAMETER is specified in the `a1` register
-          * The RETURN VALUE is available in the `a0` register after the call
+      * The OPERATION NUMBER is specified in the `a0` register
+      * The PARAMETER is specified in the `a1` register
+      * The RETURN VALUE is available in the `a0` register after the call
 
-          All registers and data block fields are XLEN wide.
+      All registers and data block fields are XLEN wide.
   - title: Semihosting Services
-    content:
-      - id: non-isa-semihosting-services
-        normative: false
-        text: |
-          The RISC-V semihosting specification adopts the services defined by the ARM
-          semihosting specification. This includes operations for:
+    content: |
+      [NOTE]
+      ====
+      The RISC-V semihosting specification adopts the services defined by the ARM
+      semihosting specification. This includes operations for:
 
-          * Console I/O (character and string input/output)
-          * File system access (open, close, read, write, seek, etc.)
-          * System information (clock, time, command line, heap info)
-          * Exit and error reporting
+      * Console I/O (character and string input/output)
+      * File system access (open, close, read, write, seek, etc.)
+      * System information (clock, time, command line, heap info)
+      * Exit and error reporting
 
-          For the complete list of semihosting operations and their parameters,
-          refer to the ARM semihosting specification.
+      For the complete list of semihosting operations and their parameters,
+      refer to the ARM semihosting specification.
+      ====
 references:
   - title: RISC-V Semihosting Specification
     url: https://github.com/riscv-non-isa/riscv-semihosting


### PR DESCRIPTION
## Summary

Add the RISC-V Semihosting specification as the first standard non-ISA specification in `spec/std/non_isa/`.

## Changes

- Created `spec/std/non_isa/Semihosting.yaml` following the `non_isa_schema.json` format
- Uses structured prose with tagged statements (id, normative, text) as per the schema requirements

## Specification Details

The RISC-V Semihosting specification defines a binary interface that allows applications running in debug/simulation environments to access host system resources through a special instruction sequence:

```
slli x0, x0, 0x1f   # Entry NOP
ebreak              # Break to debugger  
srai x0, x0, 7      # Exit NOP
```

The specification includes:
- **Description**: Overview of semihosting concept and its design rationale
- **Breakpoint Instruction Sequence** (normative): Requirements for the 3-instruction sequence
- **Semihosting Parameters** (normative): Parameter passing via a0/a1 registers
- **Semihosting Services** (informative): Overview of available operations
- **References**: Links to official RISC-V and ARM semihosting specifications

## Notes

This is the first non-ISA specification being added to `spec/std/non_isa/`. Happy to iterate on the format based on feedback.

Closes #1393