### PR TITLE
fix: use $HOME instead of $H for XDG_CACHE_HOME fallback

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -194,7 +194,7 @@ setup_z3() {
 
   local xdg_cache
   if [ "$CONTAINER_TYPE" == "native" ]; then
-    xdg_cache="${XDG_CACHE_HOME:-${H}/.cache}"
+    xdg_cache="${XDG_CACHE_HOME:-${HOME}/.cache}"
   else
     xdg_cache="${ROOT}/.docker-home/.cache"
   fi


### PR DESCRIPTION
The script previously used **${H}/.cache** as fallback for **XDG_CACHE_HOME**,
but **$H** is not a standard environment variable. Changed to use **$HOME**,
which is the standard environment variable for user home directory.
This prevents the script from defaulting to '**/.cache**' when neither
variable is set, avoiding permission issues.