### PR TITLE
fix: handle boundary conditions in vmv.v.i operation

### DIFF
--- a/spec/std/isa/inst/V/vmv.v.i.yaml
+++ b/spec/std/isa/inst/V/vmv.v.i.yaml
@@ -55,11 +55,27 @@ operation(): |
     U32 end_bit_pos = start_bit_pos + state.sew - 1;
 
     # Write the sign-extended immediate (truncated to SEW bits) to the element
-    v[vd] = {
-      v[vd][VLEN-1:end_bit_pos + 1],
-      sext_imm[state.sew-1:0],
-      v[vd][start_bit_pos-1:0]
-    };
+    if (start_bit_pos == 0) {
+      if (end_bit_pos == VLEN - 1) {
+        v[vd] = sext_imm[state.sew-1:0];
+      } else {
+        v[vd] = {
+          v[vd][VLEN-1:end_bit_pos + 1],
+          sext_imm[state.sew-1:0]
+        };
+      }
+    } else if (end_bit_pos == VLEN - 1) {
+      v[vd] = {
+        sext_imm[state.sew-1:0],
+        v[vd][start_bit_pos-1:0]
+      };
+    } else {
+      v[vd] = {
+        v[vd][VLEN-1:end_bit_pos + 1],
+        sext_imm[state.sew-1:0],
+        v[vd][start_bit_pos-1:0]
+      };
+    }
   }
 
   CSR[vstart].VALUE = 0;


### PR DESCRIPTION
The vmv.v.i instruction implementation previously used unconditional vector slicing to update the destination register, which caused assertion failures in the ISS when accessing invalid bit ranges (e.g., msb < lsb). This commit introduces conditional logic to handle cases where the modified element is at the start (bit 0) or end (bit VLEN-1) of the vector register, ensuring only valid slices are concatenated. Fixes issue with vmv.v.i causing Assertion failed: (msb >= lsb) in ISS.
fixes #1618 