### PR TITLE
docs(data): add descriptions for Zve* and Zvl*b extensions

### DIFF
--- a/spec/std/isa/ext/Zve32f.yaml
+++ b/spec/std/isa/ext/Zve32f.yaml
@@ -8,7 +8,20 @@ kind: extension
 name: Zve32f
 long_name: Vector Extension for Minimal Single-Precision Embedded Floating-Point
 description: |
-  TBD - See GitHub issue 616
+  The Zve32f extension adds single-precision vector floating-point support to
+  the Zve32x base embedded vector extension. The maximum element width (ELEN)
+  remains 32 bits.
+
+  Zve32f includes all functionality of Zve32x plus:
+
+  * Single-precision vector floating-point instructions
+  * Vector floating-point reductions
+  * Vector floating-point compare and classify instructions
+
+  Zve32f requires the F (single-precision floating-point) extension.
+
+  This extension is intended for embedded processors that need both vector
+  integer and single-precision floating-point operations.
 type: unprivileged
 versions:
   - version: "1.0.0"

--- a/spec/std/isa/ext/Zve32x.yaml
+++ b/spec/std/isa/ext/Zve32x.yaml
@@ -8,7 +8,24 @@ kind: extension
 name: Zve32x
 long_name: Vector Extension for Minimal Vector Register Length of 32 Bits
 description: |
-  TBD - See GitHub issue 616
+  The Zve32x extension provides support for vector integer operations with a
+  maximum element width (ELEN) of 32 bits. This is a base embedded vector
+  extension that excludes floating-point vector operations.
+
+  Zve32x includes:
+
+  * All vector load and store instructions
+  * All vector integer instructions
+  * All vector fixed-point arithmetic instructions
+  * All vector mask instructions
+  * All vector permutation instructions
+  * Vector integer reduction instructions
+
+  Zve32x excludes all vector floating-point instructions and does not require
+  implementation of the F extension.
+
+  This extension is intended for embedded processors that need vector
+  operations but do not require floating-point support.
 type: unprivileged
 versions:
   - version: "1.0.0"

--- a/spec/std/isa/ext/Zve64d.yaml
+++ b/spec/std/isa/ext/Zve64d.yaml
@@ -8,7 +8,21 @@ kind: extension
 name: Zve64d
 long_name: Vector Extension for Minimal Double-Precision Embedded Floating-Point
 description: |
-  TBD - See GitHub issue 616
+  The Zve64d extension adds double-precision vector floating-point support to
+  the Zve64f embedded vector extension. The maximum element width (ELEN) is
+  64 bits, supporting 64-bit integer and 64-bit double-precision floating-point
+  elements.
+
+  Zve64d includes all functionality of Zve64f plus:
+
+  * Double-precision vector floating-point instructions
+  * Double-precision vector floating-point reductions
+  * Vector floating-point conversion instructions between single and double precision
+
+  Zve64d requires the D (double-precision floating-point) extension.
+
+  This extension provides the full embedded vector floating-point capability
+  with support for both single and double precision operations.
 type: unprivileged
 versions:
   - version: "1.0.0"

--- a/spec/std/isa/ext/Zve64f.yaml
+++ b/spec/std/isa/ext/Zve64f.yaml
@@ -8,7 +8,19 @@ kind: extension
 name: Zve64f
 long_name: Vector Extension for Minimal Single-Precision Embedded Floating-Point
 description: |
-  TBD - See GitHub issue 616
+  The Zve64f extension adds single-precision vector floating-point support to
+  the Zve64x base embedded vector extension. The maximum element width (ELEN)
+  is 64 bits, supporting both 64-bit integer and 32-bit floating-point elements.
+
+  Zve64f includes all functionality of Zve64x and Zve32f plus:
+
+  * Single-precision vector floating-point instructions with 64-bit integer support
+  * Support for widening floating-point operations up to 64-bit integers
+
+  Zve64f requires the F (single-precision floating-point) extension.
+
+  This extension is intended for embedded processors that need 64-bit vector
+  integer operations and single-precision floating-point support.
 type: unprivileged
 versions:
   - version: "1.0.0"

--- a/spec/std/isa/ext/Zve64x.yaml
+++ b/spec/std/isa/ext/Zve64x.yaml
@@ -8,7 +8,21 @@ kind: extension
 name: Zve64x
 long_name: Vector Extension for Minimal Vector Register Length of 64 Bits
 description: |
-  TBD - See GitHub issue 616
+  The Zve64x extension provides support for vector integer operations with a
+  maximum element width (ELEN) of 64 bits. This is a base embedded vector
+  extension that excludes floating-point vector operations.
+
+  Zve64x includes all functionality of Zve32x plus:
+
+  * Support for 64-bit integer vector elements (SEW=64)
+  * 64-bit vector load and store instructions
+  * All vector integer instructions operating on 64-bit elements
+
+  Zve64x excludes all vector floating-point instructions and does not require
+  implementation of the F or D extensions.
+
+  This extension is intended for embedded processors that need 64-bit vector
+  integer operations but do not require floating-point support.
 type: unprivileged
 versions:
   - version: "1.0.0"

--- a/spec/std/isa/ext/Zvl1024b.yaml
+++ b/spec/std/isa/ext/Zvl1024b.yaml
@@ -8,7 +8,14 @@ kind: extension
 name: Zvl1024b
 long_name: Vector register length must be at least 1024 bits
 description: |
-  TBD - See GitHub issue 616
+  The Zvl1024b extension requires the implementation to have a vector register
+  length (VLEN) of at least 1024 bits.
+
+  The Zvl*b extensions are a family of extensions that specify minimum vector
+  register lengths. They allow software to determine the minimum VLEN supported
+  by an implementation without needing to probe at runtime.
+
+  With VLEN=1024 and SEW=8 bits, VLMAX is 128 elements (with LMUL=1).
 type: unprivileged
 versions:
   - version: "1.0.0"

--- a/spec/std/isa/ext/Zvl128b.yaml
+++ b/spec/std/isa/ext/Zvl128b.yaml
@@ -8,7 +8,15 @@ kind: extension
 name: Zvl128b
 long_name: Vector register length must be at least 128 bits
 description: |
-  TBD - See GitHub issue 616
+  The Zvl128b extension requires the implementation to have a vector register
+  length (VLEN) of at least 128 bits.
+
+  The Zvl*b extensions are a family of extensions that specify minimum vector
+  register lengths. They allow software to determine the minimum VLEN supported
+  by an implementation without needing to probe at runtime.
+
+  VLEN=128 is the minimum vector register length required by the full V
+  extension. With VLEN=128 and SEW=8 bits, VLMAX is 16 elements (with LMUL=1).
 type: unprivileged
 versions:
   - version: "1.0.0"

--- a/spec/std/isa/ext/Zvl256b.yaml
+++ b/spec/std/isa/ext/Zvl256b.yaml
@@ -8,7 +8,14 @@ kind: extension
 name: Zvl256b
 long_name: Vector register length must be at least 256 bits
 description: |
-  TBD - See GitHub issue 616
+  The Zvl256b extension requires the implementation to have a vector register
+  length (VLEN) of at least 256 bits.
+
+  The Zvl*b extensions are a family of extensions that specify minimum vector
+  register lengths. They allow software to determine the minimum VLEN supported
+  by an implementation without needing to probe at runtime.
+
+  With VLEN=256 and SEW=8 bits, VLMAX is 32 elements (with LMUL=1).
 type: unprivileged
 versions:
   - version: "1.0.0"

--- a/spec/std/isa/ext/Zvl32b.yaml
+++ b/spec/std/isa/ext/Zvl32b.yaml
@@ -8,7 +8,15 @@ kind: extension
 name: Zvl32b
 long_name: Vector register length must be at least 32 bits
 description: |
-  TBD - See GitHub issue 616
+  The Zvl32b extension requires the implementation to have a vector register
+  length (VLEN) of at least 32 bits.
+
+  The Zvl*b extensions are a family of extensions that specify minimum vector
+  register lengths. They allow software to determine the minimum VLEN supported
+  by an implementation without needing to probe at runtime.
+
+  With VLEN=32 and the smallest supported SEW of 8 bits, the minimum VLMAX
+  is 4 elements (with LMUL=1).
 type: unprivileged
 versions:
   - version: "1.0.0"

--- a/spec/std/isa/ext/Zvl512b.yaml
+++ b/spec/std/isa/ext/Zvl512b.yaml
@@ -8,7 +8,14 @@ kind: extension
 name: Zvl512b
 long_name: Vector register length must be at least 512 bits
 description: |
-  TBD - See GitHub issue 616
+  The Zvl512b extension requires the implementation to have a vector register
+  length (VLEN) of at least 512 bits.
+
+  The Zvl*b extensions are a family of extensions that specify minimum vector
+  register lengths. They allow software to determine the minimum VLEN supported
+  by an implementation without needing to probe at runtime.
+
+  With VLEN=512 and SEW=8 bits, VLMAX is 64 elements (with LMUL=1).
 type: unprivileged
 versions:
   - version: "1.0.0"

--- a/spec/std/isa/ext/Zvl64b.yaml
+++ b/spec/std/isa/ext/Zvl64b.yaml
@@ -8,7 +8,15 @@ kind: extension
 name: Zvl64b
 long_name: Vector register length must be at least 64 bits
 description: |
-  TBD - See GitHub issue 616
+  The Zvl64b extension requires the implementation to have a vector register
+  length (VLEN) of at least 64 bits.
+
+  The Zvl*b extensions are a family of extensions that specify minimum vector
+  register lengths. They allow software to determine the minimum VLEN supported
+  by an implementation without needing to probe at runtime.
+
+  With VLEN=64 and the smallest supported SEW of 8 bits, the minimum VLMAX
+  is 8 elements (with LMUL=1).
 type: unprivileged
 versions:
   - version: "1.0.0"


### PR DESCRIPTION
## Summary

Replace TBD placeholder descriptions with accurate documentation for the embedded vector extensions and vector register length extensions. These 11 extension files previously had `description: | TBD - See GitHub issue 616`.

## Changes

### Zvl*b Extensions (6 files)
Specify minimum vector register length (VLEN) requirements:

| Extension | Min VLEN | VLMAX (SEW=8, LMUL=1) |
|-----------|----------|------------------------|
| Zvl32b    | 32 bits  | 4 elements            |
| Zvl64b    | 64 bits  | 8 elements            |
| Zvl128b   | 128 bits | 16 elements           |
| Zvl256b   | 256 bits | 32 elements           |
| Zvl512b   | 512 bits | 64 elements           |
| Zvl1024b  | 1024 bits| 128 elements          |

### Zve* Extensions (5 files)
Document the embedded vector extension hierarchy:

| Extension | ELEN | Floating-Point | Requires |
|-----------|------|----------------|----------|
| Zve32x    | 32   | None           | Zicsr, Zvl32b |
| Zve32f    | 32   | Single (F)     | F, Zve32x |
| Zve64x    | 64   | None           | Zicsr, Zvl64b |
| Zve64f    | 64   | Single (F)     | F, Zve64x |
| Zve64d    | 64   | Double (D)     | D, Zve64f |

## References

All descriptions are based on the [RISC-V Vector Extension specification v1.0](https://github.com/riscv/riscv-v-spec).

Closes #616

