### PR TITLE
fix: Add Zaamo and Zalrsc extensions to RVI20U32 profile

### DIFF
--- a/spec/std/isa/profile/RVI20U32.yaml
+++ b/spec/std/isa/profile/RVI20U32.yaml
@@ -40,6 +40,12 @@ extensions:
   A:
     presence: optional
     version: "~> 2.1"
+  Zaamo:
+    presence: optional
+    version: "~> 1.0"
+  Zalrsc:
+    presence: optional
+    version: "~> 1.0"
   C:
     presence: optional
     version: "~> 2.0"


### PR DESCRIPTION
Fixes #1523

The MISALIGNED_AMO parameter was missing from RVI20 CRD because the profile only listed the A extension without explicitly including its sub-extensions Zaamo and Zalrsc.

This change adds explicit optional entries for Zaamo and Zalrsc extensions to ensure their parameters (MISALIGNED_AMO and LRSC_MISALIGNED_BEHAVIOR) are exposed in the generated CRD config.