### PR TITLE
feat(csr): add MNPELP field to mnstatus (Zicfilp)

### DIFF
--- a/spec/std/isa/csr/Smrnmi/mnstatus.yaml
+++ b/spec/std/isa/csr/Smrnmi/mnstatus.yaml
@@ -61,6 +61,18 @@ fields:
       } else {
         return true;
       }
+  MNPELP:
+    location: 9
+    description: |
+      M-mode NMI Previous Expected Landing Pad state.
+
+      Defined by the Zicfilp extension. Holds the previous
+      Expected Landing Pad (ELP) state when entering M-mode NMI.
+    type: RW-H
+    reset_value: UNDEFINED_LEGAL
+    definedBy:
+      extension:
+        name: Zicfilp
   MNPV:
     location: 7
     description: |


### PR DESCRIPTION
Adds the MNPELP field definition to mnstatus CSR as defined by the Zicfilp extension.

 Closes #1686