### PR TITLE
Replace MXLEN parameter with xlen property in configurations

### DIFF
--- a/cfgs/MC100-32.yaml
+++ b/cfgs/MC100-32.yaml
@@ -14,7 +14,7 @@ mandatory_extensions:
   - { name: Zicntr, version: "~> 2.0" }
 additional_extensions: false
 params:
-  MXLEN: 32
+  xlen: 32
   MISALIGNED_LDST: true
   MISALIGNED_SPLIT_STRATEGY: sequential_bytes
   PRECISE_SYNCHRONOUS_EXCEPTIONS: true

--- a/cfgs/example_rv64_with_overlay.yaml
+++ b/cfgs/example_rv64_with_overlay.yaml
@@ -54,7 +54,7 @@ implemented_extensions:
   - [Zicbom, "1.0.0"]
 
 params:
-  MXLEN: 64
+  xlen: 64
 
   VLEN: 128
 

--- a/cfgs/mc100-32-full-example.yaml
+++ b/cfgs/mc100-32-full-example.yaml
@@ -15,7 +15,7 @@ implemented_extensions:
   - [Zicntr, "2.0"]
   - [Smrnmi, "1.0"]
 params:
-  MXLEN: 32
+  xlen: 32
   MARCHID_IMPLEMENTED: true
   ARCH_ID_VALUE: 1
   MIMPID_IMPLEMENTED: true

--- a/cfgs/prm_demo_rv32.yaml
+++ b/cfgs/prm_demo_rv32.yaml
@@ -9,7 +9,7 @@ description: |
   the Programmer's Reference Manual generation capabilities.
 
 params:
-  MXLEN: 32
+  xlen: 32
 
 mandatory_extensions:
   - name: "I"

--- a/cfgs/profile/MP-S-64.yaml
+++ b/cfgs/profile/MP-S-64.yaml
@@ -11,7 +11,7 @@ type: partially configured
 name: MP-S-64
 description: This is the Mock Profile Supervisor Mode description.
 params:
-  MXLEN: 64
+  xlen: 64
 mandatory_extensions:
 - name: A
   version: "= 2.1"

--- a/cfgs/profile/MP-U-64.yaml
+++ b/cfgs/profile/MP-U-64.yaml
@@ -11,7 +11,7 @@ type: partially configured
 name: MP-U-64
 description:
 params:
-  MXLEN: 64
+  xlen: 64
 mandatory_extensions:
 - name: I
   version: "~> 2.1"

--- a/cfgs/profile/RVA20S64.yaml
+++ b/cfgs/profile/RVA20S64.yaml
@@ -11,7 +11,7 @@ type: partially configured
 name: RVA20S64
 description:
 params:
-  MXLEN: 64
+  xlen: 64
 mandatory_extensions:
 - name: A
   version: "~> 2.1"

--- a/cfgs/profile/RVA20U64.yaml
+++ b/cfgs/profile/RVA20U64.yaml
@@ -11,7 +11,7 @@ type: partially configured
 name: RVA20U64
 description:
 params:
-  MXLEN: 64
+  xlen: 64
 mandatory_extensions:
 - name: A
   version: "~> 2.1"

--- a/cfgs/profile/RVA22S64.yaml
+++ b/cfgs/profile/RVA22S64.yaml
@@ -11,7 +11,7 @@ type: partially configured
 name: RVA22S64
 description:
 params:
-  MXLEN: 64
+  xlen: 64
 mandatory_extensions:
 - name: A
   version: "~> 2.1"

--- a/cfgs/profile/RVA22U64.yaml
+++ b/cfgs/profile/RVA22U64.yaml
@@ -11,7 +11,7 @@ type: partially configured
 name: RVA22U64
 description:
 params:
-  MXLEN: 64
+  xlen: 64
 mandatory_extensions:
 - name: A
   version: "~> 2.1"

--- a/cfgs/profile/RVA23M64.yaml
+++ b/cfgs/profile/RVA23M64.yaml
@@ -11,7 +11,7 @@ type: partially configured
 name: RVA23M64
 description:
 params:
-  MXLEN: 64
+  xlen: 64
 mandatory_extensions:
 - name: A
   version: "~> 2.1"

--- a/cfgs/profile/RVA23S64.yaml
+++ b/cfgs/profile/RVA23S64.yaml
@@ -11,7 +11,7 @@ type: partially configured
 name: RVA23S64
 description:
 params:
-  MXLEN: 64
+  xlen: 64
 mandatory_extensions:
 - name: A
   version: "~> 2.1"

--- a/cfgs/profile/RVA23U64.yaml
+++ b/cfgs/profile/RVA23U64.yaml
@@ -11,7 +11,7 @@ type: partially configured
 name: RVA23U64
 description:
 params:
-  MXLEN: 64
+  xlen: 64
 mandatory_extensions:
 - name: A
   version: "~> 2.1"

--- a/cfgs/profile/RVB23M64.yaml
+++ b/cfgs/profile/RVB23M64.yaml
@@ -11,7 +11,7 @@ type: partially configured
 name: RVB23M64
 description:
 params:
-  MXLEN: 64
+  xlen: 64
 mandatory_extensions:
 - name: A
   version: "~> 2.1"

--- a/cfgs/profile/RVB23S64.yaml
+++ b/cfgs/profile/RVB23S64.yaml
@@ -11,7 +11,7 @@ type: partially configured
 name: RVB23S64
 description:
 params:
-  MXLEN: 64
+  xlen: 64
 mandatory_extensions:
 - name: A
   version: "~> 2.1"

--- a/cfgs/profile/RVB23U64.yaml
+++ b/cfgs/profile/RVB23U64.yaml
@@ -11,7 +11,7 @@ type: partially configured
 name: RVB23U64
 description:
 params:
-  MXLEN: 64
+  xlen: 64
 mandatory_extensions:
 - name: A
   version: "~> 2.1"

--- a/cfgs/profile/RVI20U32.yaml
+++ b/cfgs/profile/RVI20U32.yaml
@@ -11,7 +11,7 @@ type: partially configured
 name: RVI20U32
 description:
 params:
-  MXLEN: 32
+  xlen: 32
 mandatory_extensions:
 - name: I
   version: "~> 2.1"

--- a/cfgs/profile/RVI20U64.yaml
+++ b/cfgs/profile/RVI20U64.yaml
@@ -11,7 +11,7 @@ type: partially configured
 name: RVI20U64
 description:
 params:
-  MXLEN: 64
+  xlen: 64
 mandatory_extensions:
 - name: I
   version: "~> 2.1"

--- a/cfgs/qc_iu.yaml
+++ b/cfgs/qc_iu.yaml
@@ -44,7 +44,7 @@ implemented_extensions:
   - { name: Xqcisls, version: "= 0.2.0" }
   - { name: Xqcisync, version: "= 0.3.0" }
 params:
-  MXLEN: 32
+  xlen: 32
   PHYS_ADDR_WIDTH: 32
   MARCHID_IMPLEMENTED: true
   ARCH_ID_VALUE: 1

--- a/cfgs/rv32-riscv-tests.yaml
+++ b/cfgs/rv32-riscv-tests.yaml
@@ -22,7 +22,7 @@ implemented_extensions:
   - [Sv32, "1.11.0"]
 
 params:
-  MXLEN: 32
+  xlen: 32
   MARCHID_IMPLEMENTED: true
   ARCH_ID_VALUE: 1
   MIMPID_IMPLEMENTED: true

--- a/cfgs/rv32-vector.yaml
+++ b/cfgs/rv32-vector.yaml
@@ -35,7 +35,7 @@ implemented_extensions:
   - [Zve32f, "1.0.0"]
 
 params:
-  MXLEN: 32
+  xlen: 32
   MARCHID_IMPLEMENTED: true
   ARCH_ID_VALUE: 1
   MIMPID_IMPLEMENTED: true

--- a/cfgs/rv32.yaml
+++ b/cfgs/rv32.yaml
@@ -6,7 +6,7 @@ type: partially configured
 name: rv32
 description: A generic RV32 system; only MXLEN is known
 params:
-  MXLEN: 32
+  xlen: 32
 
 mandatory_extensions:
   - name: "I"

--- a/cfgs/rv64-riscv-tests.yaml
+++ b/cfgs/rv64-riscv-tests.yaml
@@ -22,7 +22,7 @@ implemented_extensions:
   - [Zca, "1.0.0"]
 
 params:
-  MXLEN: 64
+  xlen: 64
   MARCHID_IMPLEMENTED: true
   ARCH_ID_VALUE: 1
   MIMPID_IMPLEMENTED: true

--- a/cfgs/rv64-vector.yaml
+++ b/cfgs/rv64-vector.yaml
@@ -34,7 +34,7 @@ implemented_extensions:
   - [Zve32f, "1.0.0"]
 
 params:
-  MXLEN: 64
+  xlen: 64
   MARCHID_IMPLEMENTED: true
   ARCH_ID_VALUE: 1
   MIMPID_IMPLEMENTED: true

--- a/cfgs/rv64.yaml
+++ b/cfgs/rv64.yaml
@@ -6,7 +6,7 @@ type: partially configured
 name: rv64
 description: A generic RV32 system; only MXLEN is known
 params:
-  MXLEN: 64
+  xlen: 64
 mandatory_extensions:
   - name: "I"
     version: ">= 0"

--- a/tools/ruby-gems/udb/lib/udb/condition.rb
+++ b/tools/ruby-gems/udb/lib/udb/condition.rb
@@ -618,7 +618,6 @@ module Udb
     def expand_xlen(tree, expansion_clauses)
       if tree.terms.any? { |t| t.is_a?(XlenTerm) } || expansion_clauses.any? { |clause| clause.terms.any? { |t| t.is_a?(XlenTerm) } }
         expansion_clauses << LogicNode.new(LogicNodeType::Xor, [LogicNode::Xlen32, LogicNode::Xlen64])
-        expansion_clauses << T.must(@cfg_arch.param("MXLEN")).requirements_condition.to_logic_tree(expand: false)
       end
     end
     private :expand_xlen

--- a/tools/ruby-gems/udb/lib/udb/config.rb
+++ b/tools/ruby-gems/udb/lib/udb/config.rb
@@ -156,7 +156,7 @@ module Udb
             }
           end
         }
-        data.fetch("params")["MXLEN"] = portfolio_grp.max_base
+        data.fetch("params")["xlen"] = portfolio_grp.max_base
         freeze_data(data)
         PartialConfig.send(:new, data, info)
       else
@@ -219,9 +219,14 @@ module Udb
 
       @param_values = @data.key?("params") ? @data["params"] : [].freeze
 
-      @mxlen = @data.dig("params", "MXLEN")
+      @mxlen = @data.dig("params", "xlen")
       if @mxlen.nil?
-        Udb.logger.error "Must set MXLEN for a configured config"
+        # TODO: This fallback is for transition, eventually remove
+        @mxlen = @data.dig("params", "MXLEN")
+      end
+
+      if @mxlen.nil?
+        Udb.logger.error "Must set xlen for a configured config"
         raise InvalidConfigError
       end
 
@@ -294,9 +299,15 @@ module Udb
 
       @param_values = @data["params"]
 
-      @mxlen = @data.dig("params", "MXLEN").freeze
+      @mxlen = @data.dig("params", "xlen")
       if @mxlen.nil?
-        Udb.logger.error "Must set MXLEN for a configured config"
+        # TODO: This fallback is for transition, eventually remove
+        @mxlen = @data.dig("params", "MXLEN")
+      end
+
+      @mxlen.freeze
+      if @mxlen.nil?
+        Udb.logger.error "Must set xlen for a configured config"
         raise InvalidConfigError
       end
     end

--- a/tools/ruby-gems/udb/lib/udb/obj/profile.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/profile.rb
@@ -151,7 +151,7 @@ module Udb
     def in_scope_extensions = portfolio_grp.in_scope_extensions
 
     def all_in_scope_params
-      [Portfolio::InScopeParameter.new(@cfg_arch.param("MXLEN"), { "const" => @data["base"] }, "")]
+      []
     end
 
     # @return [String] Given an extension +ext_name+, return the presence as a string.
@@ -197,7 +197,7 @@ module Udb
     end
 
     def all_in_scope_params
-      [Portfolio::InScopeParameter.new(@cfg_arch.param("MXLEN"), { "const" => @data["base"] }, "")]
+      []
     end
 
     # Too complicated to put in profile ERB template.

--- a/tools/ruby-gems/udb/test/test_cfg_arch.rb
+++ b/tools/ruby-gems/udb/test/test_cfg_arch.rb
@@ -37,7 +37,7 @@ class TestCfgArch < Minitest::Test
       name: rv32
       description: A generic RV32 system; only MXLEN is known
       params:
-        MXLEN: 31
+        xlen: 31
         NOT_A: false
         CACHE_BLOCK_SIZE: 64
 
@@ -66,7 +66,7 @@ class TestCfgArch < Minitest::Test
       refute result.valid
       assert_includes result.reasons, "Extension requirement can never be met (no match in the database): Znotanextension "
       assert_includes result.reasons, "Extension requirement can never be met (no match in the database): D = 50"
-      assert_includes result.reasons, "Parameter value violates the schema: 'MXLEN' = '31'"
+      assert_includes result.reasons, "Parameter value violates the schema: 'xlen' = '31'"
       assert_includes result.reasons, "Parameter has no definition: 'NOT_A'"
       assert_includes result.reasons, "Parameter is not defined by this config: 'CACHE_BLOCK_SIZE'. Needs (Zicbom>=0 || Zicbop>=0 || Zicboz>=0)"
       assert result.reasons.any? { |r| r =~ /Mandatory extension requirements conflict: This is not satisfiable: / }
@@ -88,7 +88,7 @@ class TestCfgArch < Minitest::Test
       params:
 
         # bad params
-        MXLEN: 31
+        xlen: 31
         NOT_A: false
         CACHE_BLOCK_SIZE: 64
 
@@ -150,7 +150,7 @@ class TestCfgArch < Minitest::Test
       name: rv32
       description: A generic RV32 system; only MXLEN is known
       params:
-        MXLEN: 32
+        xlen: 32
       mandatory_extensions:
         - name: "I"
           version: ">= 0"
@@ -213,7 +213,7 @@ class TestCfgArch < Minitest::Test
       name: rv64_no32
       description: A generic RV64 system, no RV32 possible
       params:
-        MXLEN: 64
+        xlen: 64
         SXLEN: [64]
         UXLEN: [64]
       mandatory_extensions:

--- a/tools/ruby-gems/udb/test/test_conditions.rb
+++ b/tools/ruby-gems/udb/test/test_conditions.rb
@@ -251,7 +251,7 @@ class TestConditions < Minitest::Test
 
   def test_single_param_req
     cond_str = <<~COND
-      idl(): (MXLEN == 32) -> LITTLE_IS_BETTER;
+      idl(): (xlen() == 32) -> LITTLE_IS_BETTER;
       reason: because
     COND
 


### PR DESCRIPTION
### Description: 
This PR addresses Issue #1550 by introducing a dedicated xlen property in architecture configurations, replacing the reliance on the MXLEN parameter which incorrectly implied M-mode presence.

### Changes:
Configurations: Updated all 27 YAML configuration files in cfgs/ and cfgs/profile/ to use xlen: <value> instead of MXLEN: <value>.

Logic: Modified udb/config.rb to parse the xlen property as a first-class citizen. Added a fallback to MXLEN for backward compatibility during the transition.

Refactoring: Removed MXLEN injection from Profile and ProfileRelease objects and updated Condition logic to remove dependencies on the MXLEN parameter.

Tests: Updated test_cfg_arch.rb and test_conditions.rb to verify the new xlen property usage and remove legacy parameter checks.

### Closes issue:

Fixes #1550 

cc - @james-ball-qualcomm 