### PR TITLE
fix(data): add reserved_instruction check for AMO operations when misa.A is cleared

### DIFF
--- a/spec/std/isa/inst/Zaamo/amoadd.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amoadd.SIZE.AQRL.layout
@@ -69,8 +69,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::<%= %w[b h].include?(size) ? "Zabha" : "A" %>) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
 <% if aq -%>

--- a/spec/std/isa/inst/Zaamo/amoadd.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.d.aq.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoadd.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.d.aqrl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoadd.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.d.rl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoadd.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.d.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoadd.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.w.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoadd.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.w.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoadd.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.w.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoadd.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amoadd.w.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoand.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amoand.SIZE.AQRL.layout
@@ -69,8 +69,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::<%= %w[b h].include?(size) ? "Zabha" : "A" %>) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
 <% if aq -%>

--- a/spec/std/isa/inst/Zaamo/amoand.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.d.aq.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoand.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.d.aqrl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoand.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.d.rl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoand.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.d.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoand.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.w.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoand.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.w.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoand.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.w.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoand.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amoand.w.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomax.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amomax.SIZE.AQRL.layout
@@ -69,8 +69,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::<%= %w[b h].include?(size) ? "Zabha" : "A" %>) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
 <% if aq -%>

--- a/spec/std/isa/inst/Zaamo/amomax.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.d.aq.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amomax.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.d.aqrl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amomax.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.d.rl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomax.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.d.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomax.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.w.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amomax.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.w.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amomax.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.w.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomax.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amomax.w.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomaxu.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amomaxu.SIZE.AQRL.layout
@@ -69,8 +69,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::<%= %w[b h].include?(size) ? "Zabha" : "A" %>) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
 <% if aq -%>

--- a/spec/std/isa/inst/Zaamo/amomaxu.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.d.aq.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amomaxu.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.d.aqrl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amomaxu.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.d.rl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomaxu.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.d.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomaxu.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.w.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amomaxu.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.w.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amomaxu.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.w.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomaxu.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amomaxu.w.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomin.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amomin.SIZE.AQRL.layout
@@ -69,8 +69,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::<%= %w[b h].include?(size) ? "Zabha" : "A" %>) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
 <% if aq -%>

--- a/spec/std/isa/inst/Zaamo/amomin.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.d.aq.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amomin.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.d.aqrl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amomin.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.d.rl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomin.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.d.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomin.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.w.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amomin.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.w.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amomin.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.w.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amomin.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amomin.w.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amominu.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amominu.SIZE.AQRL.layout
@@ -69,8 +69,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::<%= %w[b h].include?(size) ? "Zabha" : "A" %>) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
 <% if aq -%>

--- a/spec/std/isa/inst/Zaamo/amominu.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.d.aq.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amominu.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.d.aqrl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amominu.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.d.rl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amominu.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.d.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amominu.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.w.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amominu.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.w.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amominu.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.w.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amominu.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amominu.w.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoor.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amoor.SIZE.AQRL.layout
@@ -69,8 +69,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::<%= %w[b h].include?(size) ? "Zabha" : "A" %>) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
 <% if aq -%>

--- a/spec/std/isa/inst/Zaamo/amoor.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.d.aq.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoor.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.d.aqrl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoor.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.d.rl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoor.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.d.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoor.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.w.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoor.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.w.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoor.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.w.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoor.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amoor.w.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoswap.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amoswap.SIZE.AQRL.layout
@@ -68,8 +68,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::<%= %w[b h].include?(size) ? "Zabha" : "A" %>) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
 <% if aq -%>

--- a/spec/std/isa/inst/Zaamo/amoswap.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.d.aq.yaml
@@ -38,8 +38,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoswap.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.d.aqrl.yaml
@@ -38,8 +38,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoswap.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.d.rl.yaml
@@ -38,8 +38,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoswap.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.d.yaml
@@ -38,8 +38,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoswap.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.w.aq.yaml
@@ -36,8 +36,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoswap.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.w.aqrl.yaml
@@ -36,8 +36,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoswap.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.w.rl.yaml
@@ -36,8 +36,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoswap.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amoswap.w.yaml
@@ -36,8 +36,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoxor.SIZE.AQRL.layout
+++ b/spec/std/isa/inst/Zaamo/amoxor.SIZE.AQRL.layout
@@ -69,8 +69,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::<%= %w[b h].include?(size) ? "Zabha" : "A" %>) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
 <% if aq -%>

--- a/spec/std/isa/inst/Zaamo/amoxor.d.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.d.aq.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoxor.d.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.d.aqrl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoxor.d.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.d.rl.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoxor.d.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.d.yaml
@@ -39,8 +39,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoxor.w.aq.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.w.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoxor.w.aqrl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.w.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zaamo/amoxor.w.rl.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.w.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zaamo/amoxor.w.yaml
+++ b/spec/std/isa/inst/Zaamo/amoxor.w.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::A) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoadd.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.b.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoadd.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.b.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoadd.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.b.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoadd.b.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.b.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoadd.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.h.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoadd.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.h.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoadd.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.h.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoadd.h.yaml
+++ b/spec/std/isa/inst/Zabha/amoadd.h.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoand.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.b.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoand.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.b.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoand.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.b.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoand.b.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.b.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoand.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.h.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoand.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.h.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoand.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.h.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoand.h.yaml
+++ b/spec/std/isa/inst/Zabha/amoand.h.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomax.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.b.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amomax.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.b.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amomax.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.b.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomax.b.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.b.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomax.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.h.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amomax.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.h.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amomax.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.h.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomax.h.yaml
+++ b/spec/std/isa/inst/Zabha/amomax.h.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomaxu.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.b.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amomaxu.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.b.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amomaxu.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.b.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomaxu.b.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.b.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomaxu.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.h.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amomaxu.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.h.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amomaxu.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.h.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomaxu.h.yaml
+++ b/spec/std/isa/inst/Zabha/amomaxu.h.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomin.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.b.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amomin.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.b.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amomin.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.b.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomin.b.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.b.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomin.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.h.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amomin.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.h.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amomin.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.h.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amomin.h.yaml
+++ b/spec/std/isa/inst/Zabha/amomin.h.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amominu.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.b.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amominu.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.b.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amominu.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.b.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amominu.b.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.b.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amominu.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.h.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amominu.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.h.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amominu.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.h.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amominu.h.yaml
+++ b/spec/std/isa/inst/Zabha/amominu.h.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoor.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.b.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoor.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.b.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoor.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.b.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoor.b.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.b.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoor.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.h.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoor.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.h.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoor.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.h.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoor.h.yaml
+++ b/spec/std/isa/inst/Zabha/amoor.h.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoswap.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.b.aq.yaml
@@ -36,8 +36,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoswap.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.b.aqrl.yaml
@@ -36,8 +36,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoswap.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.b.rl.yaml
@@ -36,8 +36,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoswap.b.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.b.yaml
@@ -36,8 +36,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoswap.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.h.aq.yaml
@@ -36,8 +36,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoswap.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.h.aqrl.yaml
@@ -36,8 +36,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoswap.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.h.rl.yaml
@@ -36,8 +36,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoswap.h.yaml
+++ b/spec/std/isa/inst/Zabha/amoswap.h.yaml
@@ -36,8 +36,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoxor.b.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.b.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoxor.b.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.b.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoxor.b.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.b.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoxor.b.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.b.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoxor.h.aq.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.h.aq.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoxor.h.aqrl.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.h.aqrl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   memory_model_acquire();

--- a/spec/std/isa/inst/Zabha/amoxor.h.rl.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.h.rl.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/inst/Zabha/amoxor.h.yaml
+++ b/spec/std/isa/inst/Zabha/amoxor.h.yaml
@@ -37,8 +37,8 @@ access:
   vs: always
   vu: always
 operation(): |
-  if (!implemented?(ExtensionName::Zabha) || (MISA_CSR_IMPLEMENTED && (CSR[misa].A == 1'b0))) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+  if (implemented?(ExtensionName::A) && MISA_CSR_IMPLEMENTED && CSR[misa].A == 1'b0) {
+    reserved_instruction($encoding);
   }
 
   XReg virtual_address = X[xs1];

--- a/spec/std/isa/isa/globals.isa
+++ b/spec/std/isa/isa/globals.isa
@@ -380,6 +380,24 @@ function creg2reg {
   }
 }
 
+function reserved_instruction {
+  arguments Bits<INSTR_ENC_SIZE> encoding
+  description {
+    Either raises an IllegalInstruction exception or enters unpredictable state,
+    depending on the setting of the TRAP_ON_UNIMPLEMENTED_INSTRUCTION parameter.
+
+    This should be called when an instruction is architecturally defined but
+    has been disabled at runtime (_e.g._, by clearing misa.A).
+  }
+  body {
+    if (TRAP_ON_UNIMPLEMENTED_INSTRUCTION) {
+      raise(ExceptionCode::IllegalInstruction, mode(), encoding);
+    } else {
+      unpredictable("Unimplemented instruction that does not trap");
+    }
+  }
+}
+
 function unimplemented_csr {
   arguments Bits<INSTR_ENC_SIZE> encoding
   description {


### PR DESCRIPTION
Update the `operation()` methods for all Zaamo and Zabha instructions to check when the A extension is disabled at runtime.

- Add a `reserved_instruction` function in `globals.isa` that either traps with `IllegalInstruction` or enters an unpredictable state, depending on the `TRAP_ON_UNIMPLEMENTED_INSTRUCTION` parameter.
- Update Zaamo and Zabha layout templates to call `reserved_instruction()` when A extension is disabled at runtime.
- Regenerate all affected instruction YAML files (72 Zaamo + 72 Zabha)