### PR TITLE
disable Renovate until CI issues are fixed

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -62,5 +62,6 @@
   },
   "pre-commit": {
     "enabled": true
-  }
+  },
+  "enabled": false
 }


### PR DESCRIPTION
Disable Renovate until #1662 is fixed to avoid breaking the repo.