### PR TITLE
ci: pull container from ghcr.io if tag already exists

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -7,6 +7,7 @@ name: CI/CD
 permissions:
   contents: read
   pull-requests: write
+  packages: read
 'on':
   pull_request:
     branches:
@@ -27,6 +28,9 @@ concurrency:
 jobs:
   build-container:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
     - name: Clone Github Repo Action
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -34,9 +38,30 @@ jobs:
       run: |
         TAG=$(cat bin/.container-tag)
         echo "TAG=$TAG" >> $GITHUB_ENV
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+      with:
+        registry: ghcr.io
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Check if container image exists in registry
+      id: check-registry
+      run: |
+        if docker manifest inspect ghcr.io/riscv/udb:${{ env.TAG }} > /dev/null 2>&1; then
+          echo "REGISTRY_HIT=true" >> $GITHUB_ENV
+        else
+          echo "REGISTRY_HIT=false" >> $GITHUB_ENV
+        fi
+    - name: Pull image from registry
+      if: env.REGISTRY_HIT == 'true'
+      run: |
+        docker pull ghcr.io/riscv/udb:${{ env.TAG }}
+        docker save ghcr.io/riscv/udb:${{ env.TAG }} -o ${{ runner.temp }}/docker_image.tar
     - name: Set up Docker Buildx
+      if: env.REGISTRY_HIT == 'false'
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
     - name: Build and export
+      if: env.REGISTRY_HIT == 'false'
       uses: docker/build-push-action@601a80b39c9405e50806ae38af30926f9d957c47
       with:
         push: false

--- a/tools/test/regress-gh-template.yaml
+++ b/tools/test/regress-gh-template.yaml
@@ -8,6 +8,7 @@ name: CI/CD
 permissions:
   contents: read
   pull-requests: write
+  packages: read
 
 "on": # needs to be quoted or else Psych treats this as true
   pull_request:
@@ -32,6 +33,9 @@ concurrency:
 jobs:
   build-container:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Clone Github Repo Action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -41,10 +45,34 @@ jobs:
           TAG=$(cat bin/.container-tag)
           echo "TAG=$TAG" >> $GITHUB_ENV
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if container image exists in registry
+        id: check-registry
+        run: |
+          if docker manifest inspect ghcr.io/riscv/udb:${{ env.TAG }} > /dev/null 2>&1; then
+            echo "REGISTRY_HIT=true" >> $GITHUB_ENV
+          else
+            echo "REGISTRY_HIT=false" >> $GITHUB_ENV
+          fi
+
+      - name: Pull image from registry
+        if: env.REGISTRY_HIT == 'true'
+        run: |
+          docker pull ghcr.io/riscv/udb:${{ env.TAG }}
+          docker save ghcr.io/riscv/udb:${{ env.TAG }} -o ${{ runner.temp }}/docker_image.tar
+
       - name: Set up Docker Buildx
+        if: env.REGISTRY_HIT == 'false'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build and export
+        if: env.REGISTRY_HIT == 'false'
         uses: docker/build-push-action@601a80b39c9405e50806ae38af30926f9d957c47 # v6.19.1
         with:
           push: false


### PR DESCRIPTION
In the `build-container` job, check whether the image tag already exists in `ghcr.io/riscv/udb` before rebuilding from scratch. If the tag is found, pull and export it directly; otherwise fall through to the existing Buildx build path.

This avoids redundant multi-minute container builds on PRs that do not touch the Dockerfile or container tag.