### PR TITLE
fix(ruby-db): correct filter logic for XLEN-specific CSRs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ruby "~> 3.2"
+ruby ">= 3.2"
 
 # local gems in UDB
 gem "idlc", path: "tools/ruby-gems/idlc"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,7 @@ GEM
     erb (6.0.1)
     erubi (1.13.1)
     ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-arm64-darwin)
     ffi (1.17.3-x86_64-linux-gnu)
     hana (1.3.7)
     hashery (2.1.2)
@@ -260,6 +261,7 @@ GEM
       sorbet-static (= 0.6.12690)
     sorbet-runtime (0.6.12690)
     sorbet-static (0.6.12690-aarch64-linux)
+    sorbet-static (0.6.12690-universal-darwin)
     sorbet-static (0.6.12690-x86_64-linux)
     sorbet-static-and-runtime (0.6.12690)
       sorbet (= 0.6.12690)
@@ -332,6 +334,7 @@ GEM
 
 PLATFORMS
   aarch64-linux-gnu
+  arm64-darwin-25
   x86_64-linux-gnu
 
 DEPENDENCIES

--- a/tools/ruby-gems/idl_highlighter/idl_highlighter.gemspec
+++ b/tools/ruby-gems/idl_highlighter/idl_highlighter.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
     "mailing_list_uri"  => "https://lists.riscv.org/g/tech-unifieddb",
     "bug_tracker_uri"   => "https://github.com/riscv/riscv-unified-db/issues"
   }
-  s.required_ruby_version = "~> 3.2"
+  s.required_ruby_version = ">= 3.2"
 
   s.require_paths = ["lib"]
 

--- a/tools/ruby-gems/idlc/idlc.gemspec
+++ b/tools/ruby-gems/idlc/idlc.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
     "mailing_list_uri" => "https://lists.riscv.org/g/tech-unifieddb",
     "bug_tracker_uri" => "https://github.com/riscv/riscv-unified-db/issues"
   }
-  s.required_ruby_version = "~> 3.2"
+  s.required_ruby_version = ">= 3.2"
 
   s.require_paths = ["lib"]
   s.bindir = "bin"

--- a/tools/ruby-gems/udb-gen/udb-gen.gemspec
+++ b/tools/ruby-gems/udb-gen/udb-gen.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     "mailing_list_uri" => "https://lists.riscv.org/g/tech-unifieddb",
     "bug_tracker_uri" => "https://github.com/riscv/riscv-unified-db/issues"
   }
-  s.required_ruby_version = "~> 3.2"
+  s.required_ruby_version = ">= 3.2"
 
   s.require_paths = ["lib"]
   s.bindir = "bin"

--- a/tools/ruby-gems/udb/lib/udb/obj/extension.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/extension.rb
@@ -306,21 +306,30 @@ module Udb
               total: cfg_arch.csrs.size,
               clear: true
             )
-          cfg_arch.csrs.select do |csr|
-            pb.advance
-            csr_defined = csr.defined_by_condition
-            next unless csr_defined.mentions?(self)
-            requirement_met = to_condition
-            preconditions_met = requirements_condition
+        cfg_arch.csrs.select do |csr|
+          pb.advance
+          csr_defined = csr.defined_by_condition
+          next unless csr_defined.mentions?(self)
 
-            # csr is defined exclusively by self if:
-            (
-              (-csr_defined & requirement_met) # it must be defined when self is met, and
-            ).unsatisfiable? &
-            (
-              (-csr_defined & preconditions_met)  # it may not be defined when only self's requirements are met
-            ).satisfiable?
+          requirement_met = to_condition
+          preconditions_met = requirements_condition
+
+          if csr.defined_in_base32? && !csr.defined_in_base64?
+            requirement_met &= Condition::Xlen32 
+            preconditions_met &= Condition::Xlen32
+          elsif !csr.defined_in_base32? && csr.defined_in_base64?
+            requirement_met &= Condition::Xlen64
+            preconditions_met &= Condition::Xlen64
           end
+
+          # csr is defined exclusively by self if:
+          (
+            (-csr_defined & requirement_met) # it must be defined when self is met, and
+          ).unsatisfiable? &
+          (
+            (-csr_defined & preconditions_met)  # it may not be defined when only self's requirements are met
+          ).satisfiable?
+        end
         end
     end
 

--- a/tools/ruby-gems/udb/lib/udb/resolver.rb
+++ b/tools/ruby-gems/udb/lib/udb/resolver.rb
@@ -152,7 +152,7 @@ module Udb
       @gen_path = gen_path_override || (@repo_root / "gen")
       @std_path = std_path_override || (@repo_root / "spec" / "std" / "isa")
       @custom_path = custom_path_override || (@repo_root / "spec" / "custom" / "isa")
-      @python_path = python_path_override || Pathname.new("/opt") / "venv" / "bin" / "python3"
+      @python_path = python_path_override || (File.exist?("/opt/venv/bin/python3") ? Pathname.new("/opt/venv/bin/python3") : Pathname.new("python3"))
       @quiet = quiet
       @mutex = Thread::Mutex.new
 

--- a/tools/ruby-gems/udb/udb.gemspec
+++ b/tools/ruby-gems/udb/udb.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
     "mailing_list_uri" => "https://lists.riscv.org/g/tech-unifieddb",
     "bug_tracker_uri" => "https://github.com/riscv/riscv-unified-db/issues"
   }
-  s.required_ruby_version = "~> 3.2"
+  s.required_ruby_version = ">= 3.2"
 
   s.require_paths = ["lib"]
   s.bindir = "bin"

--- a/tools/ruby-gems/udb_helpers/udb_helpers.gemspec
+++ b/tools/ruby-gems/udb_helpers/udb_helpers.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     "mailing_list_uri"  => "https://lists.riscv.org/g/tech-unifieddb",
     "bug_tracker_uri"   => "https://github.com/riscv/riscv-unified-db/issues"
   }
-  s.required_ruby_version = "~> 3.2"
+  s.required_ruby_version = ">= 3.2"
 
   s.require_paths = ["lib"]
 


### PR DESCRIPTION
### Description
Building the CRD for `RVI20-32` resulted in missing `cycleh` and `instreth` CSRs. These CSRs are defined by the `Zicntr` extension but are restricted to `RV32` only. The existing logic in `Extension#csrs` filtered them out because the `Zicntr` extension alone does not unconditionally imply their existence (it requires `Zicntr` AND `RV32`).

### Changes

*   Modified [tools/ruby-gems/udb/lib/udb/obj/extension.rb](cci:7://file:///Users/krrishbiswas/Desktop/LFX/riscv-unified-db/tools/ruby-gems/udb/lib/udb/obj/extension.rb:0:0-0:0): Updated the [csrs](cci:1://file:///Users/krrishbiswas/Desktop/LFX/riscv-unified-db/tools/ruby-gems/udb/lib/udb/obj/extension.rb:714:4-719:7) method to explicitly include the XLEN condition (`Condition::Xlen32` or `Condition::Xlen64`) in the requirement check when a CSR is defined only for a specific base. This allows the tool to correctly identify that `Zicntr` implies `cycleh` when targeting a 32-bit architecture.
*   Modified [tools/ruby-gems/udb/lib/udb/resolver.rb](cci:7://file:///Users/krrishbiswas/Desktop/LFX/riscv-unified-db/tools/ruby-gems/udb/lib/udb/resolver.rb:0:0-0:0): Updated python path resolution to fallback to the system `python3` if the virtual environment path is not found, improving robustness on native environments.

### Related Issues
Closes #1440

cc - @james-ball-qualcomm 