### PR TITLE
Enable autofix.ci

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
 permissions:
   contents: read
+env:
+  DOCKER: 1
 
 jobs:
   autofix:

--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -1,0 +1,14 @@
+name: autofix.ci  # needed to securely identify the workflow
+
+on:
+  pull_request:
+permissions:
+  contents: read
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: ./bin/chore gen all
+      - uses: autofix-ci/action@7a166d7532b277f34e16238930461bf77f9d7ed8

--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -11,6 +11,6 @@ jobs:
   autofix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: ./bin/chore gen all
-      - uses: autofix-ci/action@7a166d7532b277f34e16238930461bf77f9d7ed8
+      - uses: autofix-ci/action@7a166d7532b277f34e16238930461bf77f9d7ed8 # v1.3.3

--- a/tools/ruby-gems/udb-gen/sorbet/rbi/gems/idlc@0.1.0.rbi
+++ b/tools/ruby-gems/udb-gen/sorbet/rbi/gems/idlc@0.1.0.rbi
@@ -326,11 +326,11 @@ module Idl
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1375
+# source://idlc//lib/idlc/ast.rb#1391
 class Idl::ArrayIncludesAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#1385
+  # source://idlc//lib/idlc/ast.rb#1401
   sig do
     params(
       input: T.nilable(::String),
@@ -341,43 +341,43 @@ class Idl::ArrayIncludesAst < ::Idl::AstNode
   end
   def initialize(input, interval, ary, value); end
 
-  # source://idlc//lib/idlc/ast.rb#1379
+  # source://idlc//lib/idlc/ast.rb#1395
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def ary; end
 
-  # source://idlc//lib/idlc/ast.rb#1413
+  # source://idlc//lib/idlc/ast.rb#1429
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1382
+  # source://idlc//lib/idlc/ast.rb#1398
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def expr; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#305
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#1419
+  # source://idlc//lib/idlc/ast.rb#1435
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1416
+  # source://idlc//lib/idlc/ast.rb#1432
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1403
+  # source://idlc//lib/idlc/ast.rb#1419
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1390
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1406
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1408
+  # source://idlc//lib/idlc/ast.rb#1424
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1427
+    # source://idlc//lib/idlc/ast.rb#1443
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -388,45 +388,45 @@ class Idl::ArrayIncludesAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1369
+# source://idlc//lib/idlc/ast.rb#1385
 class Idl::ArrayIncludesSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1370
+  # source://idlc//lib/idlc/ast.rb#1386
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5259
+# source://idlc//lib/idlc/ast.rb#5282
 class Idl::ArrayLiteralAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5263
+  # source://idlc//lib/idlc/ast.rb#5286
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5267
+  # source://idlc//lib/idlc/ast.rb#5290
   def element_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#5265
+  # source://idlc//lib/idlc/ast.rb#5288
   def entries; end
 
-  # source://idlc//lib/idlc/ast.rb#5294
+  # source://idlc//lib/idlc/ast.rb#5317
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5291
+  # source://idlc//lib/idlc/ast.rb#5314
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5282
+  # source://idlc//lib/idlc/ast.rb#5305
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5272
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5295
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5286
+  # source://idlc//lib/idlc/ast.rb#5309
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5301
+    # source://idlc//lib/idlc/ast.rb#5324
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -437,49 +437,49 @@ class Idl::ArrayLiteralAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5253
+# source://idlc//lib/idlc/ast.rb#5276
 class Idl::ArrayLiteralSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5254
+  # source://idlc//lib/idlc/ast.rb#5277
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#1446
+# source://idlc//lib/idlc/ast.rb#1462
 class Idl::ArraySizeAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#1455
+  # source://idlc//lib/idlc/ast.rb#1471
   def initialize(input, interval, expression); end
 
-  # source://idlc//lib/idlc/ast.rb#1453
+  # source://idlc//lib/idlc/ast.rb#1469
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1450
+  # source://idlc//lib/idlc/ast.rb#1466
   def expression; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#299
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#1487
+  # source://idlc//lib/idlc/ast.rb#1503
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1484
+  # source://idlc//lib/idlc/ast.rb#1500
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1466
+  # source://idlc//lib/idlc/ast.rb#1482
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1459
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1475
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1477
+  # source://idlc//lib/idlc/ast.rb#1493
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Integer) }
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1494
+    # source://idlc//lib/idlc/ast.rb#1510
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -490,9 +490,9 @@ class Idl::ArraySizeAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1440
+# source://idlc//lib/idlc/ast.rb#1456
 class Idl::ArraySizeSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1441
+  # source://idlc//lib/idlc/ast.rb#1457
   def to_ast; end
 end
 
@@ -520,51 +520,51 @@ module Idl::AryAccess2
   def brackets; end
 end
 
-# source://idlc//lib/idlc/ast.rb#2381
+# source://idlc//lib/idlc/ast.rb#2397
 class Idl::AryAccessSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#2385
+  # source://idlc//lib/idlc/ast.rb#2401
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#2401
+# source://idlc//lib/idlc/ast.rb#2417
 class Idl::AryElementAccessAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#2416
+  # source://idlc//lib/idlc/ast.rb#2432
   def initialize(input, interval, var, index); end
 
-  # source://idlc//lib/idlc/ast.rb#2405
+  # source://idlc//lib/idlc/ast.rb#2421
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#229
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#2414
+  # source://idlc//lib/idlc/ast.rb#2430
   def index; end
 
-  # source://idlc//lib/idlc/ast.rb#2489
+  # source://idlc//lib/idlc/ast.rb#2505
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2486
+  # source://idlc//lib/idlc/ast.rb#2502
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2451
+  # source://idlc//lib/idlc/ast.rb#2467
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2421
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2437
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#2466
+  # source://idlc//lib/idlc/ast.rb#2482
   def value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2413
+  # source://idlc//lib/idlc/ast.rb#2429
   def var; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2497
+    # source://idlc//lib/idlc/ast.rb#2513
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -575,48 +575,48 @@ class Idl::AryElementAccessAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2804
+# source://idlc//lib/idlc/ast.rb#2820
 class Idl::AryElementAssignmentAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#2826
+  # source://idlc//lib/idlc/ast.rb#2842
   def initialize(input, interval, lhs, idx, rhs); end
 
-  # source://idlc//lib/idlc/ast.rb#2808
+  # source://idlc//lib/idlc/ast.rb#2824
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2865
+  # source://idlc//lib/idlc/ast.rb#2881
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2895
+  # source://idlc//lib/idlc/ast.rb#2911
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#253
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#2823
+  # source://idlc//lib/idlc/ast.rb#2839
   def idx; end
 
-  # source://idlc//lib/idlc/ast.rb#2822
+  # source://idlc//lib/idlc/ast.rb#2838
   def lhs; end
 
-  # source://idlc//lib/idlc/ast.rb#2824
+  # source://idlc//lib/idlc/ast.rb#2840
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#2933
+  # source://idlc//lib/idlc/ast.rb#2949
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2930
+  # source://idlc//lib/idlc/ast.rb#2946
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2831
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2847
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2942
+    # source://idlc//lib/idlc/ast.rb#2958
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -627,55 +627,55 @@ class Idl::AryElementAssignmentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2794
+# source://idlc//lib/idlc/ast.rb#2810
 class Idl::AryElementAssignmentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#2795
+  # source://idlc//lib/idlc/ast.rb#2811
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#2510
+# source://idlc//lib/idlc/ast.rb#2526
 class Idl::AryRangeAccessAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#2528
+  # source://idlc//lib/idlc/ast.rb#2544
   def initialize(input, interval, var, msb, lsb); end
 
-  # source://idlc//lib/idlc/ast.rb#2514
+  # source://idlc//lib/idlc/ast.rb#2530
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#168
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#2526
+  # source://idlc//lib/idlc/ast.rb#2542
   def lsb; end
 
-  # source://idlc//lib/idlc/ast.rb#2525
+  # source://idlc//lib/idlc/ast.rb#2541
   def msb; end
 
-  # source://idlc//lib/idlc/ast.rb#2584
+  # source://idlc//lib/idlc/ast.rb#2600
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2581
+  # source://idlc//lib/idlc/ast.rb#2597
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2558
+  # source://idlc//lib/idlc/ast.rb#2574
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2533
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2549
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#2574
+  # source://idlc//lib/idlc/ast.rb#2590
   def value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2524
+  # source://idlc//lib/idlc/ast.rb#2540
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def var; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2595
+    # source://idlc//lib/idlc/ast.rb#2611
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -686,54 +686,54 @@ class Idl::AryRangeAccessAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2966
+# source://idlc//lib/idlc/ast.rb#2982
 class Idl::AryRangeAssignmentAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#2989
+  # source://idlc//lib/idlc/ast.rb#3005
   def initialize(input, interval, variable, msb, lsb, write_value); end
 
-  # source://idlc//lib/idlc/ast.rb#2970
+  # source://idlc//lib/idlc/ast.rb#2986
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3026
+  # source://idlc//lib/idlc/ast.rb#3042
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3054
+  # source://idlc//lib/idlc/ast.rb#3070
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#20
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#2986
+  # source://idlc//lib/idlc/ast.rb#3002
   def lsb; end
 
-  # source://idlc//lib/idlc/ast.rb#2985
+  # source://idlc//lib/idlc/ast.rb#3001
   def msb; end
 
-  # source://idlc//lib/idlc/ast.rb#3021
+  # source://idlc//lib/idlc/ast.rb#3037
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#3063
+  # source://idlc//lib/idlc/ast.rb#3079
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#3060
+  # source://idlc//lib/idlc/ast.rb#3076
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2994
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#3010
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#2984
+  # source://idlc//lib/idlc/ast.rb#3000
   def variable; end
 
-  # source://idlc//lib/idlc/ast.rb#2987
+  # source://idlc//lib/idlc/ast.rb#3003
   def write_value; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#3075
+    # source://idlc//lib/idlc/ast.rb#3091
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -744,9 +744,9 @@ class Idl::AryRangeAssignmentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2956
+# source://idlc//lib/idlc/ast.rb#2972
 class Idl::AryRangeAssignmentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#2957
+  # source://idlc//lib/idlc/ast.rb#2973
   def to_ast; end
 end
 
@@ -841,7 +841,7 @@ end
 class Idl::AstNode
   abstract!
 
-  # source://idlc//lib/idlc/ast.rb#204
+  # source://idlc//lib/idlc/ast.rb#202
   sig do
     params(
       input: T.nilable(::String),
@@ -851,19 +851,19 @@ class Idl::AstNode
   end
   def initialize(input, interval, children); end
 
-  # source://idlc//lib/idlc/ast.rb#80
+  # source://idlc//lib/idlc/ast.rb#78
   sig { returns(T::Array[::Idl::AstNode]) }
   def children; end
 
-  # source://idlc//lib/idlc/ast.rb#198
+  # source://idlc//lib/idlc/ast.rb#196
   sig { abstract.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#259
+  # source://idlc//lib/idlc/ast.rb#257
   sig { params(klass: ::Class).returns(T.nilable(::Idl::AstNode)) }
   def find_ancestor(klass); end
 
-  # source://idlc//lib/idlc/ast.rb#436
+  # source://idlc//lib/idlc/ast.rb#434
   sig { params(global_symtab: ::Idl::SymbolTable).returns(::Idl::AstNode) }
   def freeze_tree(global_symtab); end
 
@@ -873,54 +873,54 @@ class Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#16
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#61
+  # source://idlc//lib/idlc/ast.rb#59
   sig { returns(T.nilable(::String)) }
   def input; end
 
-  # source://idlc//lib/idlc/ast.rb#53
+  # source://idlc//lib/idlc/ast.rb#51
   sig { returns(T.nilable(::Pathname)) }
   def input_file; end
 
-  # source://idlc//lib/idlc/ast.rb#587
+  # source://idlc//lib/idlc/ast.rb#585
   sig { returns(::String) }
   def inspect; end
 
-  # source://idlc//lib/idlc/ast.rb#370
+  # source://idlc//lib/idlc/ast.rb#368
   sig { params(reason: ::String).returns(T.noreturn) }
   def internal_error(reason); end
 
-  # source://idlc//lib/idlc/ast.rb#65
+  # source://idlc//lib/idlc/ast.rb#63
   sig { returns(T.nilable(T::Range[::Integer])) }
   def interval; end
 
-  # source://idlc//lib/idlc/ast.rb#252
+  # source://idlc//lib/idlc/ast.rb#250
   sig { returns(::Integer) }
   def lineno; end
 
-  # source://idlc//lib/idlc/ast.rb#277
+  # source://idlc//lib/idlc/ast.rb#275
   sig { returns(::Idl::AstNode::LinesDescriptor) }
   def lines_around; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#64
+  # source://idlc//lib/idlc/passes/prune.rb#71
   def nullify_assignments(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#76
+  # source://idlc//lib/idlc/ast.rb#74
   sig { returns(T.nilable(::Idl::AstNode)) }
   def parent; end
 
   # source://idlc//lib/idlc/passes/find_return_values.rb#11
   def pass_find_return_values(values, current_conditions); end
 
-  # source://idlc//lib/idlc/ast.rb#445
+  # source://idlc//lib/idlc/ast.rb#443
   sig { returns(::String) }
   def path; end
 
-  # source://idlc//lib/idlc/ast.rb#419
+  # source://idlc//lib/idlc/ast.rb#417
   sig { params(indent: ::Integer, indent_size: ::Integer, io: ::IO).void }
   def print_ast(indent = T.unsafe(nil), indent_size: T.unsafe(nil), io: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#45
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#52
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
   # source://idlc//lib/idlc/passes/reachable_exceptions.rb#13
   def reachable_exceptions(symtab, cache = T.unsafe(nil)); end
@@ -928,68 +928,68 @@ class Idl::AstNode
   # source://idlc//lib/idlc/passes/reachable_functions.rb#12
   def reachable_functions(symtab, cache = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#241
+  # source://idlc//lib/idlc/ast.rb#239
   sig { params(filename: T.any(::Pathname, ::String), starting_line: ::Integer).void }
   def set_input_file(filename, starting_line = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#225
+  # source://idlc//lib/idlc/ast.rb#223
   sig { params(filename: T.any(::Pathname, ::String), starting_line: ::Integer).void }
   def set_input_file_unless_already_set(filename, starting_line = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#484
+  # source://idlc//lib/idlc/ast.rb#482
   sig { returns(T::Hash[::String, T.untyped]) }
   def source_yaml; end
 
-  # source://idlc//lib/idlc/ast.rb#57
+  # source://idlc//lib/idlc/ast.rb#55
   sig { returns(::Integer) }
   def starting_line; end
 
-  # source://idlc//lib/idlc/ast.rb#69
+  # source://idlc//lib/idlc/ast.rb#67
   sig { returns(::String) }
   def text_value; end
 
-  # source://idlc//lib/idlc/ast.rb#504
+  # source://idlc//lib/idlc/ast.rb#502
   sig { abstract.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#477
+  # source://idlc//lib/idlc/ast.rb#475
   sig { abstract.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#480
+  # source://idlc//lib/idlc/ast.rb#478
   sig { overridable.returns(::String) }
   def to_idl_verbose; end
 
-  # source://idlc//lib/idlc/ast.rb#305
+  # source://idlc//lib/idlc/ast.rb#303
   sig { params(reason: ::String).void }
   def truncation_warn(reason); end
 
-  # source://idlc//lib/idlc/ast.rb#467
-  sig { abstract.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#465
+  sig { abstract.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#321
+  # source://idlc//lib/idlc/ast.rb#319
   sig { params(reason: ::String).returns(T.noreturn) }
   def type_error(reason); end
 
-  # source://idlc//lib/idlc/ast.rb#409
+  # source://idlc//lib/idlc/ast.rb#407
   sig { params(s: ::String).returns(::String) }
   def unindent(s); end
 
-  # source://idlc//lib/idlc/ast.rb#192
+  # source://idlc//lib/idlc/ast.rb#190
   sig { params(value_result: T.untyped, block: T.proc.returns(T.untyped)).returns(T.untyped) }
   def value_else(value_result, &block); end
 
-  # source://idlc//lib/idlc/ast.rb#400
+  # source://idlc//lib/idlc/ast.rb#398
   sig { params(reason: ::String).returns(T.noreturn) }
   def value_error(reason); end
 
-  # source://idlc//lib/idlc/ast.rb#182
+  # source://idlc//lib/idlc/ast.rb#180
   sig { params(block: T.proc.params(arg0: ::Object).returns(T.untyped)).returns(T.untyped) }
   def value_try(&block); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#507
+    # source://idlc//lib/idlc/ast.rb#505
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -998,7 +998,7 @@ class Idl::AstNode
     end
     def from_h(yaml, source_mapper); end
 
-    # source://idlc//lib/idlc/ast.rb#493
+    # source://idlc//lib/idlc/ast.rb#491
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1007,190 +1007,190 @@ class Idl::AstNode
     end
     def input_from_source_yaml(yaml, source_mapper); end
 
-    # source://idlc//lib/idlc/ast.rb#499
+    # source://idlc//lib/idlc/ast.rb#497
     sig { params(yaml: T::Hash[::String, T.untyped]).returns(T.nilable(T::Range[::Integer])) }
     def interval_from_source_yaml(yaml); end
 
-    # source://idlc//lib/idlc/ast.rb#185
+    # source://idlc//lib/idlc/ast.rb#183
     sig { params(value_result: T.untyped, _block: T.proc.returns(T.untyped)).returns(T.untyped) }
     def value_else(value_result, &_block); end
 
-    # source://idlc//lib/idlc/ast.rb#391
+    # source://idlc//lib/idlc/ast.rb#389
     sig { params(reason: ::String, ast: T.nilable(::Idl::AstNode)).returns(T.noreturn) }
     def value_error(reason, ast = T.unsafe(nil)); end
 
-    # source://idlc//lib/idlc/ast.rb#383
+    # source://idlc//lib/idlc/ast.rb#381
     def value_error_ast; end
 
-    # source://idlc//lib/idlc/ast.rb#383
+    # source://idlc//lib/idlc/ast.rb#381
     def value_error_ast=(_arg0); end
 
-    # source://idlc//lib/idlc/ast.rb#383
+    # source://idlc//lib/idlc/ast.rb#381
     def value_error_reason; end
 
-    # source://idlc//lib/idlc/ast.rb#383
+    # source://idlc//lib/idlc/ast.rb#381
     def value_error_reason=(_arg0); end
 
-    # source://idlc//lib/idlc/ast.rb#178
+    # source://idlc//lib/idlc/ast.rb#176
     sig { params(block: T.proc.params(arg0: ::Object).returns(T.untyped)).returns(T.untyped) }
     def value_try(&block); end
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#40
+# source://idlc//lib/idlc/ast.rb#38
 Idl::AstNode::Bits1Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#42
+# source://idlc//lib/idlc/ast.rb#40
 Idl::AstNode::Bits32Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#44
+# source://idlc//lib/idlc/ast.rb#42
 Idl::AstNode::Bits64Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#47
+# source://idlc//lib/idlc/ast.rb#45
 Idl::AstNode::BoolType = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#46
+# source://idlc//lib/idlc/ast.rb#44
 Idl::AstNode::ConstBoolType = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#113
+# source://idlc//lib/idlc/ast.rb#111
 class Idl::AstNode::InternalError < ::StandardError
-  # source://idlc//lib/idlc/ast.rb#129
+  # source://idlc//lib/idlc/ast.rb#127
   sig { params(what: ::String).void }
   def initialize(what); end
 
-  # source://idlc//lib/idlc/ast.rb#126
+  # source://idlc//lib/idlc/ast.rb#124
   sig { returns(T::Array[::String]) }
   def bt; end
 
-  # source://idlc//lib/idlc/ast.rb#118
+  # source://idlc//lib/idlc/ast.rb#116
   sig { returns(::String) }
   def what; end
 end
 
-# source://idlc//lib/idlc/ast.rb#269
+# source://idlc//lib/idlc/ast.rb#267
 class Idl::AstNode::LinesDescriptor < ::T::Struct
   const :lines, ::String
   const :problem_interval, T::Range[T.untyped]
   const :lines_interval, T::Range[T.untyped]
 end
 
-# source://idlc//lib/idlc/ast.rb#41
+# source://idlc//lib/idlc/ast.rb#39
 Idl::AstNode::PossiblyUnknownBits1Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#43
+# source://idlc//lib/idlc/ast.rb#41
 Idl::AstNode::PossiblyUnknownBits32Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#45
+# source://idlc//lib/idlc/ast.rb#43
 Idl::AstNode::PossiblyUnknownBits64Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#49
+# source://idlc//lib/idlc/ast.rb#47
 Idl::AstNode::StringType = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#83
+# source://idlc//lib/idlc/ast.rb#81
 class Idl::AstNode::TypeError < ::StandardError
-  # source://idlc//lib/idlc/ast.rb#100
+  # source://idlc//lib/idlc/ast.rb#98
   sig { params(what: ::String).void }
   def initialize(what); end
 
-  # source://idlc//lib/idlc/ast.rb#96
+  # source://idlc//lib/idlc/ast.rb#94
   sig { returns(T::Array[::String]) }
   def bt; end
 
-  # source://idlc//lib/idlc/ast.rb#88
+  # source://idlc//lib/idlc/ast.rb#86
   sig { returns(::String) }
   def what; end
 end
 
-# source://idlc//lib/idlc/ast.rb#143
+# source://idlc//lib/idlc/ast.rb#141
 class Idl::AstNode::ValueError < ::StandardError
-  # source://idlc//lib/idlc/ast.rb#156
+  # source://idlc//lib/idlc/ast.rb#154
   sig { params(lineno: ::Integer, file: ::String, reason: ::String).void }
   def initialize(lineno, file, reason); end
 
-  # source://idlc//lib/idlc/ast.rb#150
+  # source://idlc//lib/idlc/ast.rb#148
   sig { returns(::String) }
   def file; end
 
-  # source://idlc//lib/idlc/ast.rb#147
+  # source://idlc//lib/idlc/ast.rb#145
   sig { returns(::Integer) }
   def lineno; end
 
-  # source://idlc//lib/idlc/ast.rb#167
+  # source://idlc//lib/idlc/ast.rb#165
   sig { returns(::String) }
   def message; end
 
-  # source://idlc//lib/idlc/ast.rb#153
+  # source://idlc//lib/idlc/ast.rb#151
   sig { returns(::String) }
   def reason; end
 
-  # source://idlc//lib/idlc/ast.rb#164
+  # source://idlc//lib/idlc/ast.rb#162
   sig { returns(::String) }
   def what; end
 end
 
-# source://idlc//lib/idlc/ast.rb#48
+# source://idlc//lib/idlc/ast.rb#46
 Idl::AstNode::VoidType = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#17
+# source://idlc//lib/idlc/ast.rb#15
 Idl::BasicValueRbType = T.type_alias { T.any(::Integer, ::String, T::Array[::Integer], T::Array[::String], T::Array[T::Boolean], T::Boolean) }
 
-# source://idlc//lib/idlc/ast.rb#4392
+# source://idlc//lib/idlc/ast.rb#4413
 class Idl::BinaryExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#4411
+  # source://idlc//lib/idlc/ast.rb#4432
   def initialize(input, interval, lhs, op, rhs); end
 
-  # source://idlc//lib/idlc/ast.rb#4681
+  # source://idlc//lib/idlc/ast.rb#4702
   def bits_needed(value, signed); end
 
-  # source://idlc//lib/idlc/ast.rb#4401
+  # source://idlc//lib/idlc/ast.rb#4422
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#235
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#4418
+  # source://idlc//lib/idlc/ast.rb#4439
   def invert(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4407
+  # source://idlc//lib/idlc/ast.rb#4428
   def lhs; end
 
-  # source://idlc//lib/idlc/ast.rb#4708
+  # source://idlc//lib/idlc/ast.rb#4729
   def max_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4851
+  # source://idlc//lib/idlc/ast.rb#4872
   def min_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5195
+  # source://idlc//lib/idlc/ast.rb#5218
   def op; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#239
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#269
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#4408
+  # source://idlc//lib/idlc/ast.rb#4429
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#4454
+  # source://idlc//lib/idlc/ast.rb#4475
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#4449
+  # source://idlc//lib/idlc/ast.rb#4470
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#4477
+  # source://idlc//lib/idlc/ast.rb#4498
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4577
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#4598
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5001
+  # source://idlc//lib/idlc/ast.rb#5022
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#4463
+    # source://idlc//lib/idlc/ast.rb#4484
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1201,25 +1201,25 @@ class Idl::BinaryExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#4397
+# source://idlc//lib/idlc/ast.rb#4418
 Idl::BinaryExpressionAst::ARITH_OPS = T.let(T.unsafe(nil), Array)
 
-# source://idlc//lib/idlc/ast.rb#4396
+# source://idlc//lib/idlc/ast.rb#4417
 Idl::BinaryExpressionAst::BIT_OPS = T.let(T.unsafe(nil), Array)
 
-# source://idlc//lib/idlc/ast.rb#4395
+# source://idlc//lib/idlc/ast.rb#4416
 Idl::BinaryExpressionAst::LOGICAL_OPS = T.let(T.unsafe(nil), Array)
 
-# source://idlc//lib/idlc/ast.rb#4398
+# source://idlc//lib/idlc/ast.rb#4419
 Idl::BinaryExpressionAst::OPS = T.let(T.unsafe(nil), Array)
 
-# source://idlc//lib/idlc/ast.rb#3937
+# source://idlc//lib/idlc/ast.rb#3953
 class Idl::BinaryExpressionRightSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3941
+  # source://idlc//lib/idlc/ast.rb#3957
   def to_ast; end
 
-  # source://idlc//lib/idlc/ast.rb#3958
-  def type_check(_symtab); end
+  # source://idlc//lib/idlc/ast.rb#3974
+  def type_check(_symtab, strict:); end
 end
 
 # source://idlc//lib/idlc/idl_parser.rb#847
@@ -1258,54 +1258,54 @@ module Idl::BitfieldDefinition3
   def user_type_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#2113
+# source://idlc//lib/idlc/ast.rb#2129
 class Idl::BitfieldDefinitionAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#2119
+  # source://idlc//lib/idlc/ast.rb#2135
   def initialize(input, interval, name, size, fields); end
 
-  # source://idlc//lib/idlc/ast.rb#2172
+  # source://idlc//lib/idlc/ast.rb#2188
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2117
+  # source://idlc//lib/idlc/ast.rb#2133
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2144
+  # source://idlc//lib/idlc/ast.rb#2160
   def element_names; end
 
-  # source://idlc//lib/idlc/ast.rb#2152
+  # source://idlc//lib/idlc/ast.rb#2168
   def element_ranges(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2128
+  # source://idlc//lib/idlc/ast.rb#2144
   def freeze_tree(global_symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2194
+  # source://idlc//lib/idlc/ast.rb#2210
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#2139
+  # source://idlc//lib/idlc/ast.rb#2155
   def size(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2211
+  # source://idlc//lib/idlc/ast.rb#2227
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2201
+  # source://idlc//lib/idlc/ast.rb#2217
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2182
+  # source://idlc//lib/idlc/ast.rb#2198
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2159
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2175
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#2197
+  # source://idlc//lib/idlc/ast.rb#2213
   def value(_symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2220
+    # source://idlc//lib/idlc/ast.rb#2236
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1316,40 +1316,40 @@ class Idl::BitfieldDefinitionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2082
+# source://idlc//lib/idlc/ast.rb#2098
 class Idl::BitfieldDefinitionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#2083
+  # source://idlc//lib/idlc/ast.rb#2099
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#1997
+# source://idlc//lib/idlc/ast.rb#2013
 class Idl::BitfieldFieldDefinitionAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#2004
+  # source://idlc//lib/idlc/ast.rb#2020
   def initialize(input, interval, name, msb, lsb); end
 
-  # source://idlc//lib/idlc/ast.rb#2002
+  # source://idlc//lib/idlc/ast.rb#2018
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1999
+  # source://idlc//lib/idlc/ast.rb#2015
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#2039
+  # source://idlc//lib/idlc/ast.rb#2055
   def range(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2057
+  # source://idlc//lib/idlc/ast.rb#2073
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2048
+  # source://idlc//lib/idlc/ast.rb#2064
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2017
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2033
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2068
+    # source://idlc//lib/idlc/ast.rb#2084
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1360,28 +1360,31 @@ class Idl::BitfieldFieldDefinitionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/type.rb#711
+# source://idlc//lib/idlc/type.rb#730
 class Idl::BitfieldType < ::Idl::Type
-  # source://idlc//lib/idlc/type.rb#712
+  # source://idlc//lib/idlc/type.rb#732
   def initialize(type_name, width, field_names, field_ranges); end
 
-  # source://idlc//lib/idlc/type.rb#732
+  # source://idlc//lib/idlc/type.rb#752
   def clone; end
 
-  # source://idlc//lib/idlc/type.rb#728
+  # source://idlc//lib/idlc/type.rb#748
   def field_names; end
 
-  # source://idlc//lib/idlc/type.rb#721
+  # source://idlc//lib/idlc/type.rb#741
   def range(field_name); end
+
+  # source://idlc//lib/idlc/type.rb#731
+  def width; end
 end
 
-# source://idlc//lib/idlc/type.rb#996
+# source://idlc//lib/idlc/type.rb#1016
 Idl::Bits1Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/type.rb#997
+# source://idlc//lib/idlc/type.rb#1017
 Idl::Bits32Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/type.rb#998
+# source://idlc//lib/idlc/type.rb#1018
 Idl::Bits64Type = T.let(T.unsafe(nil), Idl::Type)
 
 # source://idlc//lib/idlc/idl_parser.rb#6569
@@ -1390,45 +1393,45 @@ module Idl::BitsCast0
   def expr; end
 end
 
-# source://idlc//lib/idlc/ast.rb#4303
+# source://idlc//lib/idlc/ast.rb#4320
 class Idl::BitsCastAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#4314
+  # source://idlc//lib/idlc/ast.rb#4331
   def initialize(input, interval, exp); end
 
-  # source://idlc//lib/idlc/ast.rb#4307
+  # source://idlc//lib/idlc/ast.rb#4324
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4312
+  # source://idlc//lib/idlc/ast.rb#4329
   def expr; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#102
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#506
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#615
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#4373
+  # source://idlc//lib/idlc/ast.rb#4394
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#4370
+  # source://idlc//lib/idlc/ast.rb#4391
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#4326
+  # source://idlc//lib/idlc/ast.rb#4343
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4317
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#4334
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#4347
+  # source://idlc//lib/idlc/ast.rb#4366
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#4380
+    # source://idlc//lib/idlc/ast.rb#4401
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1439,13 +1442,13 @@ class Idl::BitsCastAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#4292
+# source://idlc//lib/idlc/ast.rb#4309
 class Idl::BitsCastSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#4293
+  # source://idlc//lib/idlc/ast.rb#4310
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/type.rb#999
+# source://idlc//lib/idlc/type.rb#1019
 Idl::BitsUnknownType = T.let(T.unsafe(nil), Idl::Type)
 
 # source://idlc//lib/idlc/idl_parser.rb#9522
@@ -1526,14 +1529,14 @@ module Idl::BodyFunctionDefinition8
   def type; end
 end
 
-# source://idlc//lib/idlc/type.rb#1002
+# source://idlc//lib/idlc/type.rb#1022
 Idl::BoolType = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#1932
+# source://idlc//lib/idlc/ast.rb#1948
 class Idl::BuiltinEnumDefinitionAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#1939
+  # source://idlc//lib/idlc/ast.rb#1955
   sig do
     params(
       input: T.nilable(::String),
@@ -1543,38 +1546,38 @@ class Idl::BuiltinEnumDefinitionAst < ::Idl::AstNode
   end
   def initialize(input, interval, user_type); end
 
-  # source://idlc//lib/idlc/ast.rb#1966
+  # source://idlc//lib/idlc/ast.rb#1982
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1936
+  # source://idlc//lib/idlc/ast.rb#1952
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1952
+  # source://idlc//lib/idlc/ast.rb#1968
   def element_names(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1956
+  # source://idlc//lib/idlc/ast.rb#1972
   def element_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1971
+  # source://idlc//lib/idlc/ast.rb#1987
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#1978
+  # source://idlc//lib/idlc/ast.rb#1994
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1975
+  # source://idlc//lib/idlc/ast.rb#1991
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1961
+  # source://idlc//lib/idlc/ast.rb#1977
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1945
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1961
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1985
+    # source://idlc//lib/idlc/ast.rb#2001
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1585,9 +1588,9 @@ class Idl::BuiltinEnumDefinitionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1921
+# source://idlc//lib/idlc/ast.rb#1937
 class Idl::BuiltinEnumDefinitionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1922
+  # source://idlc//lib/idlc/ast.rb#1938
   def to_ast; end
 end
 
@@ -1651,41 +1654,41 @@ module Idl::BuiltinTypeName4; end
 # source://idlc//lib/idlc/idl_parser.rb#14708
 module Idl::BuiltinTypeName5; end
 
-# source://idlc//lib/idlc/ast.rb#6868
+# source://idlc//lib/idlc/ast.rb#6929
 class Idl::BuiltinTypeNameAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#6875
+  # source://idlc//lib/idlc/ast.rb#6936
   def initialize(input, interval, type_name, bits_expression); end
 
-  # source://idlc//lib/idlc/ast.rb#6873
+  # source://idlc//lib/idlc/ast.rb#6934
   def bits_expression; end
 
-  # source://idlc//lib/idlc/ast.rb#6871
+  # source://idlc//lib/idlc/ast.rb#6932
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6902
+  # source://idlc//lib/idlc/ast.rb#6963
   def freeze_tree(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#192
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#6964
+  # source://idlc//lib/idlc/ast.rb#7025
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6955
+  # source://idlc//lib/idlc/ast.rb#7016
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6921
+  # source://idlc//lib/idlc/ast.rb#6982
   sig { params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6885
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6946
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6981
+    # source://idlc//lib/idlc/ast.rb#7042
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1696,52 +1699,52 @@ class Idl::BuiltinTypeNameAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6847
+# source://idlc//lib/idlc/ast.rb#6908
 class Idl::BuiltinTypeNameSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6848
+  # source://idlc//lib/idlc/ast.rb#6909
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5575
+# source://idlc//lib/idlc/ast.rb#5606
 class Idl::BuiltinVariableAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5594
+  # source://idlc//lib/idlc/ast.rb#5625
   sig { params(input: T.nilable(::String), interval: T.nilable(T::Range[::Integer]), name: ::String).void }
   def initialize(input, interval, name); end
 
-  # source://idlc//lib/idlc/ast.rb#5579
+  # source://idlc//lib/idlc/ast.rb#5610
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#213
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5590
+  # source://idlc//lib/idlc/ast.rb#5621
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#5591
+  # source://idlc//lib/idlc/ast.rb#5622
   def text_value; end
 
-  # source://idlc//lib/idlc/ast.rb#5626
+  # source://idlc//lib/idlc/ast.rb#5657
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5623
+  # source://idlc//lib/idlc/ast.rb#5654
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5603
+  # source://idlc//lib/idlc/ast.rb#5634
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5599
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5630
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5618
+  # source://idlc//lib/idlc/ast.rb#5649
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5633
+    # source://idlc//lib/idlc/ast.rb#5664
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1752,9 +1755,9 @@ class Idl::BuiltinVariableAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5645
+# source://idlc//lib/idlc/ast.rb#5676
 class Idl::BuiltinVariableSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5646
+  # source://idlc//lib/idlc/ast.rb#5677
   def to_ast; end
 end
 
@@ -1767,34 +1770,34 @@ module Idl::Comment1
   def content; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6805
+# source://idlc//lib/idlc/ast.rb#6866
 class Idl::CommentAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#6809
+  # source://idlc//lib/idlc/ast.rb#6870
   def initialize(input, interval, text); end
 
-  # source://idlc//lib/idlc/ast.rb#6807
+  # source://idlc//lib/idlc/ast.rb#6868
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6822
+  # source://idlc//lib/idlc/ast.rb#6883
   def content; end
 
-  # source://idlc//lib/idlc/ast.rb#6814
+  # source://idlc//lib/idlc/ast.rb#6875
   def text_value; end
 
-  # source://idlc//lib/idlc/ast.rb#6828
+  # source://idlc//lib/idlc/ast.rb#6889
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6825
+  # source://idlc//lib/idlc/ast.rb#6886
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6817
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6878
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6835
+    # source://idlc//lib/idlc/ast.rb#6896
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1805,9 +1808,9 @@ class Idl::CommentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6800
+# source://idlc//lib/idlc/ast.rb#6861
 class Idl::CommentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6801
+  # source://idlc//lib/idlc/ast.rb#6862
   def to_ast; end
 end
 
@@ -1872,39 +1875,42 @@ module Idl::ConcatenationExpression1
   def rest; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5323
+# source://idlc//lib/idlc/ast.rb#5346
 class Idl::ConcatenationExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5327
+  # source://idlc//lib/idlc/ast.rb#5350
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5329
+  # source://idlc//lib/idlc/ast.rb#5352
   def expressions; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#97
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5395
+  # source://idlc//lib/idlc/passes/prune.rb#493
+  def prune(symtab, forced_type: T.unsafe(nil)); end
+
+  # source://idlc//lib/idlc/ast.rb#5422
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5392
+  # source://idlc//lib/idlc/ast.rb#5419
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5345
+  # source://idlc//lib/idlc/ast.rb#5368
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5332
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5355
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5380
+  # source://idlc//lib/idlc/ast.rb#5403
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5402
+    # source://idlc//lib/idlc/ast.rb#5429
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1915,31 +1921,31 @@ class Idl::ConcatenationExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5313
+# source://idlc//lib/idlc/ast.rb#5336
 class Idl::ConcatenationExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5314
+  # source://idlc//lib/idlc/ast.rb#5337
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6720
+# source://idlc//lib/idlc/ast.rb#6781
 class Idl::ConditionalReturnStatementAst < ::Idl::AstNode
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#6729
+  # source://idlc//lib/idlc/ast.rb#6790
   def initialize(input, interval, return_expression, condition); end
 
-  # source://idlc//lib/idlc/ast.rb#6727
+  # source://idlc//lib/idlc/ast.rb#6788
   def condition; end
 
-  # source://idlc//lib/idlc/ast.rb#6724
+  # source://idlc//lib/idlc/ast.rb#6785
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#25
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#413
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#450
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
   # source://idlc//lib/idlc/passes/reachable_exceptions.rb#150
   def reachable_exceptions(symtab, cache = T.unsafe(nil)); end
@@ -1947,34 +1953,34 @@ class Idl::ConditionalReturnStatementAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/reachable_functions.rb#137
   def reachable_functions(symtab, cache); end
 
-  # source://idlc//lib/idlc/ast.rb#6726
+  # source://idlc//lib/idlc/ast.rb#6787
   def return_expression; end
 
-  # source://idlc//lib/idlc/ast.rb#6741
+  # source://idlc//lib/idlc/ast.rb#6802
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6746
+  # source://idlc//lib/idlc/ast.rb#6807
   def return_types(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6752
+  # source://idlc//lib/idlc/ast.rb#6813
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6761
+  # source://idlc//lib/idlc/ast.rb#6822
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6778
+  # source://idlc//lib/idlc/ast.rb#6839
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6775
+  # source://idlc//lib/idlc/ast.rb#6836
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6734
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6795
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6786
+    # source://idlc//lib/idlc/ast.rb#6847
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1985,38 +1991,38 @@ class Idl::ConditionalReturnStatementAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6714
+# source://idlc//lib/idlc/ast.rb#6775
 class Idl::ConditionalReturnStatementSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6715
+  # source://idlc//lib/idlc/ast.rb#6776
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6329
+# source://idlc//lib/idlc/ast.rb#6390
 class Idl::ConditionalStatementAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#6336
+  # source://idlc//lib/idlc/ast.rb#6397
   def initialize(input, interval, action, condition); end
 
-  # source://idlc//lib/idlc/ast.rb#6330
+  # source://idlc//lib/idlc/ast.rb#6391
   def action; end
 
-  # source://idlc//lib/idlc/ast.rb#6331
+  # source://idlc//lib/idlc/ast.rb#6392
   def condition; end
 
-  # source://idlc//lib/idlc/ast.rb#6334
+  # source://idlc//lib/idlc/ast.rb#6395
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6350
+  # source://idlc//lib/idlc/ast.rb#6411
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6366
+  # source://idlc//lib/idlc/ast.rb#6427
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#283
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#428
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#465
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
   # source://idlc//lib/idlc/passes/reachable_exceptions.rb#166
   def reachable_exceptions(symtab, cache = T.unsafe(nil)); end
@@ -2024,19 +2030,19 @@ class Idl::ConditionalStatementAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/reachable_functions.rb#154
   def reachable_functions(symtab, cache = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#6377
+  # source://idlc//lib/idlc/ast.rb#6438
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6372
+  # source://idlc//lib/idlc/ast.rb#6433
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6341
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6402
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6385
+    # source://idlc//lib/idlc/ast.rb#6446
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2047,16 +2053,16 @@ class Idl::ConditionalStatementAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6319
+# source://idlc//lib/idlc/ast.rb#6380
 class Idl::ConditionalStatementSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6320
+  # source://idlc//lib/idlc/ast.rb#6381
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/type.rb#1000
+# source://idlc//lib/idlc/type.rb#1020
 Idl::ConstBitsUnknownType = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/type.rb#1001
+# source://idlc//lib/idlc/type.rb#1021
 Idl::ConstBoolType = T.let(T.unsafe(nil), Idl::Type)
 
 # source://idlc//lib/idlc/idl_parser.rb#8601
@@ -2071,9 +2077,9 @@ module Idl::ConstraintBody1
   def b; end
 end
 
-# source://idlc//lib/idlc/ast.rb#4106
+# source://idlc//lib/idlc/ast.rb#4122
 class Idl::ConstraintBodyAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#4114
+  # source://idlc//lib/idlc/ast.rb#4130
   sig do
     params(
       input: T.nilable(::String),
@@ -2083,32 +2089,32 @@ class Idl::ConstraintBodyAst < ::Idl::AstNode
   end
   def initialize(input, interval, stmts); end
 
-  # source://idlc//lib/idlc/ast.rb#4119
+  # source://idlc//lib/idlc/ast.rb#4135
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4132
+  # source://idlc//lib/idlc/ast.rb#4148
   sig { params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def satisfied?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4122
+  # source://idlc//lib/idlc/ast.rb#4138
   sig { returns(T::Array[T.any(::Idl::ForLoopAst, ::Idl::ImplicationStatementAst)]) }
   def stmts; end
 
-  # source://idlc//lib/idlc/ast.rb#4144
+  # source://idlc//lib/idlc/ast.rb#4160
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#4139
+  # source://idlc//lib/idlc/ast.rb#4155
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#4125
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#4141
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#4151
+    # source://idlc//lib/idlc/ast.rb#4167
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2119,14 +2125,14 @@ class Idl::ConstraintBodyAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#4095
+# source://idlc//lib/idlc/ast.rb#4111
 class Idl::ConstraintBodySyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#4097
+  # source://idlc//lib/idlc/ast.rb#4113
   sig { override.returns(::Idl::ConstraintBodyAst) }
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/interfaces.rb#110
+# source://idlc//lib/idlc/type.rb#15
 module Idl::Csr
   interface!
 
@@ -2216,11 +2222,11 @@ module Idl::CsrFieldAccessExpression0
   def csr_field_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#3237
+# source://idlc//lib/idlc/ast.rb#3253
 class Idl::CsrFieldAssignmentAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#3247
+  # source://idlc//lib/idlc/ast.rb#3263
   sig do
     params(
       input: T.nilable(::String),
@@ -2231,48 +2237,48 @@ class Idl::CsrFieldAssignmentAst < ::Idl::AstNode
   end
   def initialize(input, interval, csr_field, write_value); end
 
-  # source://idlc//lib/idlc/ast.rb#3241
+  # source://idlc//lib/idlc/ast.rb#3257
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3243
+  # source://idlc//lib/idlc/ast.rb#3259
   def csr_field; end
 
-  # source://idlc//lib/idlc/ast.rb#3268
+  # source://idlc//lib/idlc/ast.rb#3284
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3273
+  # source://idlc//lib/idlc/ast.rb#3289
   def execute_unknown(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3256
+  # source://idlc//lib/idlc/ast.rb#3272
   def field(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#112
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#476
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#579
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3279
+  # source://idlc//lib/idlc/ast.rb#3295
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#3276
+  # source://idlc//lib/idlc/ast.rb#3292
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#3252
+  # source://idlc//lib/idlc/ast.rb#3268
   sig { params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3260
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#3276
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#3244
+  # source://idlc//lib/idlc/ast.rb#3260
   def write_value; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#3287
+    # source://idlc//lib/idlc/ast.rb#3303
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2283,20 +2289,20 @@ class Idl::CsrFieldAssignmentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#3231
+# source://idlc//lib/idlc/ast.rb#3247
 class Idl::CsrFieldAssignmentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3232
+  # source://idlc//lib/idlc/ast.rb#3248
   def to_ast; end
 end
 
 # source://idlc//lib/idlc/idl_parser.rb#16453
 module Idl::CsrFieldName0; end
 
-# source://idlc//lib/idlc/ast.rb#9276
+# source://idlc//lib/idlc/ast.rb#9362
 class Idl::CsrFieldReadExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#9290
+  # source://idlc//lib/idlc/ast.rb#9376
   sig do
     params(
       input: T.nilable(::String),
@@ -2307,61 +2313,61 @@ class Idl::CsrFieldReadExpressionAst < ::Idl::AstNode
   end
   def initialize(input, interval, csr, field_name); end
 
-  # source://idlc//lib/idlc/ast.rb#9371
+  # source://idlc//lib/idlc/ast.rb#9460
   sig { params(symtab: ::Idl::SymbolTable).returns(T.nilable(::Idl::Type)) }
   def calc_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9404
+  # source://idlc//lib/idlc/ast.rb#9489
   sig { params(symtab: ::Idl::SymbolTable).void }
   def calc_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9287
+  # source://idlc//lib/idlc/ast.rb#9373
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9319
+  # source://idlc//lib/idlc/ast.rb#9408
   sig { params(symtab: ::Idl::SymbolTable).returns(::Idl::Csr) }
   def csr_def(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9324
+  # source://idlc//lib/idlc/ast.rb#9413
   sig { returns(::String) }
   def csr_name; end
 
-  # source://idlc//lib/idlc/ast.rb#9299
+  # source://idlc//lib/idlc/ast.rb#9385
   sig { params(symtab: ::Idl::SymbolTable).returns(::Idl::Csr) }
   def csr_obj(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9327
+  # source://idlc//lib/idlc/ast.rb#9416
   sig { params(symtab: ::Idl::SymbolTable).returns(::Idl::CsrField) }
   def field_def(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9332
+  # source://idlc//lib/idlc/ast.rb#9421
   sig { params(symtab: ::Idl::SymbolTable).returns(::String) }
   def field_name(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#317
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#482
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#585
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#9343
+  # source://idlc//lib/idlc/ast.rb#9432
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#9338
+  # source://idlc//lib/idlc/ast.rb#9427
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#9365
+  # source://idlc//lib/idlc/ast.rb#9454
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9311
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#9397
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#9391
+  # source://idlc//lib/idlc/ast.rb#9476
   sig do
     override
       .params(
@@ -2371,7 +2377,7 @@ class Idl::CsrFieldReadExpressionAst < ::Idl::AstNode
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#9351
+    # source://idlc//lib/idlc/ast.rb#9440
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2382,7 +2388,7 @@ class Idl::CsrFieldReadExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#9279
+# source://idlc//lib/idlc/ast.rb#9365
 class Idl::CsrFieldReadExpressionAst::MemoizedState < ::T::Struct
   prop :csr, T.nilable(::Idl::Csr)
   prop :type, T.nilable(::Idl::Type)
@@ -2390,63 +2396,63 @@ class Idl::CsrFieldReadExpressionAst::MemoizedState < ::T::Struct
   prop :value, T.nilable(::Integer)
 end
 
-# source://idlc//lib/idlc/ast.rb#9431
+# source://idlc//lib/idlc/ast.rb#9516
 class Idl::CsrFieldReadExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#9432
+  # source://idlc//lib/idlc/ast.rb#9517
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#9599
+# source://idlc//lib/idlc/ast.rb#9687
 class Idl::CsrFunctionCallAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#9617
+  # source://idlc//lib/idlc/ast.rb#9705
   def initialize(input, interval, function_name, csr, args); end
 
-  # source://idlc//lib/idlc/ast.rb#9615
+  # source://idlc//lib/idlc/ast.rb#9703
   def args; end
 
-  # source://idlc//lib/idlc/ast.rb#9603
+  # source://idlc//lib/idlc/ast.rb#9691
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9614
+  # source://idlc//lib/idlc/ast.rb#9702
   def csr; end
 
-  # source://idlc//lib/idlc/ast.rb#9655
+  # source://idlc//lib/idlc/ast.rb#9743
   def csr_def(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9649
+  # source://idlc//lib/idlc/ast.rb#9737
   def csr_known?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9653
+  # source://idlc//lib/idlc/ast.rb#9741
   def csr_name; end
 
-  # source://idlc//lib/idlc/ast.rb#9612
+  # source://idlc//lib/idlc/ast.rb#9700
   def function_name; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#76
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#9684
+  # source://idlc//lib/idlc/ast.rb#9772
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#9679
+  # source://idlc//lib/idlc/ast.rb#9767
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#9632
+  # source://idlc//lib/idlc/ast.rb#9720
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9622
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#9710
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#9660
+  # source://idlc//lib/idlc/ast.rb#9748
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#9693
+    # source://idlc//lib/idlc/ast.rb#9781
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2457,63 +2463,63 @@ class Idl::CsrFunctionCallAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#9584
+# source://idlc//lib/idlc/ast.rb#9672
 class Idl::CsrFunctionCallSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#9585
+  # source://idlc//lib/idlc/ast.rb#9673
   def to_ast; end
 end
 
 # source://idlc//lib/idlc/idl_parser.rb#16398
 module Idl::CsrName0; end
 
-# source://idlc//lib/idlc/ast.rb#9437
+# source://idlc//lib/idlc/ast.rb#9522
 class Idl::CsrReadExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#9445
+  # source://idlc//lib/idlc/ast.rb#9535
   def initialize(input, interval, csr_name); end
 
-  # source://idlc//lib/idlc/ast.rb#9441
+  # source://idlc//lib/idlc/ast.rb#9531
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9471
+  # source://idlc//lib/idlc/ast.rb#9559
   def csr_def(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9475
+  # source://idlc//lib/idlc/ast.rb#9563
   def csr_known?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9443
+  # source://idlc//lib/idlc/ast.rb#9533
   def csr_name; end
 
-  # source://idlc//lib/idlc/ast.rb#9451
+  # source://idlc//lib/idlc/ast.rb#9542
   def freeze_tree(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#325
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#494
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#600
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#9493
+  # source://idlc//lib/idlc/ast.rb#9581
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#9490
+  # source://idlc//lib/idlc/ast.rb#9578
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#9464
+  # source://idlc//lib/idlc/ast.rb#9552
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9467
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#9555
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#9480
+  # source://idlc//lib/idlc/ast.rb#9568
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#9500
+    # source://idlc//lib/idlc/ast.rb#9588
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2524,9 +2530,15 @@ class Idl::CsrReadExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#9425
+# source://idlc//lib/idlc/ast.rb#9525
+class Idl::CsrReadExpressionAst::Memo < ::T::Struct
+  prop :csr_obj, T.nilable(::Idl::Csr)
+  prop :type, T.nilable(::Idl::Type)
+end
+
+# source://idlc//lib/idlc/ast.rb#9510
 class Idl::CsrReadExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#9426
+  # source://idlc//lib/idlc/ast.rb#9511
   def to_ast; end
 end
 
@@ -2536,54 +2548,54 @@ module Idl::CsrRegisterAccessExpression0
   def csr_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#9517
+# source://idlc//lib/idlc/ast.rb#9605
 class Idl::CsrSoftwareWriteAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#9526
+  # source://idlc//lib/idlc/ast.rb#9614
   def initialize(input, interval, csr, expression); end
 
-  # source://idlc//lib/idlc/ast.rb#9521
+  # source://idlc//lib/idlc/ast.rb#9609
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9523
+  # source://idlc//lib/idlc/ast.rb#9611
   def csr; end
 
-  # source://idlc//lib/idlc/ast.rb#9540
+  # source://idlc//lib/idlc/ast.rb#9628
   def csr_known?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9544
+  # source://idlc//lib/idlc/ast.rb#9632
   def csr_name; end
 
-  # source://idlc//lib/idlc/ast.rb#9552
+  # source://idlc//lib/idlc/ast.rb#9640
   def execute(_symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9555
+  # source://idlc//lib/idlc/ast.rb#9643
   def execute_unknown(_symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9524
+  # source://idlc//lib/idlc/ast.rb#9612
   def expression; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#82
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#9562
+  # source://idlc//lib/idlc/ast.rb#9650
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#9559
+  # source://idlc//lib/idlc/ast.rb#9647
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#9530
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#9618
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#9547
+  # source://idlc//lib/idlc/ast.rb#9635
   def value(_symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#9570
+    # source://idlc//lib/idlc/ast.rb#9658
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2594,69 +2606,69 @@ class Idl::CsrSoftwareWriteAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#9511
+# source://idlc//lib/idlc/ast.rb#9599
 class Idl::CsrSoftwareWriteSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#9512
+  # source://idlc//lib/idlc/ast.rb#9600
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/type.rb#744
+# source://idlc//lib/idlc/type.rb#764
 class Idl::CsrType < ::Idl::Type
-  # source://idlc//lib/idlc/type.rb#751
+  # source://idlc//lib/idlc/type.rb#771
   sig { params(csr: ::Idl::Csr, qualifiers: T::Array[::Symbol]).void }
   def initialize(csr, qualifiers: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/type.rb#748
+  # source://idlc//lib/idlc/type.rb#768
   sig { returns(::Idl::Csr) }
   def csr; end
 
-  # source://idlc//lib/idlc/type.rb#756
+  # source://idlc//lib/idlc/type.rb#776
   sig { returns(T::Array[::Idl::CsrField]) }
   def fields; end
 end
 
-# source://idlc//lib/idlc/ast.rb#9711
+# source://idlc//lib/idlc/ast.rb#9799
 class Idl::CsrWriteAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#9719
+  # source://idlc//lib/idlc/ast.rb#9807
   def initialize(input, interval, idx); end
 
-  # source://idlc//lib/idlc/ast.rb#9715
+  # source://idlc//lib/idlc/ast.rb#9803
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9735
+  # source://idlc//lib/idlc/ast.rb#9823
   def csr_def(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9754
+  # source://idlc//lib/idlc/ast.rb#9842
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9759
+  # source://idlc//lib/idlc/ast.rb#9847
   def execute_unknown(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9717
+  # source://idlc//lib/idlc/ast.rb#9805
   def idx; end
 
-  # source://idlc//lib/idlc/ast.rb#9749
+  # source://idlc//lib/idlc/ast.rb#9837
   def name(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9766
+  # source://idlc//lib/idlc/ast.rb#9854
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#9763
+  # source://idlc//lib/idlc/ast.rb#9851
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#9745
+  # source://idlc//lib/idlc/ast.rb#9833
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9724
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#9812
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#9773
+    # source://idlc//lib/idlc/ast.rb#9861
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2667,17 +2679,17 @@ class Idl::CsrWriteAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#9707
+# source://idlc//lib/idlc/ast.rb#9795
 class Idl::CsrWriteSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#9708
+  # source://idlc//lib/idlc/ast.rb#9796
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#820
+# source://idlc//lib/idlc/ast.rb#818
 module Idl::Declaration
   interface!
 
-  # source://idlc//lib/idlc/ast.rb#830
+  # source://idlc//lib/idlc/ast.rb#828
   sig { abstract.params(symtab: ::Idl::SymbolTable).void }
   def add_symbol(symtab); end
 end
@@ -2700,36 +2712,36 @@ module Idl::Declaration1
   def type_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6471
+# source://idlc//lib/idlc/ast.rb#6532
 class Idl::DontCareLvalueAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#6477
+  # source://idlc//lib/idlc/ast.rb#6538
   def initialize(input, interval); end
 
-  # source://idlc//lib/idlc/ast.rb#6475
+  # source://idlc//lib/idlc/ast.rb#6536
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6496
+  # source://idlc//lib/idlc/ast.rb#6557
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6493
+  # source://idlc//lib/idlc/ast.rb#6554
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6485
+  # source://idlc//lib/idlc/ast.rb#6546
   def type(_symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6480
-  def type_check(_symtab); end
+  # source://idlc//lib/idlc/ast.rb#6541
+  def type_check(_symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#6490
+  # source://idlc//lib/idlc/ast.rb#6551
   def value(_symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6502
+    # source://idlc//lib/idlc/ast.rb#6563
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2740,48 +2752,48 @@ class Idl::DontCareLvalueAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6467
+# source://idlc//lib/idlc/ast.rb#6528
 class Idl::DontCareLvalueSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6468
+  # source://idlc//lib/idlc/ast.rb#6529
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6408
+# source://idlc//lib/idlc/ast.rb#6469
 class Idl::DontCareReturnAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#6414
+  # source://idlc//lib/idlc/ast.rb#6475
   def initialize(input, interval); end
 
-  # source://idlc//lib/idlc/ast.rb#6412
+  # source://idlc//lib/idlc/ast.rb#6473
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#61
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#6442
+  # source://idlc//lib/idlc/ast.rb#6503
   def set_expected_type(t); end
 
-  # source://idlc//lib/idlc/ast.rb#6450
+  # source://idlc//lib/idlc/ast.rb#6511
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6447
+  # source://idlc//lib/idlc/ast.rb#6508
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6424
+  # source://idlc//lib/idlc/ast.rb#6485
   def type(_symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6419
-  def type_check(_symtab); end
+  # source://idlc//lib/idlc/ast.rb#6480
+  def type_check(_symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#6429
+  # source://idlc//lib/idlc/ast.rb#6490
   def value(_symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6456
+    # source://idlc//lib/idlc/ast.rb#6517
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2792,20 +2804,20 @@ class Idl::DontCareReturnAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6398
+# source://idlc//lib/idlc/ast.rb#6459
 class Idl::DontCareReturnSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6399
+  # source://idlc//lib/idlc/ast.rb#6460
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#35
+# source://idlc//lib/idlc/ast.rb#33
 Idl::EMPTY_ARRAY = T.let(T.unsafe(nil), Array)
 
-# source://idlc//lib/idlc/ast.rb#8862
+# source://idlc//lib/idlc/ast.rb#8948
 class Idl::ElseIfAst < ::Idl::AstNode
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#8877
+  # source://idlc//lib/idlc/ast.rb#8963
   sig do
     params(
       input: T.nilable(::String),
@@ -2817,44 +2829,44 @@ class Idl::ElseIfAst < ::Idl::AstNode
   end
   def initialize(input, interval, body_interval, cond, body_stmts); end
 
-  # source://idlc//lib/idlc/ast.rb#8874
+  # source://idlc//lib/idlc/ast.rb#8960
   sig { returns(::Idl::IfBodyAst) }
   def body; end
 
-  # source://idlc//lib/idlc/ast.rb#8871
+  # source://idlc//lib/idlc/ast.rb#8957
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def cond; end
 
-  # source://idlc//lib/idlc/ast.rb#8866
+  # source://idlc//lib/idlc/ast.rb#8952
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#343
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#380
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#8898
+  # source://idlc//lib/idlc/ast.rb#8984
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8903
+  # source://idlc//lib/idlc/ast.rb#8989
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8914
+  # source://idlc//lib/idlc/ast.rb#9000
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8931
+  # source://idlc//lib/idlc/ast.rb#9017
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#8926
+  # source://idlc//lib/idlc/ast.rb#9012
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#8882
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8968
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#8939
+    # source://idlc//lib/idlc/ast.rb#9025
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2865,11 +2877,11 @@ class Idl::ElseIfAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1714
+# source://idlc//lib/idlc/ast.rb#1730
 class Idl::EnumArrayCastAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#1723
+  # source://idlc//lib/idlc/ast.rb#1739
   sig do
     params(
       input: T.nilable(::String),
@@ -2879,35 +2891,35 @@ class Idl::EnumArrayCastAst < ::Idl::AstNode
   end
   def initialize(input, interval, enum_class_name); end
 
-  # source://idlc//lib/idlc/ast.rb#1720
+  # source://idlc//lib/idlc/ast.rb#1736
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1717
+  # source://idlc//lib/idlc/ast.rb#1733
   def enum_class; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#132
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#1748
+  # source://idlc//lib/idlc/ast.rb#1764
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1745
+  # source://idlc//lib/idlc/ast.rb#1761
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1731
+  # source://idlc//lib/idlc/ast.rb#1747
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1727
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1743
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1740
+  # source://idlc//lib/idlc/ast.rb#1756
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1755
+    # source://idlc//lib/idlc/ast.rb#1771
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2918,17 +2930,17 @@ class Idl::EnumArrayCastAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1705
+# source://idlc//lib/idlc/ast.rb#1721
 class Idl::EnumArrayCastSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1706
+  # source://idlc//lib/idlc/ast.rb#1722
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#1630
+# source://idlc//lib/idlc/ast.rb#1646
 class Idl::EnumCastAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#1651
+  # source://idlc//lib/idlc/ast.rb#1667
   sig do
     params(
       input: T.nilable(::String),
@@ -2939,38 +2951,38 @@ class Idl::EnumCastAst < ::Idl::AstNode
   end
   def initialize(input, interval, user_type_name, expression); end
 
-  # source://idlc//lib/idlc/ast.rb#1634
+  # source://idlc//lib/idlc/ast.rb#1650
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1637
+  # source://idlc//lib/idlc/ast.rb#1653
   def enum_name; end
 
-  # source://idlc//lib/idlc/ast.rb#1640
+  # source://idlc//lib/idlc/ast.rb#1656
   def expression; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#107
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#1684
+  # source://idlc//lib/idlc/ast.rb#1700
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1681
+  # source://idlc//lib/idlc/ast.rb#1697
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1673
+  # source://idlc//lib/idlc/ast.rb#1689
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1655
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1671
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1678
+  # source://idlc//lib/idlc/ast.rb#1694
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1692
+    # source://idlc//lib/idlc/ast.rb#1708
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2981,9 +2993,9 @@ class Idl::EnumCastAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1624
+# source://idlc//lib/idlc/ast.rb#1640
 class Idl::EnumCastSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1625
+  # source://idlc//lib/idlc/ast.rb#1641
   def to_ast; end
 end
 
@@ -3021,7 +3033,7 @@ end
 class Idl::EnumDefinitionAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#1815
+  # source://idlc//lib/idlc/ast.rb#1831
   sig do
     params(
       input: T.nilable(::String),
@@ -3033,43 +3045,43 @@ class Idl::EnumDefinitionAst < ::Idl::AstNode
   end
   def initialize(input, interval, user_type, element_names, element_values); end
 
-  # source://idlc//lib/idlc/ast.rb#1864
+  # source://idlc//lib/idlc/ast.rb#1880
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1804
+  # source://idlc//lib/idlc/ast.rb#1820
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1839
+  # source://idlc//lib/idlc/ast.rb#1855
   sig { returns(T::Array[::String]) }
   def element_names; end
 
-  # source://idlc//lib/idlc/ast.rb#1849
+  # source://idlc//lib/idlc/ast.rb#1865
   sig { returns(T::Array[::Integer]) }
   def element_values; end
 
-  # source://idlc//lib/idlc/ast.rb#1880
+  # source://idlc//lib/idlc/ast.rb#1896
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#1894
+  # source://idlc//lib/idlc/ast.rb#1910
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1884
+  # source://idlc//lib/idlc/ast.rb#1900
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1872
+  # source://idlc//lib/idlc/ast.rb#1888
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1852
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1868
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1877
+  # source://idlc//lib/idlc/ast.rb#1893
   def value(_symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1907
+    # source://idlc//lib/idlc/ast.rb#1923
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3080,17 +3092,17 @@ class Idl::EnumDefinitionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1767
+# source://idlc//lib/idlc/ast.rb#1783
 class Idl::EnumDefinitionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1768
+  # source://idlc//lib/idlc/ast.rb#1784
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#1576
+# source://idlc//lib/idlc/ast.rb#1592
 class Idl::EnumElementSizeAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#1585
+  # source://idlc//lib/idlc/ast.rb#1601
   sig do
     params(
       input: T.nilable(::String),
@@ -3100,35 +3112,35 @@ class Idl::EnumElementSizeAst < ::Idl::AstNode
   end
   def initialize(input, interval, enum_class_name); end
 
-  # source://idlc//lib/idlc/ast.rb#1582
+  # source://idlc//lib/idlc/ast.rb#1598
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1579
+  # source://idlc//lib/idlc/ast.rb#1595
   def enum_class; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#127
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#1605
+  # source://idlc//lib/idlc/ast.rb#1621
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1602
+  # source://idlc//lib/idlc/ast.rb#1618
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1593
+  # source://idlc//lib/idlc/ast.rb#1609
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1589
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1605
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1597
+  # source://idlc//lib/idlc/ast.rb#1613
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1612
+    # source://idlc//lib/idlc/ast.rb#1628
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3139,9 +3151,9 @@ class Idl::EnumElementSizeAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1567
+# source://idlc//lib/idlc/ast.rb#1583
 class Idl::EnumElementSizeSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1568
+  # source://idlc//lib/idlc/ast.rb#1584
   def to_ast; end
 end
 
@@ -3154,22 +3166,22 @@ module Idl::EnumRef0
   def member; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5843
+# source://idlc//lib/idlc/ast.rb#5874
 class Idl::EnumRefAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5852
+  # source://idlc//lib/idlc/ast.rb#5887
   def initialize(input, interval, class_name, member_name); end
 
-  # source://idlc//lib/idlc/ast.rb#5849
+  # source://idlc//lib/idlc/ast.rb#5884
   def class_name; end
 
-  # source://idlc//lib/idlc/ast.rb#5847
+  # source://idlc//lib/idlc/ast.rb#5882
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5861
-  def freeze_tree(global_symtab); end
+  # source://idlc//lib/idlc/ast.rb#5895
+  def enum_def_type(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#117
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
@@ -3177,28 +3189,28 @@ class Idl::EnumRefAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#148
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#5850
+  # source://idlc//lib/idlc/ast.rb#5885
   def member_name; end
 
-  # source://idlc//lib/idlc/ast.rb#5910
+  # source://idlc//lib/idlc/ast.rb#5931
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5907
+  # source://idlc//lib/idlc/ast.rb#5928
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5884
+  # source://idlc//lib/idlc/ast.rb#5915
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5874
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5907
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5900
+  # source://idlc//lib/idlc/ast.rb#5922
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5918
+    # source://idlc//lib/idlc/ast.rb#5939
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3209,48 +3221,53 @@ class Idl::EnumRefAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5832
+# source://idlc//lib/idlc/ast.rb#5877
+class Idl::EnumRefAst::Memo < ::T::Struct
+  prop :enum_def_type, T::Hash[::Idl::SymbolTable, ::Idl::EnumerationType], default: T.unsafe(nil)
+end
+
+# source://idlc//lib/idlc/ast.rb#5863
 class Idl::EnumRefSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5833
+  # source://idlc//lib/idlc/ast.rb#5864
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#1516
+# source://idlc//lib/idlc/ast.rb#1532
 class Idl::EnumSizeAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#1524
+  # source://idlc//lib/idlc/ast.rb#1540
   def initialize(input, interval, enum_class_name); end
 
-  # source://idlc//lib/idlc/ast.rb#1522
+  # source://idlc//lib/idlc/ast.rb#1538
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1519
+  # source://idlc//lib/idlc/ast.rb#1535
   def enum_class; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#122
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#1548
+  # source://idlc//lib/idlc/ast.rb#1564
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1545
+  # source://idlc//lib/idlc/ast.rb#1561
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1532
+  # source://idlc//lib/idlc/ast.rb#1548
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1528
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1544
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1540
+  # source://idlc//lib/idlc/ast.rb#1556
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1555
+    # source://idlc//lib/idlc/ast.rb#1571
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3261,9 +3278,9 @@ class Idl::EnumSizeAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1507
+# source://idlc//lib/idlc/ast.rb#1523
 class Idl::EnumSizeSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1508
+  # source://idlc//lib/idlc/ast.rb#1524
   def to_ast; end
 end
 
@@ -3273,9 +3290,9 @@ module Idl::EnumToA0
   def user_type_name; end
 end
 
-# source://idlc//lib/idlc/type.rb#641
+# source://idlc//lib/idlc/type.rb#14
 class Idl::EnumerationType < ::Idl::Type
-  # source://idlc//lib/idlc/type.rb#671
+  # source://idlc//lib/idlc/type.rb#690
   sig do
     params(
       type_name: ::String,
@@ -3286,53 +3303,53 @@ class Idl::EnumerationType < ::Idl::Type
   end
   def initialize(type_name, element_names, element_values, builtin: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/type.rb#686
+  # source://idlc//lib/idlc/type.rb#705
   sig { returns(T::Boolean) }
   def builtin?; end
 
-  # source://idlc//lib/idlc/type.rb#689
+  # source://idlc//lib/idlc/type.rb#708
   sig { returns(::Idl::EnumerationType) }
   def clone; end
 
-  # source://idlc//lib/idlc/type.rb#702
+  # source://idlc//lib/idlc/type.rb#721
   sig { params(element_value: ::Integer).returns(T.nilable(::String)) }
   def element_name(element_value); end
 
-  # source://idlc//lib/idlc/type.rb#650
+  # source://idlc//lib/idlc/type.rb#669
   sig { returns(T::Array[::String]) }
   def element_names; end
 
-  # source://idlc//lib/idlc/type.rb#654
+  # source://idlc//lib/idlc/type.rb#673
   sig { returns(T::Array[::Integer]) }
   def element_values; end
 
-  # source://idlc//lib/idlc/type.rb#658
+  # source://idlc//lib/idlc/type.rb#677
   sig { returns(::Idl::Type) }
   def ref_type; end
 
-  # source://idlc//lib/idlc/type.rb#694
+  # source://idlc//lib/idlc/type.rb#713
   sig { params(element_name: ::String).returns(T.nilable(::Integer)) }
   def value(element_name); end
 
-  # source://idlc//lib/idlc/type.rb#646
+  # source://idlc//lib/idlc/type.rb#665
   sig { returns(::Integer) }
   def width; end
 end
 
-# source://idlc//lib/idlc/ast.rb#591
+# source://idlc//lib/idlc/ast.rb#589
 module Idl::Executable
   interface!
 
-  # source://idlc//lib/idlc/ast.rb#613
+  # source://idlc//lib/idlc/ast.rb#611
   sig { abstract.params(symtab: ::Idl::SymbolTable).void }
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#617
+  # source://idlc//lib/idlc/ast.rb#615
   sig { abstract.params(symtab: ::Idl::SymbolTable).void }
   def execute_unknown(symtab); end
 end
 
-# source://idlc//lib/idlc/ast.rb#620
+# source://idlc//lib/idlc/ast.rb#618
 Idl::ExecutableAst = T.type_alias { T.all(::Idl::AstNode, ::Idl::Executable) }
 
 # source://idlc//lib/idlc/idl_parser.rb#13702
@@ -3383,15 +3400,15 @@ module Idl::ExecuteIfBlock5
   def if_cond; end
 end
 
-# source://idlc//lib/idlc/ast.rb#916
+# source://idlc//lib/idlc/ast.rb#914
 class Idl::FalseExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#920
+  # source://idlc//lib/idlc/ast.rb#918
   sig { params(input: ::String, interval: T::Range[::Integer]).void }
   def initialize(input, interval); end
 
-  # source://idlc//lib/idlc/ast.rb#925
+  # source://idlc//lib/idlc/ast.rb#923
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
@@ -3401,28 +3418,28 @@ class Idl::FalseExpressionAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#93
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#940
+  # source://idlc//lib/idlc/ast.rb#938
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#937
+  # source://idlc//lib/idlc/ast.rb#935
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#931
+  # source://idlc//lib/idlc/ast.rb#929
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#928
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#926
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#934
+  # source://idlc//lib/idlc/ast.rb#932
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::FalseClass) }
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#946
+    # source://idlc//lib/idlc/ast.rb#944
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3433,9 +3450,9 @@ class Idl::FalseExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#912
+# source://idlc//lib/idlc/ast.rb#910
 class Idl::FalseExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#913
+  # source://idlc//lib/idlc/ast.rb#911
   def to_ast; end
 end
 
@@ -3445,9 +3462,9 @@ module Idl::Fetch0
   def function_body; end
 end
 
-# source://idlc//lib/idlc/ast.rb#7982
+# source://idlc//lib/idlc/ast.rb#1250
 class Idl::FetchAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#7989
+  # source://idlc//lib/idlc/ast.rb#8075
   sig do
     params(
       input: T.nilable(::String),
@@ -3457,29 +3474,29 @@ class Idl::FetchAst < ::Idl::AstNode
   end
   def initialize(input, interval, body); end
 
-  # source://idlc//lib/idlc/ast.rb#7986
+  # source://idlc//lib/idlc/ast.rb#8072
   def body; end
 
-  # source://idlc//lib/idlc/ast.rb#7984
+  # source://idlc//lib/idlc/ast.rb#8070
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7997
+  # source://idlc//lib/idlc/ast.rb#8083
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8011
+  # source://idlc//lib/idlc/ast.rb#8097
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#8002
+  # source://idlc//lib/idlc/ast.rb#8088
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#7993
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8079
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#8018
+    # source://idlc//lib/idlc/ast.rb#8104
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3490,9 +3507,9 @@ class Idl::FetchAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#7976
+# source://idlc//lib/idlc/ast.rb#8062
 class Idl::FetchSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#7977
+  # source://idlc//lib/idlc/ast.rb#8063
   def to_ast; end
 end
 
@@ -3505,11 +3522,11 @@ module Idl::FieldAccessExpression0
   def field_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5744
+# source://idlc//lib/idlc/ast.rb#5775
 class Idl::FieldAccessExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5754
+  # source://idlc//lib/idlc/ast.rb#5785
   sig do
     params(
       input: T.nilable(::String),
@@ -3520,39 +3537,39 @@ class Idl::FieldAccessExpressionAst < ::Idl::AstNode
   end
   def initialize(input, interval, bitfield, field_name); end
 
-  # source://idlc//lib/idlc/ast.rb#5748
+  # source://idlc//lib/idlc/ast.rb#5779
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#87
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5760
+  # source://idlc//lib/idlc/ast.rb#5791
   def kind(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5751
+  # source://idlc//lib/idlc/ast.rb#5782
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def obj; end
 
-  # source://idlc//lib/idlc/ast.rb#5811
+  # source://idlc//lib/idlc/ast.rb#5842
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5808
+  # source://idlc//lib/idlc/ast.rb#5839
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5765
+  # source://idlc//lib/idlc/ast.rb#5796
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5777
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5808
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5795
+  # source://idlc//lib/idlc/ast.rb#5826
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5819
+    # source://idlc//lib/idlc/ast.rb#5850
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3563,17 +3580,17 @@ class Idl::FieldAccessExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5734
+# source://idlc//lib/idlc/ast.rb#5765
 class Idl::FieldAccessExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5735
+  # source://idlc//lib/idlc/ast.rb#5766
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#3102
+# source://idlc//lib/idlc/ast.rb#3118
 class Idl::FieldAssignmentAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#3130
+  # source://idlc//lib/idlc/ast.rb#3146
   sig do
     params(
       input: T.nilable(::String),
@@ -3585,47 +3602,47 @@ class Idl::FieldAssignmentAst < ::Idl::AstNode
   end
   def initialize(input, interval, id, field_name, rhs); end
 
-  # source://idlc//lib/idlc/ast.rb#3115
+  # source://idlc//lib/idlc/ast.rb#3131
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3175
+  # source://idlc//lib/idlc/ast.rb#3191
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3198
+  # source://idlc//lib/idlc/ast.rb#3214
   def execute_unknown(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3112
+  # source://idlc//lib/idlc/ast.rb#3128
   sig { returns(::String) }
   def field_name; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#92
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3106
+  # source://idlc//lib/idlc/ast.rb#3122
   sig { returns(::Idl::IdAst) }
   def id; end
 
-  # source://idlc//lib/idlc/ast.rb#3109
+  # source://idlc//lib/idlc/ast.rb#3125
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#3208
+  # source://idlc//lib/idlc/ast.rb#3224
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#3205
+  # source://idlc//lib/idlc/ast.rb#3221
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#3136
+  # source://idlc//lib/idlc/ast.rb#3152
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3150
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#3166
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#3217
+    # source://idlc//lib/idlc/ast.rb#3233
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3636,9 +3653,9 @@ class Idl::FieldAssignmentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#3090
+# source://idlc//lib/idlc/ast.rb#3106
 class Idl::FieldAssignmentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3091
+  # source://idlc//lib/idlc/ast.rb#3107
   def to_ast; end
 end
 
@@ -3666,38 +3683,38 @@ module Idl::ForLoop1
   def stmts; end
 end
 
-# source://idlc//lib/idlc/ast.rb#8511
+# source://idlc//lib/idlc/ast.rb#8597
 class Idl::ForLoopAst < ::Idl::AstNode
   include ::Idl::Executable
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#8536
+  # source://idlc//lib/idlc/ast.rb#8622
   def initialize(input, interval, init, condition, update, stmts); end
 
-  # source://idlc//lib/idlc/ast.rb#8527
+  # source://idlc//lib/idlc/ast.rb#8613
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def condition; end
 
-  # source://idlc//lib/idlc/ast.rb#8516
+  # source://idlc//lib/idlc/ast.rb#8602
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8654
+  # source://idlc//lib/idlc/ast.rb#8740
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8657
+  # source://idlc//lib/idlc/ast.rb#8743
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#202
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#8524
+  # source://idlc//lib/idlc/ast.rb#8610
   sig { returns(::Idl::VariableDeclarationWithInitializationAst) }
   def init; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#118
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#136
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
   # source://idlc//lib/idlc/passes/reachable_exceptions.rb#197
   def reachable_exceptions(symtab, cache = T.unsafe(nil)); end
@@ -3705,43 +3722,43 @@ class Idl::ForLoopAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/reachable_functions.rb#174
   def reachable_functions(symtab, cache = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#8603
+  # source://idlc//lib/idlc/ast.rb#8689
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8570
+  # source://idlc//lib/idlc/ast.rb#8656
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8609
+  # source://idlc//lib/idlc/ast.rb#8695
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8553
+  # source://idlc//lib/idlc/ast.rb#8639
   sig { params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def satisfied?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8534
+  # source://idlc//lib/idlc/ast.rb#8620
   sig do
     returns(T::Array[T.any(::Idl::ForLoopAst, ::Idl::IfAst, ::Idl::ImplicationStatementAst, ::Idl::ReturnStatementAst, ::Idl::StatementAst)])
   end
   def stmts; end
 
-  # source://idlc//lib/idlc/ast.rb#8689
+  # source://idlc//lib/idlc/ast.rb#8775
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#8679
+  # source://idlc//lib/idlc/ast.rb#8765
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#8541
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8627
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#8530
+  # source://idlc//lib/idlc/ast.rb#8616
   sig { returns(T.all(::Idl::AstNode, ::Idl::Executable)) }
   def update; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#8699
+    # source://idlc//lib/idlc/ast.rb#8785
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3752,7 +3769,7 @@ class Idl::ForLoopAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#8532
+# source://idlc//lib/idlc/ast.rb#8618
 Idl::ForLoopAst::StmtType = T.type_alias { T.any(::Idl::ForLoopAst, ::Idl::IfAst, ::Idl::ImplicationStatementAst, ::Idl::ReturnStatementAst, ::Idl::StatementAst) }
 
 # source://idlc//lib/idlc/idl_parser.rb#12060
@@ -3770,15 +3787,15 @@ module Idl::ForLoopIterationVariableDeclaration0
   def type_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#3703
+# source://idlc//lib/idlc/ast.rb#3719
 class Idl::ForLoopIterationVariableDeclarationSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3704
+  # source://idlc//lib/idlc/ast.rb#3720
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#8499
+# source://idlc//lib/idlc/ast.rb#8585
 class Idl::ForLoopSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#8500
+  # source://idlc//lib/idlc/ast.rb#8586
   def to_ast; end
 end
 
@@ -3809,12 +3826,12 @@ module Idl::FunctionBody1
   def func_stmt_list; end
 end
 
-# source://idlc//lib/idlc/ast.rb#7837
+# source://idlc//lib/idlc/ast.rb#7923
 class Idl::FunctionBodyAst < ::Idl::AstNode
   include ::Idl::Executable
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#7849
+  # source://idlc//lib/idlc/ast.rb#7935
   sig do
     params(
       input: T.nilable(::String),
@@ -3824,14 +3841,14 @@ class Idl::FunctionBodyAst < ::Idl::AstNode
   end
   def initialize(input, interval, stmts); end
 
-  # source://idlc//lib/idlc/ast.rb#7842
+  # source://idlc//lib/idlc/ast.rb#7928
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7912
+  # source://idlc//lib/idlc/ast.rb#7998
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7915
+  # source://idlc//lib/idlc/ast.rb#8001
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def execute_unknown(symtab); end
 
@@ -3844,37 +3861,37 @@ class Idl::FunctionBodyAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/find_return_values.rb#67
   def pass_find_return_values(symtab); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#161
-  def prune(symtab, args_already_applied: T.unsafe(nil)); end
+  # source://idlc//lib/idlc/passes/prune.rb#191
+  def prune(symtab, forced_type: T.unsafe(nil), args_already_applied: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#7881
+  # source://idlc//lib/idlc/ast.rb#7967
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7896
+  # source://idlc//lib/idlc/ast.rb#7982
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7922
+  # source://idlc//lib/idlc/ast.rb#8008
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7853
+  # source://idlc//lib/idlc/ast.rb#7939
   def statements; end
 
-  # source://idlc//lib/idlc/ast.rb#7855
+  # source://idlc//lib/idlc/ast.rb#7941
   def stmts; end
 
-  # source://idlc//lib/idlc/ast.rb#7957
+  # source://idlc//lib/idlc/ast.rb#8043
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#7952
+  # source://idlc//lib/idlc/ast.rb#8038
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#7858
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#7944
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#7964
+    # source://idlc//lib/idlc/ast.rb#8050
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3885,9 +3902,9 @@ class Idl::FunctionBodyAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#7830
+# source://idlc//lib/idlc/ast.rb#7916
 class Idl::FunctionBodySyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#7832
+  # source://idlc//lib/idlc/ast.rb#7918
   def to_ast; end
 end
 
@@ -3930,31 +3947,31 @@ module Idl::FunctionCall3
   def t; end
 end
 
-# source://idlc//lib/idlc/ast.rb#7504
+# source://idlc//lib/idlc/ast.rb#7590
 class Idl::FunctionCallExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#7519
+  # source://idlc//lib/idlc/ast.rb#7605
   def initialize(input, interval, function_name, targs, args); end
 
-  # source://idlc//lib/idlc/ast.rb#7561
+  # source://idlc//lib/idlc/ast.rb#7647
   def arg_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#7517
+  # source://idlc//lib/idlc/ast.rb#7603
   def args; end
 
-  # source://idlc//lib/idlc/ast.rb#7510
+  # source://idlc//lib/idlc/ast.rb#7596
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7717
+  # source://idlc//lib/idlc/ast.rb#7803
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7725
+  # source://idlc//lib/idlc/ast.rb#7811
   def execute_unknown(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7565
+  # source://idlc//lib/idlc/ast.rb#7651
   def func_type(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#289
@@ -3963,11 +3980,11 @@ class Idl::FunctionCallExpressionAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#28
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#7719
+  # source://idlc//lib/idlc/ast.rb#7805
   def name; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#82
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#89
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
   # source://idlc//lib/idlc/passes/reachable_exceptions.rb#25
   def reachable_exceptions(symtab, cache = T.unsafe(nil)); end
@@ -3975,37 +3992,37 @@ class Idl::FunctionCallExpressionAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/reachable_functions.rb#21
   def reachable_functions(symtab, cache = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#7516
+  # source://idlc//lib/idlc/ast.rb#7602
   def targs; end
 
-  # source://idlc//lib/idlc/ast.rb#7532
+  # source://idlc//lib/idlc/ast.rb#7618
   def template?; end
 
-  # source://idlc//lib/idlc/ast.rb#7537
+  # source://idlc//lib/idlc/ast.rb#7623
   def template_arg_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#7541
+  # source://idlc//lib/idlc/ast.rb#7627
   def template_values(symtab, unknown_ok: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#7738
+  # source://idlc//lib/idlc/ast.rb#7824
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#7729
+  # source://idlc//lib/idlc/ast.rb#7815
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#7631
+  # source://idlc//lib/idlc/ast.rb#7717
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7580
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#7666
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#7640
+  # source://idlc//lib/idlc/ast.rb#7726
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#7749
+    # source://idlc//lib/idlc/ast.rb#7835
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4016,9 +4033,9 @@ class Idl::FunctionCallExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#7494
+# source://idlc//lib/idlc/ast.rb#7580
 class Idl::FunctionCallExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#7495
+  # source://idlc//lib/idlc/ast.rb#7581
   def to_ast; end
 end
 
@@ -4037,120 +4054,120 @@ module Idl::FunctionCallTemplateArguments1
   def rest; end
 end
 
-# source://idlc//lib/idlc/ast.rb#8050
+# source://idlc//lib/idlc/ast.rb#8136
 class Idl::FunctionDefAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#8074
+  # source://idlc//lib/idlc/ast.rb#8160
   def initialize(input, interval, name, targs, return_types, arguments, desc, type, body); end
 
-  # source://idlc//lib/idlc/ast.rb#8055
+  # source://idlc//lib/idlc/ast.rb#8141
   def <=>(other); end
 
-  # source://idlc//lib/idlc/ast.rb#8342
+  # source://idlc//lib/idlc/ast.rb#8428
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8304
+  # source://idlc//lib/idlc/ast.rb#8390
   def apply_template_and_arg_syms(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8095
+  # source://idlc//lib/idlc/ast.rb#8181
   def argument_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#8125
+  # source://idlc//lib/idlc/ast.rb#8211
   def arguments(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8156
+  # source://idlc//lib/idlc/ast.rb#8242
   def arguments_list_str; end
 
-  # source://idlc//lib/idlc/ast.rb#8394
+  # source://idlc//lib/idlc/ast.rb#8480
   def body; end
 
-  # source://idlc//lib/idlc/ast.rb#8400
+  # source://idlc//lib/idlc/ast.rb#8486
   def builtin?; end
 
-  # source://idlc//lib/idlc/ast.rb#8236
+  # source://idlc//lib/idlc/ast.rb#8322
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8110
+  # source://idlc//lib/idlc/ast.rb#8196
   def description; end
 
-  # source://idlc//lib/idlc/ast.rb#8061
+  # source://idlc//lib/idlc/ast.rb#8147
   def eql?(other); end
 
-  # source://idlc//lib/idlc/ast.rb#8408
+  # source://idlc//lib/idlc/ast.rb#8494
   def external?; end
 
-  # source://idlc//lib/idlc/ast.rb#8098
+  # source://idlc//lib/idlc/ast.rb#8184
   def freeze_tree(global_symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8404
+  # source://idlc//lib/idlc/ast.rb#8490
   def generated?; end
 
-  # source://idlc//lib/idlc/ast.rb#8265
+  # source://idlc//lib/idlc/ast.rb#8351
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#8120
+  # source://idlc//lib/idlc/ast.rb#8206
   def num_args; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#141
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#159
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#8412
+  # source://idlc//lib/idlc/ast.rb#8498
   def qualifier_str; end
 
-  # source://idlc//lib/idlc/ast.rb#8095
+  # source://idlc//lib/idlc/ast.rb#8181
   def reachable_functions_cache; end
 
-  # source://idlc//lib/idlc/ast.rb#8161
+  # source://idlc//lib/idlc/ast.rb#8247
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8224
+  # source://idlc//lib/idlc/ast.rb#8310
   def return_type_list_str; end
 
-  # source://idlc//lib/idlc/ast.rb#8053
+  # source://idlc//lib/idlc/ast.rb#8139
   def return_type_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#8356
+  # source://idlc//lib/idlc/ast.rb#8442
   def template_names; end
 
-  # source://idlc//lib/idlc/ast.rb#8362
+  # source://idlc//lib/idlc/ast.rb#8448
   def template_types(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8115
+  # source://idlc//lib/idlc/ast.rb#8201
   def templated?; end
 
-  # source://idlc//lib/idlc/ast.rb#8468
+  # source://idlc//lib/idlc/ast.rb#8554
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#8425
+  # source://idlc//lib/idlc/ast.rb#8511
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#8315
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8401
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#8384
-  def type_check_args(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8470
+  def type_check_args(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#8388
-  def type_check_body(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8474
+  def type_check_body(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#8288
-  def type_check_from_call(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8374
+  def type_check_from_call(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#8380
-  def type_check_return(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8466
+  def type_check_return(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#8375
+  # source://idlc//lib/idlc/ast.rb#8461
   def type_check_targs(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8270
-  def type_check_template_instance(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8356
+  def type_check_template_instance(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#8481
+    # source://idlc//lib/idlc/ast.rb#8567
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4161,9 +4178,9 @@ class Idl::FunctionDefAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#8030
+# source://idlc//lib/idlc/ast.rb#8116
 class Idl::FunctionDefSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#8031
+  # source://idlc//lib/idlc/ast.rb#8117
   def to_ast; end
 end
 
@@ -4218,12 +4235,12 @@ end
 # source://idlc//lib/idlc/idl_parser.rb#9334
 module Idl::FunctionName0; end
 
-# source://idlc//lib/idlc/type.rb#763
+# source://idlc//lib/idlc/type.rb#783
 class Idl::FunctionType < ::Idl::Type
-  # source://idlc//lib/idlc/type.rb#766
+  # source://idlc//lib/idlc/type.rb#786
   def initialize(func_name, func_def_ast, symtab); end
 
-  # source://idlc//lib/idlc/type.rb#845
+  # source://idlc//lib/idlc/type.rb#865
   sig do
     params(
       symtab: ::Idl::SymbolTable,
@@ -4234,40 +4251,40 @@ class Idl::FunctionType < ::Idl::Type
   end
   def apply_arguments(symtab, argument_nodes, call_site_symtab, func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#816
+  # source://idlc//lib/idlc/type.rb#836
   def apply_template_values(template_values, func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#949
+  # source://idlc//lib/idlc/type.rb#969
   def argument_name(index, template_values = T.unsafe(nil), func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#934
+  # source://idlc//lib/idlc/type.rb#954
   def argument_type(index, template_values, argument_nodes, call_site_symtab, func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#866
+  # source://idlc//lib/idlc/type.rb#886
   def argument_values(symtab, argument_nodes, call_site_symtab, func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#964
+  # source://idlc//lib/idlc/type.rb#984
   def body; end
 
-  # source://idlc//lib/idlc/type.rb#778
+  # source://idlc//lib/idlc/type.rb#798
   def builtin?; end
 
-  # source://idlc//lib/idlc/type.rb#774
+  # source://idlc//lib/idlc/type.rb#794
   def clone; end
 
-  # source://idlc//lib/idlc/type.rb#782
+  # source://idlc//lib/idlc/type.rb#802
   def external?; end
 
-  # source://idlc//lib/idlc/type.rb#764
+  # source://idlc//lib/idlc/type.rb#784
   def func_def_ast; end
 
-  # source://idlc//lib/idlc/type.rb#780
+  # source://idlc//lib/idlc/type.rb#800
   def generated?; end
 
-  # source://idlc//lib/idlc/type.rb#784
+  # source://idlc//lib/idlc/type.rb#804
   def num_args; end
 
-  # source://idlc//lib/idlc/type.rb#892
+  # source://idlc//lib/idlc/type.rb#912
   sig do
     params(
       template_values: T::Array[::Integer],
@@ -4277,61 +4294,61 @@ class Idl::FunctionType < ::Idl::Type
   end
   def return_type(template_values, argument_nodes, func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#921
+  # source://idlc//lib/idlc/type.rb#941
   def return_types(template_values, argument_nodes, call_site_symtab, func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#905
+  # source://idlc//lib/idlc/type.rb#925
   def return_value(template_values, argument_nodes, call_site_symtab, func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#810
+  # source://idlc//lib/idlc/type.rb#830
   def template_names; end
 
-  # source://idlc//lib/idlc/type.rb#812
+  # source://idlc//lib/idlc/type.rb#832
   def template_types(symtab); end
 
-  # source://idlc//lib/idlc/type.rb#814
+  # source://idlc//lib/idlc/type.rb#834
   def templated?; end
 
-  # source://idlc//lib/idlc/type.rb#786
+  # source://idlc//lib/idlc/type.rb#806
   def type_check_call(template_values, argument_nodes, call_site_symtab, func_call_ast); end
 end
 
-# source://idlc//lib/idlc/ast.rb#1182
+# source://idlc//lib/idlc/ast.rb#1180
 class Idl::GlobalAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#1197
+  # source://idlc//lib/idlc/ast.rb#1195
   def initialize(input, interval, declaration); end
 
-  # source://idlc//lib/idlc/ast.rb#1210
+  # source://idlc//lib/idlc/ast.rb#1208
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1186
+  # source://idlc//lib/idlc/ast.rb#1184
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1193
+  # source://idlc//lib/idlc/ast.rb#1191
   def declaration; end
 
-  # source://idlc//lib/idlc/ast.rb#1188
+  # source://idlc//lib/idlc/ast.rb#1186
   def id; end
 
-  # source://idlc//lib/idlc/ast.rb#1220
+  # source://idlc//lib/idlc/ast.rb#1218
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1217
+  # source://idlc//lib/idlc/ast.rb#1215
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1206
+  # source://idlc//lib/idlc/ast.rb#1204
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1202
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1200
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1227
+    # source://idlc//lib/idlc/ast.rb#1225
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4360,64 +4377,64 @@ module Idl::GlobalDefinition2
   def declaration; end
 end
 
-# source://idlc//lib/idlc/ast.rb#1176
+# source://idlc//lib/idlc/ast.rb#1174
 class Idl::GlobalSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1177
+  # source://idlc//lib/idlc/ast.rb#1175
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#1102
+# source://idlc//lib/idlc/ast.rb#1100
 class Idl::GlobalWithInitializationAst < ::Idl::AstNode
   include ::Idl::Executable
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#1117
+  # source://idlc//lib/idlc/ast.rb#1115
   def initialize(input, interval, var_decl_with_init); end
 
-  # source://idlc//lib/idlc/ast.rb#1144
+  # source://idlc//lib/idlc/ast.rb#1142
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1110
+  # source://idlc//lib/idlc/ast.rb#1108
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1138
+  # source://idlc//lib/idlc/ast.rb#1136
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1141
+  # source://idlc//lib/idlc/ast.rb#1139
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def execute_unknown(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1106
+  # source://idlc//lib/idlc/ast.rb#1104
   def id; end
 
-  # source://idlc//lib/idlc/ast.rb#1107
+  # source://idlc//lib/idlc/ast.rb#1105
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#1158
+  # source://idlc//lib/idlc/ast.rb#1156
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1153
+  # source://idlc//lib/idlc/ast.rb#1151
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1128
+  # source://idlc//lib/idlc/ast.rb#1126
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1123
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1121
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1133
+  # source://idlc//lib/idlc/ast.rb#1131
   def value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1113
+  # source://idlc//lib/idlc/ast.rb#1111
   def var_decl_with_init; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1165
+    # source://idlc//lib/idlc/ast.rb#1163
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4428,28 +4445,28 @@ class Idl::GlobalWithInitializationAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1087
+# source://idlc//lib/idlc/ast.rb#1085
 class Idl::GlobalWithInitializationSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1088
+  # source://idlc//lib/idlc/ast.rb#1086
   def to_ast; end
 end
 
 # source://idlc//lib/idlc/idl_parser.rb#16283
 module Idl::Id0; end
 
-# source://idlc//lib/idlc/ast.rb#964
+# source://idlc//lib/idlc/ast.rb#962
 class Idl::IdAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#978
+  # source://idlc//lib/idlc/ast.rb#976
   sig { params(input: ::String, interval: T::Range[::Integer], name: ::String).void }
   def initialize(input, interval, name); end
 
-  # source://idlc//lib/idlc/ast.rb#1009
+  # source://idlc//lib/idlc/ast.rb#1007
   sig { returns(T::Boolean) }
   def const?; end
 
-  # source://idlc//lib/idlc/ast.rb#968
+  # source://idlc//lib/idlc/ast.rb#966
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
@@ -4459,42 +4476,42 @@ class Idl::IdAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#97
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#1025
+  # source://idlc//lib/idlc/ast.rb#1023
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T.any(::Integer, ::Symbol)) }
   def max_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1043
+  # source://idlc//lib/idlc/ast.rb#1041
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T.any(::Integer, ::Symbol)) }
   def min_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#972
+  # source://idlc//lib/idlc/ast.rb#970
   sig { returns(::String) }
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#975
+  # source://idlc//lib/idlc/ast.rb#973
   sig { override.returns(::String) }
   def text_value; end
 
-  # source://idlc//lib/idlc/ast.rb#1065
+  # source://idlc//lib/idlc/ast.rb#1063
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1062
+  # source://idlc//lib/idlc/ast.rb#1060
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#991
+  # source://idlc//lib/idlc/ast.rb#989
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#985
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#983
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1012
+  # source://idlc//lib/idlc/ast.rb#1010
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1072
+    # source://idlc//lib/idlc/ast.rb#1070
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4505,35 +4522,35 @@ class Idl::IdAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#957
+# source://idlc//lib/idlc/ast.rb#955
 class Idl::IdSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#958
+  # source://idlc//lib/idlc/ast.rb#956
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#8989
+# source://idlc//lib/idlc/ast.rb#9075
 class Idl::IfAst < ::Idl::AstNode
   include ::Idl::Executable
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#9013
+  # source://idlc//lib/idlc/ast.rb#9099
   def initialize(input, interval, if_cond, if_body, elseifs, final_else_body); end
 
-  # source://idlc//lib/idlc/ast.rb#8994
+  # source://idlc//lib/idlc/ast.rb#9080
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9008
+  # source://idlc//lib/idlc/ast.rb#9094
   sig { returns(T::Array[::Idl::ElseIfAst]) }
   def elseifs; end
 
-  # source://idlc//lib/idlc/ast.rb#9182
+  # source://idlc//lib/idlc/ast.rb#9268
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9228
+  # source://idlc//lib/idlc/ast.rb#9314
   def execute_unknown(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9011
+  # source://idlc//lib/idlc/ast.rb#9097
   sig { returns(::Idl::IfBodyAst) }
   def final_else_body; end
 
@@ -4543,19 +4560,19 @@ class Idl::IfAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#34
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#9005
+  # source://idlc//lib/idlc/ast.rb#9091
   sig { returns(::Idl::IfBodyAst) }
   def if_body; end
 
-  # source://idlc//lib/idlc/ast.rb#9002
+  # source://idlc//lib/idlc/ast.rb#9088
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def if_cond; end
 
   # source://idlc//lib/idlc/passes/find_return_values.rb#35
   def pass_find_return_values(values, current_conditions, symtab); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#355
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#392
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
   # source://idlc//lib/idlc/passes/reachable_exceptions.rb#101
   def reachable_exceptions(symtab, cache = T.unsafe(nil)); end
@@ -4563,43 +4580,43 @@ class Idl::IfAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/reachable_functions.rb#84
   def reachable_functions(symtab, cache = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#9075
+  # source://idlc//lib/idlc/ast.rb#9161
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9084
+  # source://idlc//lib/idlc/ast.rb#9170
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9125
+  # source://idlc//lib/idlc/ast.rb#9211
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9062
+  # source://idlc//lib/idlc/ast.rb#9148
   def taken_body(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9251
+  # source://idlc//lib/idlc/ast.rb#9337
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#9235
+  # source://idlc//lib/idlc/ast.rb#9321
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#9024
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#9110
+  def type_check(symtab, strict:); end
 
   private
 
-  # source://idlc//lib/idlc/ast.rb#9143
+  # source://idlc//lib/idlc/ast.rb#9229
   def execute_after_if(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9219
+  # source://idlc//lib/idlc/ast.rb#9305
   def execute_unknown_after_if(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9093
+  # source://idlc//lib/idlc/ast.rb#9179
   def return_values_after_if(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#9261
+    # source://idlc//lib/idlc/ast.rb#9347
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4610,12 +4627,12 @@ class Idl::IfAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#8714
+# source://idlc//lib/idlc/ast.rb#8800
 class Idl::IfBodyAst < ::Idl::AstNode
   include ::Idl::Executable
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#8727
+  # source://idlc//lib/idlc/ast.rb#8813
   sig do
     params(
       input: T.nilable(::String),
@@ -4625,14 +4642,14 @@ class Idl::IfBodyAst < ::Idl::AstNode
   end
   def initialize(input, interval, body_stmts); end
 
-  # source://idlc//lib/idlc/ast.rb#8719
+  # source://idlc//lib/idlc/ast.rb#8805
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8804
+  # source://idlc//lib/idlc/ast.rb#8890
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8830
+  # source://idlc//lib/idlc/ast.rb#8916
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#35
@@ -4641,36 +4658,36 @@ class Idl::IfBodyAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#71
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#331
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#368
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#8749
+  # source://idlc//lib/idlc/ast.rb#8835
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8755
+  # source://idlc//lib/idlc/ast.rb#8841
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8776
+  # source://idlc//lib/idlc/ast.rb#8862
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8724
+  # source://idlc//lib/idlc/ast.rb#8810
   sig { returns(T::Array[::Idl::StatementAst]) }
   def stmts; end
 
-  # source://idlc//lib/idlc/ast.rb#8843
+  # source://idlc//lib/idlc/ast.rb#8929
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#8838
+  # source://idlc//lib/idlc/ast.rb#8924
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#8736
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8822
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#8850
+    # source://idlc//lib/idlc/ast.rb#8936
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4681,9 +4698,9 @@ class Idl::IfBodyAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#8954
+# source://idlc//lib/idlc/ast.rb#9040
 class Idl::IfSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#8955
+  # source://idlc//lib/idlc/ast.rb#9041
   def to_ast; end
 end
 
@@ -4705,9 +4722,9 @@ module Idl::ImplicationExpression1
   def consequent; end
 end
 
-# source://idlc//lib/idlc/ast.rb#3974
+# source://idlc//lib/idlc/ast.rb#3990
 class Idl::ImplicationExpressionAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#3983
+  # source://idlc//lib/idlc/ast.rb#3999
   sig do
     params(
       input: T.nilable(::String),
@@ -4718,36 +4735,36 @@ class Idl::ImplicationExpressionAst < ::Idl::AstNode
   end
   def initialize(input, interval, antecedent, consequent); end
 
-  # source://idlc//lib/idlc/ast.rb#3994
+  # source://idlc//lib/idlc/ast.rb#4010
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def antecedent; end
 
-  # source://idlc//lib/idlc/ast.rb#3997
+  # source://idlc//lib/idlc/ast.rb#4013
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def consequent; end
 
-  # source://idlc//lib/idlc/ast.rb#3989
+  # source://idlc//lib/idlc/ast.rb#4005
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4006
+  # source://idlc//lib/idlc/ast.rb#4022
   sig { params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def satisfied?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4015
+  # source://idlc//lib/idlc/ast.rb#4031
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#4012
+  # source://idlc//lib/idlc/ast.rb#4028
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#4000
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#4016
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#4023
+    # source://idlc//lib/idlc/ast.rb#4039
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4758,9 +4775,9 @@ class Idl::ImplicationExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#3963
+# source://idlc//lib/idlc/ast.rb#3979
 class Idl::ImplicationExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3965
+  # source://idlc//lib/idlc/ast.rb#3981
   sig { override.returns(::Idl::ImplicationExpressionAst) }
   def to_ast; end
 end
@@ -4792,9 +4809,9 @@ module Idl::ImplicationStatement0
   def implication_expression; end
 end
 
-# source://idlc//lib/idlc/ast.rb#4043
+# source://idlc//lib/idlc/ast.rb#4059
 class Idl::ImplicationStatementAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#4051
+  # source://idlc//lib/idlc/ast.rb#4067
   sig do
     params(
       input: ::String,
@@ -4804,32 +4821,32 @@ class Idl::ImplicationStatementAst < ::Idl::AstNode
   end
   def initialize(input, interval, implication_expression); end
 
-  # source://idlc//lib/idlc/ast.rb#4056
+  # source://idlc//lib/idlc/ast.rb#4072
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4059
+  # source://idlc//lib/idlc/ast.rb#4075
   sig { returns(::Idl::ImplicationExpressionAst) }
   def expression; end
 
-  # source://idlc//lib/idlc/ast.rb#4067
+  # source://idlc//lib/idlc/ast.rb#4083
   sig { params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def satisfied?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4075
+  # source://idlc//lib/idlc/ast.rb#4091
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#4072
+  # source://idlc//lib/idlc/ast.rb#4088
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#4062
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#4078
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#4082
+    # source://idlc//lib/idlc/ast.rb#4098
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4840,9 +4857,9 @@ class Idl::ImplicationStatementAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#4036
+# source://idlc//lib/idlc/ast.rb#4052
 class Idl::ImplicationStatementSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#4038
+  # source://idlc//lib/idlc/ast.rb#4054
   sig { override.returns(::Idl::ImplicationStatementAst) }
   def to_ast; end
 end
@@ -4853,35 +4870,35 @@ module Idl::IncludeStatement0
   def string; end
 end
 
-# source://idlc//lib/idlc/ast.rb#841
+# source://idlc//lib/idlc/ast.rb#839
 class Idl::IncludeStatementAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#850
+  # source://idlc//lib/idlc/ast.rb#848
   sig { params(input: ::String, interval: T::Range[T.untyped], filename: ::Idl::AstNode).void }
   def initialize(input, interval, filename); end
 
-  # source://idlc//lib/idlc/ast.rb#843
+  # source://idlc//lib/idlc/ast.rb#841
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#847
+  # source://idlc//lib/idlc/ast.rb#845
   sig { returns(::String) }
   def filename; end
 
-  # source://idlc//lib/idlc/ast.rb#860
+  # source://idlc//lib/idlc/ast.rb#858
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#855
+  # source://idlc//lib/idlc/ast.rb#853
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#858
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#856
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 end
 
-# source://idlc//lib/idlc/ast.rb#833
+# source://idlc//lib/idlc/ast.rb#831
 class Idl::IncludeStatementSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#835
+  # source://idlc//lib/idlc/ast.rb#833
   sig { override.returns(::Idl::IncludeStatementAst) }
   def to_ast; end
 end
@@ -4898,9 +4915,9 @@ module Idl::InstructionOperation1
   def op_stmt_list; end
 end
 
-# source://idlc//lib/idlc/ast.rb#7824
+# source://idlc//lib/idlc/ast.rb#7910
 class Idl::InstructionOperationSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#7825
+  # source://idlc//lib/idlc/ast.rb#7911
   def to_ast; end
 end
 
@@ -4955,19 +4972,19 @@ module Idl::Int8; end
 # source://idlc//lib/idlc/idl_parser.rb#1505
 module Idl::Int9; end
 
-# source://idlc//lib/idlc/ast.rb#7150
+# source://idlc//lib/idlc/ast.rb#7231
 class Idl::IntLiteralAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#7157
+  # source://idlc//lib/idlc/ast.rb#7238
   sig { params(input: T.nilable(::String), interval: T.nilable(T::Range[::Integer]), text: ::String).void }
   def initialize(input, interval, text); end
 
-  # source://idlc//lib/idlc/ast.rb#7154
+  # source://idlc//lib/idlc/ast.rb#7235
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7164
+  # source://idlc//lib/idlc/ast.rb#7245
   def freeze_tree(global_symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#142
@@ -4976,46 +4993,49 @@ class Idl::IntLiteralAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#103
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#7421
+  # source://idlc//lib/idlc/passes/prune.rb#547
+  def prune(symtab, forced_type: T.unsafe(nil)); end
+
+  # source://idlc//lib/idlc/ast.rb#7507
   sig { returns(::Integer) }
   def radix; end
 
-  # source://idlc//lib/idlc/ast.rb#7404
+  # source://idlc//lib/idlc/ast.rb#7490
   sig { returns(T::Boolean) }
   def signed?; end
 
-  # source://idlc//lib/idlc/ast.rb#7162
+  # source://idlc//lib/idlc/ast.rb#7243
   def text_value; end
 
-  # source://idlc//lib/idlc/ast.rb#7459
+  # source://idlc//lib/idlc/ast.rb#7545
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#7392
+  # source://idlc//lib/idlc/ast.rb#7478
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#7395
+  # source://idlc//lib/idlc/ast.rb#7481
   sig { override.returns(::String) }
   def to_idl_verbose; end
 
-  # source://idlc//lib/idlc/ast.rb#7190
+  # source://idlc//lib/idlc/ast.rb#7271
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7174
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#7255
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#7311
+  # source://idlc//lib/idlc/ast.rb#7397
   def unsigned_value; end
 
-  # source://idlc//lib/idlc/ast.rb#7264
+  # source://idlc//lib/idlc/ast.rb#7350
   def value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7225
+  # source://idlc//lib/idlc/ast.rb#7311
   def width(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#7482
+    # source://idlc//lib/idlc/ast.rb#7568
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5024,14 +5044,14 @@ class Idl::IntLiteralAst < ::Idl::AstNode
     end
     def from_h(yaml, source_mapper); end
 
-    # source://idlc//lib/idlc/ast.rb#7470
+    # source://idlc//lib/idlc/ast.rb#7556
     def radix_to_verilog(r); end
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#7060
+# source://idlc//lib/idlc/ast.rb#7121
 module Idl::IntLiteralSyntaxNode
-  # source://idlc//lib/idlc/ast.rb#7061
+  # source://idlc//lib/idlc/ast.rb#7122
   def to_ast; end
 end
 
@@ -5046,50 +5066,60 @@ end
 
 # source://idlc//lib/idlc/ast.rb#1253
 class Idl::IsaAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#1280
+  # source://idlc//lib/idlc/ast.rb#1259
+  sig do
+    params(
+      input: T.nilable(::String),
+      interval: T.nilable(T::Range[::Integer]),
+      children: T::Array[::Idl::AstNode]
+    ).void
+  end
+  def initialize(input, interval, children); end
+
+  # source://idlc//lib/idlc/ast.rb#1297
   def add_global_symbols(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1266
+  # source://idlc//lib/idlc/ast.rb#1276
   def bitfields; end
 
-  # source://idlc//lib/idlc/ast.rb#1257
+  # source://idlc//lib/idlc/ast.rb#1267
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1254
+  # source://idlc//lib/idlc/ast.rb#1264
   def definitions; end
 
-  # source://idlc//lib/idlc/ast.rb#1263
+  # source://idlc//lib/idlc/ast.rb#1273
   def enums; end
 
-  # source://idlc//lib/idlc/ast.rb#1275
+  # source://idlc//lib/idlc/ast.rb#1285
   def fetch; end
 
-  # source://idlc//lib/idlc/ast.rb#1272
+  # source://idlc//lib/idlc/ast.rb#1282
   def functions; end
 
-  # source://idlc//lib/idlc/ast.rb#1260
+  # source://idlc//lib/idlc/ast.rb#1270
   def globals; end
 
-  # source://idlc//lib/idlc/ast.rb#1295
+  # source://idlc//lib/idlc/ast.rb#1312
   def replace_include!(include_ast, isa_ast); end
 
-  # source://idlc//lib/idlc/ast.rb#1269
+  # source://idlc//lib/idlc/ast.rb#1279
   def structs; end
 
-  # source://idlc//lib/idlc/ast.rb#1328
+  # source://idlc//lib/idlc/ast.rb#1344
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1314
+  # source://idlc//lib/idlc/ast.rb#1330
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1305
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1322
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1335
+    # source://idlc//lib/idlc/ast.rb#1351
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5100,9 +5130,14 @@ class Idl::IsaAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1240
+# source://idlc//lib/idlc/ast.rb#1254
+class Idl::IsaAst::Memo < ::T::Struct
+  prop :fetch, T.nilable(::Idl::FetchAst)
+end
+
+# source://idlc//lib/idlc/ast.rb#1238
 class Idl::IsaSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1241
+  # source://idlc//lib/idlc/ast.rb#1239
   def to_ast; end
 end
 
@@ -5154,51 +5189,51 @@ module Idl::Keyword8; end
 # source://idlc//lib/idlc/idl_parser.rb#15067
 module Idl::Keyword9; end
 
-# source://idlc//lib/idlc/ast.rb#3310
+# source://idlc//lib/idlc/ast.rb#3326
 class Idl::MultiVariableAssignmentAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#3332
+  # source://idlc//lib/idlc/ast.rb#3348
   def initialize(input, interval, variables, function_call); end
 
-  # source://idlc//lib/idlc/ast.rb#3314
+  # source://idlc//lib/idlc/ast.rb#3330
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3377
+  # source://idlc//lib/idlc/ast.rb#3393
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3401
+  # source://idlc//lib/idlc/ast.rb#3417
   def execute_unknown(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3330
+  # source://idlc//lib/idlc/ast.rb#3346
   def function_call; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#71
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3341
+  # source://idlc//lib/idlc/ast.rb#3357
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#3412
+  # source://idlc//lib/idlc/ast.rb#3428
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#3409
+  # source://idlc//lib/idlc/ast.rb#3425
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#3346
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#3362
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#3329
+  # source://idlc//lib/idlc/ast.rb#3345
   def variables; end
 
-  # source://idlc//lib/idlc/ast.rb#3337
+  # source://idlc//lib/idlc/ast.rb#3353
   def vars; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#3420
+    # source://idlc//lib/idlc/ast.rb#3436
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5209,17 +5244,17 @@ class Idl::MultiVariableAssignmentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#3300
+# source://idlc//lib/idlc/ast.rb#3316
 class Idl::MultiVariableAssignmentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3301
+  # source://idlc//lib/idlc/ast.rb#3317
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#3444
+# source://idlc//lib/idlc/ast.rb#3460
 class Idl::MultiVariableDeclarationAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#3460
+  # source://idlc//lib/idlc/ast.rb#3476
   sig do
     params(
       input: T.nilable(::String),
@@ -5230,44 +5265,44 @@ class Idl::MultiVariableDeclarationAst < ::Idl::AstNode
   end
   def initialize(input, interval, type_name, var_names); end
 
-  # source://idlc//lib/idlc/ast.rb#3493
+  # source://idlc//lib/idlc/ast.rb#3509
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3448
+  # source://idlc//lib/idlc/ast.rb#3464
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#180
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3467
+  # source://idlc//lib/idlc/ast.rb#3483
   def make_global; end
 
-  # source://idlc//lib/idlc/ast.rb#3504
+  # source://idlc//lib/idlc/ast.rb#3520
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#3501
+  # source://idlc//lib/idlc/ast.rb#3517
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#3484
+  # source://idlc//lib/idlc/ast.rb#3500
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3477
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#3493
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#3454
+  # source://idlc//lib/idlc/ast.rb#3470
   def type_name; end
 
-  # source://idlc//lib/idlc/ast.rb#3457
+  # source://idlc//lib/idlc/ast.rb#3473
   def var_name_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#3472
+  # source://idlc//lib/idlc/ast.rb#3488
   def var_names; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#3512
+    # source://idlc//lib/idlc/ast.rb#3528
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5278,43 +5313,43 @@ class Idl::MultiVariableDeclarationAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#3433
+# source://idlc//lib/idlc/ast.rb#3449
 class Idl::MultiVariableDeclarationSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3434
+  # source://idlc//lib/idlc/ast.rb#3450
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6217
+# source://idlc//lib/idlc/ast.rb#6278
 class Idl::NoopAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#6221
+  # source://idlc//lib/idlc/ast.rb#6282
   def initialize; end
 
-  # source://idlc//lib/idlc/ast.rb#6219
+  # source://idlc//lib/idlc/ast.rb#6280
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6229
+  # source://idlc//lib/idlc/ast.rb#6290
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6232
+  # source://idlc//lib/idlc/ast.rb#6293
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#17
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#6239
+  # source://idlc//lib/idlc/ast.rb#6300
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6236
+  # source://idlc//lib/idlc/ast.rb#6297
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6226
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6287
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6245
+    # source://idlc//lib/idlc/ast.rb#6306
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5517,45 +5552,48 @@ module Idl::ParenExpression0
   def e; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5208
+# source://idlc//lib/idlc/ast.rb#5231
 class Idl::ParenExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5214
+  # source://idlc//lib/idlc/ast.rb#5237
   def initialize(input, interval, exp); end
 
-  # source://idlc//lib/idlc/ast.rb#5212
+  # source://idlc//lib/idlc/ast.rb#5235
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5216
+  # source://idlc//lib/idlc/ast.rb#5239
   def expression; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#137
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5218
+  # source://idlc//lib/idlc/ast.rb#5241
   def invert(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5234
+  # source://idlc//lib/idlc/passes/prune.rb#179
+  def prune(symtab, forced_type: T.unsafe(nil)); end
+
+  # source://idlc//lib/idlc/ast.rb#5257
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5231
+  # source://idlc//lib/idlc/ast.rb#5254
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5224
+  # source://idlc//lib/idlc/ast.rb#5247
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5221
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5244
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5227
+  # source://idlc//lib/idlc/ast.rb#5250
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5241
+    # source://idlc//lib/idlc/ast.rb#5264
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5566,17 +5604,17 @@ class Idl::ParenExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5198
+# source://idlc//lib/idlc/ast.rb#5221
 class Idl::ParenExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5199
+  # source://idlc//lib/idlc/ast.rb#5222
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#2616
+# source://idlc//lib/idlc/ast.rb#2632
 class Idl::PcAssignmentAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#2627
+  # source://idlc//lib/idlc/ast.rb#2643
   sig do
     params(
       input: T.nilable(::String),
@@ -5586,39 +5624,39 @@ class Idl::PcAssignmentAst < ::Idl::AstNode
   end
   def initialize(input, interval, rval); end
 
-  # source://idlc//lib/idlc/ast.rb#2620
+  # source://idlc//lib/idlc/ast.rb#2636
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2633
+  # source://idlc//lib/idlc/ast.rb#2649
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2637
+  # source://idlc//lib/idlc/ast.rb#2653
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#247
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#2624
+  # source://idlc//lib/idlc/ast.rb#2640
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#2650
+  # source://idlc//lib/idlc/ast.rb#2666
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2647
+  # source://idlc//lib/idlc/ast.rb#2663
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2641
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2657
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2657
+    # source://idlc//lib/idlc/ast.rb#2673
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5629,9 +5667,9 @@ class Idl::PcAssignmentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2610
+# source://idlc//lib/idlc/ast.rb#2626
 class Idl::PcAssignmentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#2611
+  # source://idlc//lib/idlc/ast.rb#2627
   def to_ast; end
 end
 
@@ -5641,46 +5679,46 @@ module Idl::PostDec0
   def rval; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5506
+# source://idlc//lib/idlc/ast.rb#5537
 class Idl::PostDecrementExpressionAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#5515
+  # source://idlc//lib/idlc/ast.rb#5546
   def initialize(input, interval, rval); end
 
-  # source://idlc//lib/idlc/ast.rb#5510
+  # source://idlc//lib/idlc/ast.rb#5541
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5532
+  # source://idlc//lib/idlc/ast.rb#5563
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5548
+  # source://idlc//lib/idlc/ast.rb#5579
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#50
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5513
+  # source://idlc//lib/idlc/ast.rb#5544
   sig { returns(T.any(::Idl::BuiltinVariableAst, ::Idl::IdAst, ::Idl::IntLiteralAst, ::Idl::StringLiteralAst)) }
   def rval; end
 
-  # source://idlc//lib/idlc/ast.rb#5556
+  # source://idlc//lib/idlc/ast.rb#5587
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5553
+  # source://idlc//lib/idlc/ast.rb#5584
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5527
+  # source://idlc//lib/idlc/ast.rb#5558
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5519
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5550
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5563
+    # source://idlc//lib/idlc/ast.rb#5594
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5691,9 +5729,9 @@ class Idl::PostDecrementExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5496
+# source://idlc//lib/idlc/ast.rb#5527
 class Idl::PostDecrementExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5497
+  # source://idlc//lib/idlc/ast.rb#5528
   def to_ast; end
 end
 
@@ -5703,45 +5741,45 @@ module Idl::PostInc0
   def rval; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5661
+# source://idlc//lib/idlc/ast.rb#5692
 class Idl::PostIncrementExpressionAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#5669
+  # source://idlc//lib/idlc/ast.rb#5700
   def initialize(input, interval, rval); end
 
-  # source://idlc//lib/idlc/ast.rb#5665
+  # source://idlc//lib/idlc/ast.rb#5696
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5689
+  # source://idlc//lib/idlc/ast.rb#5720
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5706
+  # source://idlc//lib/idlc/ast.rb#5737
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#45
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5667
+  # source://idlc//lib/idlc/ast.rb#5698
   def rval; end
 
-  # source://idlc//lib/idlc/ast.rb#5715
+  # source://idlc//lib/idlc/ast.rb#5746
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5712
+  # source://idlc//lib/idlc/ast.rb#5743
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5684
+  # source://idlc//lib/idlc/ast.rb#5715
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5674
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5705
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5722
+    # source://idlc//lib/idlc/ast.rb#5753
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5752,9 +5790,9 @@ class Idl::PostIncrementExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5651
+# source://idlc//lib/idlc/ast.rb#5682
 class Idl::PostIncrementExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5652
+  # source://idlc//lib/idlc/ast.rb#5683
   def to_ast; end
 end
 
@@ -5767,45 +5805,48 @@ module Idl::ReplicationExpression0
   def v; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5424
+# source://idlc//lib/idlc/ast.rb#5451
 class Idl::ReplicationExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5434
+  # source://idlc//lib/idlc/ast.rb#5461
   def initialize(input, interval, n, v); end
 
-  # source://idlc//lib/idlc/ast.rb#5428
+  # source://idlc//lib/idlc/ast.rb#5455
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#277
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5431
+  # source://idlc//lib/idlc/ast.rb#5458
   def n; end
 
-  # source://idlc//lib/idlc/ast.rb#5475
+  # source://idlc//lib/idlc/passes/prune.rb#521
+  def prune(symtab, forced_type: T.unsafe(nil)); end
+
+  # source://idlc//lib/idlc/ast.rb#5506
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5472
+  # source://idlc//lib/idlc/ast.rb#5503
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5460
+  # source://idlc//lib/idlc/ast.rb#5491
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5439
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5466
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5432
+  # source://idlc//lib/idlc/ast.rb#5459
   def v; end
 
-  # source://idlc//lib/idlc/ast.rb#5451
+  # source://idlc//lib/idlc/ast.rb#5478
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5483
+    # source://idlc//lib/idlc/ast.rb#5514
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5816,9 +5857,9 @@ class Idl::ReplicationExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5414
+# source://idlc//lib/idlc/ast.rb#5441
 class Idl::ReplicationExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5415
+  # source://idlc//lib/idlc/ast.rb#5442
   def to_ast; end
 end
 
@@ -5849,18 +5890,18 @@ module Idl::ReturnExpression3
   def vals; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6613
+# source://idlc//lib/idlc/ast.rb#6674
 class Idl::ReturnExpressionAst < ::Idl::AstNode
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#6621
+  # source://idlc//lib/idlc/ast.rb#6682
   def initialize(input, interval, return_nodes); end
 
-  # source://idlc//lib/idlc/ast.rb#6617
+  # source://idlc//lib/idlc/ast.rb#6678
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6665
+  # source://idlc//lib/idlc/ast.rb#6726
   def enclosing_function; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#30
@@ -5869,34 +5910,34 @@ class Idl::ReturnExpressionAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#115
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#6638
+  # source://idlc//lib/idlc/ast.rb#6699
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6627
+  # source://idlc//lib/idlc/ast.rb#6688
   def return_types(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6670
+  # source://idlc//lib/idlc/ast.rb#6731
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6619
+  # source://idlc//lib/idlc/ast.rb#6680
   def return_value_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#6681
+  # source://idlc//lib/idlc/ast.rb#6742
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6695
+  # source://idlc//lib/idlc/ast.rb#6756
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6692
+  # source://idlc//lib/idlc/ast.rb#6753
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6650
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6711
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6702
+    # source://idlc//lib/idlc/ast.rb#6763
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5907,9 +5948,9 @@ class Idl::ReturnExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6600
+# source://idlc//lib/idlc/ast.rb#6661
 class Idl::ReturnExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6601
+  # source://idlc//lib/idlc/ast.rb#6662
   def to_ast; end
 end
 
@@ -5928,21 +5969,21 @@ module Idl::ReturnStatement1
   def return_expression; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6524
+# source://idlc//lib/idlc/ast.rb#6585
 class Idl::ReturnStatementAst < ::Idl::AstNode
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#6534
+  # source://idlc//lib/idlc/ast.rb#6595
   def initialize(input, interval, return_expression); end
 
-  # source://idlc//lib/idlc/ast.rb#6528
+  # source://idlc//lib/idlc/ast.rb#6589
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6563
+  # source://idlc//lib/idlc/ast.rb#6624
   def enclosing_function; end
 
-  # source://idlc//lib/idlc/ast.rb#6549
+  # source://idlc//lib/idlc/ast.rb#6610
   def expected_return_type(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#271
@@ -5954,37 +5995,37 @@ class Idl::ReturnStatementAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/find_return_values.rb#19
   def pass_find_return_values(values, current_conditions, symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6530
+  # source://idlc//lib/idlc/ast.rb#6591
   def return_expression; end
 
-  # source://idlc//lib/idlc/ast.rb#6544
+  # source://idlc//lib/idlc/ast.rb#6605
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6539
+  # source://idlc//lib/idlc/ast.rb#6600
   def return_types(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6568
+  # source://idlc//lib/idlc/ast.rb#6629
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6559
+  # source://idlc//lib/idlc/ast.rb#6620
   def return_value_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#6573
+  # source://idlc//lib/idlc/ast.rb#6634
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6581
+  # source://idlc//lib/idlc/ast.rb#6642
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6578
+  # source://idlc//lib/idlc/ast.rb#6639
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6554
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6615
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6588
+    # source://idlc//lib/idlc/ast.rb#6649
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5995,25 +6036,25 @@ class Idl::ReturnStatementAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6513
+# source://idlc//lib/idlc/ast.rb#6574
 class Idl::ReturnStatementSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6514
+  # source://idlc//lib/idlc/ast.rb#6575
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#623
+# source://idlc//lib/idlc/ast.rb#621
 module Idl::Returns
   abstract!
 
-  # source://idlc//lib/idlc/ast.rb#664
+  # source://idlc//lib/idlc/ast.rb#662
   sig { params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def expected_return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#641
+  # source://idlc//lib/idlc/ast.rb#639
   sig { abstract.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#646
+  # source://idlc//lib/idlc/ast.rb#644
   sig do
     abstract
       .params(
@@ -6022,7 +6063,7 @@ module Idl::Returns
   end
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#660
+  # source://idlc//lib/idlc/ast.rb#658
   sig do
     abstract
       .params(
@@ -6067,27 +6108,27 @@ end
 # source://idlc//lib/idlc/interfaces.rb#20
 Idl::RuntimeParam::ValueType = T.type_alias { T.any(::Integer, ::String, T::Array[::Integer], T::Array[::String], T::Array[T::Boolean], T::Boolean) }
 
-# source://idlc//lib/idlc/ast.rb#715
+# source://idlc//lib/idlc/ast.rb#713
 module Idl::Rvalue
   abstract!
 
-  # source://idlc//lib/idlc/ast.rb#765
+  # source://idlc//lib/idlc/ast.rb#763
   sig { params(symtab: ::Idl::SymbolTable).returns(T.any(::Integer, ::Symbol)) }
   def max_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#775
+  # source://idlc//lib/idlc/ast.rb#773
   sig { params(symtab: ::Idl::SymbolTable).returns(T.any(::Integer, ::Symbol)) }
   def min_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#800
+  # source://idlc//lib/idlc/ast.rb#798
   sig { params(value: ::Integer, width: ::Integer, signed: T::Boolean).returns(::Integer) }
   def truncate(value, width, signed); end
 
-  # source://idlc//lib/idlc/ast.rb#738
+  # source://idlc//lib/idlc/ast.rb#736
   sig { abstract.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#762
+  # source://idlc//lib/idlc/ast.rb#760
   sig do
     abstract
       .params(
@@ -6096,7 +6137,7 @@ module Idl::Rvalue
   end
   def value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#797
+  # source://idlc//lib/idlc/ast.rb#795
   sig do
     params(
       symtab: ::Idl::SymbolTable
@@ -6105,7 +6146,7 @@ module Idl::Rvalue
   def values(symtab); end
 end
 
-# source://idlc//lib/idlc/ast.rb#817
+# source://idlc//lib/idlc/ast.rb#815
 Idl::RvalueAst = T.type_alias { T.all(::Idl::AstNode, ::Idl::Rvalue) }
 
 # source://idlc//lib/idlc/interfaces.rb#43
@@ -6133,42 +6174,42 @@ module Idl::Schema
   def to_idl_type; end
 end
 
-# source://idlc//lib/idlc/ast.rb#4236
+# source://idlc//lib/idlc/ast.rb#4252
 class Idl::SignCastAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#4244
+  # source://idlc//lib/idlc/ast.rb#4260
   def initialize(input, interval, exp); end
 
-  # source://idlc//lib/idlc/ast.rb#4240
+  # source://idlc//lib/idlc/ast.rb#4256
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4242
+  # source://idlc//lib/idlc/ast.rb#4258
   def expression; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#163
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#4273
+  # source://idlc//lib/idlc/ast.rb#4290
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#4270
+  # source://idlc//lib/idlc/ast.rb#4287
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#4252
+  # source://idlc//lib/idlc/ast.rb#4269
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4247
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#4263
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#4255
+  # source://idlc//lib/idlc/ast.rb#4272
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#4280
+    # source://idlc//lib/idlc/ast.rb#4297
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -6179,9 +6220,9 @@ class Idl::SignCastAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#4230
+# source://idlc//lib/idlc/ast.rb#4246
 class Idl::SignCastSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#4231
+  # source://idlc//lib/idlc/ast.rb#4247
   def to_ast; end
 end
 
@@ -6239,24 +6280,24 @@ module Idl::Statement1
   def a; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6258
+# source://idlc//lib/idlc/ast.rb#6319
 class Idl::StatementAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#6266
+  # source://idlc//lib/idlc/ast.rb#6327
   def initialize(input, interval, action); end
 
-  # source://idlc//lib/idlc/ast.rb#6264
+  # source://idlc//lib/idlc/ast.rb#6325
   def action; end
 
-  # source://idlc//lib/idlc/ast.rb#6262
+  # source://idlc//lib/idlc/ast.rb#6323
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6276
+  # source://idlc//lib/idlc/ast.rb#6337
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6286
+  # source://idlc//lib/idlc/ast.rb#6347
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#259
@@ -6265,8 +6306,8 @@ class Idl::StatementAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#83
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#222
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#252
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
   # source://idlc//lib/idlc/passes/reachable_exceptions.rb#82
   def reachable_exceptions(symtab, cache = T.unsafe(nil)); end
@@ -6274,19 +6315,19 @@ class Idl::StatementAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/reachable_functions.rb#69
   def reachable_functions(symtab, cache = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#6300
+  # source://idlc//lib/idlc/ast.rb#6361
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6297
+  # source://idlc//lib/idlc/ast.rb#6358
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6271
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6332
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6307
+    # source://idlc//lib/idlc/ast.rb#6368
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -6297,9 +6338,9 @@ class Idl::StatementAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6211
+# source://idlc//lib/idlc/ast.rb#6272
 class Idl::StatementSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6212
+  # source://idlc//lib/idlc/ast.rb#6273
   def to_ast; end
 end
 
@@ -6309,44 +6350,44 @@ module Idl::String0; end
 # source://idlc//lib/idlc/idl_parser.rb#16628
 module Idl::String1; end
 
-# source://idlc//lib/idlc/ast.rb#7010
+# source://idlc//lib/idlc/ast.rb#7071
 class Idl::StringLiteralAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#7017
+  # source://idlc//lib/idlc/ast.rb#7078
   sig { params(input: T.nilable(::String), interval: T.nilable(T::Range[::Integer]), text: ::String).void }
   def initialize(input, interval, text); end
 
-  # source://idlc//lib/idlc/ast.rb#7014
+  # source://idlc//lib/idlc/ast.rb#7075
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#55
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#7024
+  # source://idlc//lib/idlc/ast.rb#7085
   sig { override.returns(::String) }
   def text_value; end
 
-  # source://idlc//lib/idlc/ast.rb#7042
+  # source://idlc//lib/idlc/ast.rb#7103
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#7039
+  # source://idlc//lib/idlc/ast.rb#7100
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#7029
+  # source://idlc//lib/idlc/ast.rb#7090
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7027
-  def type_check(_symtab); end
+  # source://idlc//lib/idlc/ast.rb#7088
+  def type_check(_symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#7034
+  # source://idlc//lib/idlc/ast.rb#7095
   def value(_symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#7049
+    # source://idlc//lib/idlc/ast.rb#7110
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -6357,13 +6398,13 @@ class Idl::StringLiteralAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6998
+# source://idlc//lib/idlc/ast.rb#7059
 module Idl::StringLiteralSyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6999
+  # source://idlc//lib/idlc/ast.rb#7060
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/type.rb#1004
+# source://idlc//lib/idlc/type.rb#1024
 Idl::StringType = T.let(T.unsafe(nil), Idl::Type)
 
 # source://idlc//lib/idlc/idl_parser.rb#1191
@@ -6384,51 +6425,51 @@ module Idl::StructDefinition1
   def user_type_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#2255
+# source://idlc//lib/idlc/ast.rb#2271
 class Idl::StructDefinitionAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#2270
+  # source://idlc//lib/idlc/ast.rb#2286
   def initialize(input, interval, name, member_types, member_names); end
 
-  # source://idlc//lib/idlc/ast.rb#2298
+  # source://idlc//lib/idlc/ast.rb#2314
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2268
+  # source://idlc//lib/idlc/ast.rb#2284
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2265
+  # source://idlc//lib/idlc/ast.rb#2281
   def member_names; end
 
-  # source://idlc//lib/idlc/ast.rb#2309
+  # source://idlc//lib/idlc/ast.rb#2325
   def member_type(name, symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2262
+  # source://idlc//lib/idlc/ast.rb#2278
   def member_types; end
 
-  # source://idlc//lib/idlc/ast.rb#2259
+  # source://idlc//lib/idlc/ast.rb#2275
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#2316
+  # source://idlc//lib/idlc/ast.rb#2332
   def num_members; end
 
-  # source://idlc//lib/idlc/ast.rb#2328
+  # source://idlc//lib/idlc/ast.rb#2344
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2319
+  # source://idlc//lib/idlc/ast.rb#2335
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2287
+  # source://idlc//lib/idlc/ast.rb#2303
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2279
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2295
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2341
+    # source://idlc//lib/idlc/ast.rb#2357
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -6439,38 +6480,38 @@ class Idl::StructDefinitionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2234
+# source://idlc//lib/idlc/ast.rb#2250
 class Idl::StructDefinitionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#2235
+  # source://idlc//lib/idlc/ast.rb#2251
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/type.rb#599
+# source://idlc//lib/idlc/type.rb#618
 class Idl::StructType < ::Idl::Type
-  # source://idlc//lib/idlc/type.rb#604
+  # source://idlc//lib/idlc/type.rb#623
   sig { params(type_name: ::String, member_types: T::Array[::Idl::Type], member_names: T::Array[::String]).void }
   def initialize(type_name, member_types, member_names); end
 
-  # source://idlc//lib/idlc/type.rb#614
+  # source://idlc//lib/idlc/type.rb#633
   def clone; end
 
-  # source://idlc//lib/idlc/type.rb#618
+  # source://idlc//lib/idlc/type.rb#637
   def default; end
 
-  # source://idlc//lib/idlc/type.rb#626
+  # source://idlc//lib/idlc/type.rb#645
   def member?(name); end
 
-  # source://idlc//lib/idlc/type.rb#628
+  # source://idlc//lib/idlc/type.rb#647
   def member_type(member_name); end
 
-  # source://idlc//lib/idlc/type.rb#612
+  # source://idlc//lib/idlc/type.rb#631
   sig { returns(::String) }
   def name; end
 
-  # source://idlc//lib/idlc/type.rb#636
+  # source://idlc//lib/idlc/type.rb#655
   def runtime?; end
 
-  # source://idlc//lib/idlc/type.rb#601
+  # source://idlc//lib/idlc/type.rb#620
   sig { returns(::String) }
   def type_name; end
 end
@@ -6828,21 +6869,30 @@ module Idl::TernaryExpression0
   def t; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6086
+# source://idlc//lib/idlc/ast.rb#6107
 class Idl::TernaryOperatorExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#6096
+  # source://idlc//lib/idlc/ast.rb#6131
+  sig do
+    params(
+      input: T.nilable(::String),
+      interval: T.nilable(T::Range[::Integer]),
+      condition: T.all(::Idl::AstNode, ::Idl::Rvalue),
+      true_expression: T.all(::Idl::AstNode, ::Idl::Rvalue),
+      false_expression: T.all(::Idl::AstNode, ::Idl::Rvalue)
+    ).void
+  end
   def initialize(input, interval, condition, true_expression, false_expression); end
 
-  # source://idlc//lib/idlc/ast.rb#6092
+  # source://idlc//lib/idlc/ast.rb#6117
   def condition; end
 
-  # source://idlc//lib/idlc/ast.rb#6090
+  # source://idlc//lib/idlc/ast.rb#6115
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6094
+  # source://idlc//lib/idlc/ast.rb#6119
   def false_expression; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#186
@@ -6851,34 +6901,34 @@ class Idl::TernaryOperatorExpressionAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#123
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#456
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#559
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#6188
+  # source://idlc//lib/idlc/ast.rb#6249
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6185
+  # source://idlc//lib/idlc/ast.rb#6246
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6093
+  # source://idlc//lib/idlc/ast.rb#6118
   def true_expression; end
 
-  # source://idlc//lib/idlc/ast.rb#6128
+  # source://idlc//lib/idlc/ast.rb#6176
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6101
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6137
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#6169
+  # source://idlc//lib/idlc/ast.rb#6230
   def value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6174
+  # source://idlc//lib/idlc/ast.rb#6235
   def values(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6197
+    # source://idlc//lib/idlc/ast.rb#6258
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -6889,21 +6939,26 @@ class Idl::TernaryOperatorExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6075
+# source://idlc//lib/idlc/ast.rb#6110
+class Idl::TernaryOperatorExpressionAst::Memo < ::T::Struct
+  prop :type, T::Hash[::Idl::SymbolTable, ::Idl::Type], default: T.unsafe(nil)
+end
+
+# source://idlc//lib/idlc/ast.rb#6096
 class Idl::TernaryOperatorExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6076
+  # source://idlc//lib/idlc/ast.rb#6097
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#869
+# source://idlc//lib/idlc/ast.rb#867
 class Idl::TrueExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#873
+  # source://idlc//lib/idlc/ast.rb#871
   sig { params(input: ::String, interval: T::Range[::Integer]).void }
   def initialize(input, interval); end
 
-  # source://idlc//lib/idlc/ast.rb#878
+  # source://idlc//lib/idlc/ast.rb#876
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
@@ -6913,28 +6968,28 @@ class Idl::TrueExpressionAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#89
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#893
+  # source://idlc//lib/idlc/ast.rb#891
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#890
+  # source://idlc//lib/idlc/ast.rb#888
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#884
+  # source://idlc//lib/idlc/ast.rb#882
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#881
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#879
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#887
+  # source://idlc//lib/idlc/ast.rb#885
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::TrueClass) }
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#899
+    # source://idlc//lib/idlc/ast.rb#897
     sig do
       override
         .params(
@@ -6946,157 +7001,176 @@ class Idl::TrueExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#865
+# source://idlc//lib/idlc/ast.rb#863
 class Idl::TrueExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#866
+  # source://idlc//lib/idlc/ast.rb#864
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/type.rb#15
+# source://idlc//lib/idlc/type.rb#13
 class Idl::Type
-  # source://idlc//lib/idlc/type.rb#132
-  def initialize(kind, qualifiers: T.unsafe(nil), width: T.unsafe(nil), width_ast: T.unsafe(nil), max_width: T.unsafe(nil), sub_type: T.unsafe(nil), name: T.unsafe(nil), tuple_types: T.unsafe(nil), return_type: T.unsafe(nil), arguments: T.unsafe(nil), enum_class: T.unsafe(nil), csr: T.unsafe(nil)); end
+  # source://idlc//lib/idlc/type.rb#152
+  sig do
+    params(
+      kind: ::Symbol,
+      qualifiers: T::Array[::Symbol],
+      width: T.nilable(T.any(::Integer, ::Symbol)),
+      width_ast: T.nilable(::Idl::AstNode),
+      max_width: T.nilable(::Integer),
+      sub_type: T.nilable(::Idl::Type),
+      name: T.nilable(::String),
+      tuple_types: T.nilable(T::Array[::Idl::Type]),
+      return_type: T.nilable(::Idl::Type),
+      enum_class: T.nilable(::Idl::EnumerationType),
+      csr: T.nilable(::Idl::Csr)
+    ).void
+  end
+  def initialize(kind, qualifiers: T.unsafe(nil), width: T.unsafe(nil), width_ast: T.unsafe(nil), max_width: T.unsafe(nil), sub_type: T.unsafe(nil), name: T.unsafe(nil), tuple_types: T.unsafe(nil), return_type: T.unsafe(nil), enum_class: T.unsafe(nil), csr: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/type.rb#48
+  # source://idlc//lib/idlc/type.rb#53
   def ==(other); end
 
-  # source://idlc//lib/idlc/type.rb#397
+  # source://idlc//lib/idlc/type.rb#416
   def ary?; end
 
-  # source://idlc//lib/idlc/type.rb#248
+  # source://idlc//lib/idlc/type.rb#267
   def ary_type(ary); end
 
-  # source://idlc//lib/idlc/type.rb#173
+  # source://idlc//lib/idlc/type.rb#192
   def clone; end
 
-  # source://idlc//lib/idlc/type.rb#188
+  # source://idlc//lib/idlc/type.rb#207
   def comparable_to?(type); end
 
-  # source://idlc//lib/idlc/type.rb#401
+  # source://idlc//lib/idlc/type.rb#420
   def const?; end
 
-  # source://idlc//lib/idlc/type.rb#258
+  # source://idlc//lib/idlc/type.rb#277
   def convertable_to?(type); end
 
-  # source://idlc//lib/idlc/type.rb#69
+  # source://idlc//lib/idlc/type.rb#74
   def default; end
 
-  # source://idlc//lib/idlc/type.rb#111
+  # source://idlc//lib/idlc/type.rb#119
   sig { returns(::Idl::EnumerationType) }
   def enum_class; end
 
-  # source://idlc//lib/idlc/type.rb#220
+  # source://idlc//lib/idlc/type.rb#239
   def equal_to?(type); end
 
-  # source://idlc//lib/idlc/type.rb#377
+  # source://idlc//lib/idlc/type.rb#396
   def fully_qualified_name; end
 
-  # source://idlc//lib/idlc/type.rb#413
+  # source://idlc//lib/idlc/type.rb#432
   def global?; end
 
-  # source://idlc//lib/idlc/type.rb#44
+  # source://idlc//lib/idlc/type.rb#49
   sig { returns(T::Boolean) }
   def integral?; end
 
-  # source://idlc//lib/idlc/type.rb#93
+  # source://idlc//lib/idlc/type.rb#98
   sig { returns(::Symbol) }
   def kind; end
 
-  # source://idlc//lib/idlc/type.rb#421
+  # source://idlc//lib/idlc/type.rb#440
   def known?; end
 
-  # source://idlc//lib/idlc/type.rb#439
+  # source://idlc//lib/idlc/type.rb#458
   sig { returns(::Idl::Type) }
   def make_const; end
 
-  # source://idlc//lib/idlc/type.rb#432
+  # source://idlc//lib/idlc/type.rb#451
   sig { returns(::Idl::Type) }
   def make_const!; end
 
-  # source://idlc//lib/idlc/type.rb#444
+  # source://idlc//lib/idlc/type.rb#463
   def make_global; end
 
-  # source://idlc//lib/idlc/type.rb#449
+  # source://idlc//lib/idlc/type.rb#468
   def make_known; end
 
-  # source://idlc//lib/idlc/type.rb#425
+  # source://idlc//lib/idlc/type.rb#444
   def make_signed; end
 
-  # source://idlc//lib/idlc/type.rb#405
+  # source://idlc//lib/idlc/type.rb#110
+  sig { returns(T.nilable(::Integer)) }
+  def max_width; end
+
+  # source://idlc//lib/idlc/type.rb#424
   def mutable?; end
 
-  # source://idlc//lib/idlc/type.rb#379
+  # source://idlc//lib/idlc/type.rb#398
   def name; end
 
-  # source://idlc//lib/idlc/type.rb#96
+  # source://idlc//lib/idlc/type.rb#101
   sig { returns(T::Array[::Symbol]) }
   def qualifiers; end
 
-  # source://idlc//lib/idlc/type.rb#113
+  # source://idlc//lib/idlc/type.rb#121
   def qualify(qualifier); end
 
-  # source://idlc//lib/idlc/type.rb#61
+  # source://idlc//lib/idlc/type.rb#66
   def runtime?; end
 
-  # source://idlc//lib/idlc/type.rb#409
+  # source://idlc//lib/idlc/type.rb#428
   def signed?; end
 
-  # source://idlc//lib/idlc/type.rb#105
+  # source://idlc//lib/idlc/type.rb#113
   sig { returns(::Idl::Type) }
   def sub_type; end
 
-  # source://idlc//lib/idlc/type.rb#417
+  # source://idlc//lib/idlc/type.rb#436
   def template_var?; end
 
-  # source://idlc//lib/idlc/type.rb#327
+  # source://idlc//lib/idlc/type.rb#346
   sig { returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/type.rb#347
+  # source://idlc//lib/idlc/type.rb#366
   def to_s; end
 
-  # source://idlc//lib/idlc/type.rb#108
+  # source://idlc//lib/idlc/type.rb#116
   sig { returns(T::Array[::Idl::Type]) }
   def tuple_types; end
 
-  # source://idlc//lib/idlc/type.rb#99
+  # source://idlc//lib/idlc/type.rb#104
   sig { returns(T.any(::Integer, ::Symbol)) }
   def width; end
 
-  # source://idlc//lib/idlc/type.rb#102
+  # source://idlc//lib/idlc/type.rb#107
   sig { returns(T.nilable(::Idl::AstNode)) }
   def width_ast; end
 
   class << self
-    # source://idlc//lib/idlc/type.rb#582
+    # source://idlc//lib/idlc/type.rb#601
     sig { params(schema: T::Hash[::String, T.untyped]).returns(T.nilable(::Idl::Type)) }
     def from_json_schema(schema); end
 
-    # source://idlc//lib/idlc/type.rb#119
+    # source://idlc//lib/idlc/type.rb#127
     def from_typename(type_name, cfg_arch); end
 
     private
 
-    # source://idlc//lib/idlc/type.rb#544
+    # source://idlc//lib/idlc/type.rb#563
     sig { params(schema: T::Hash[::String, T.untyped]).returns(::Idl::Type) }
     def from_json_schema_array_type(schema); end
 
-    # source://idlc//lib/idlc/type.rb#457
+    # source://idlc//lib/idlc/type.rb#476
     sig { params(schema: T::Hash[::String, T.untyped]).returns(T.nilable(::Idl::Type)) }
     def from_json_schema_scalar_type(schema); end
   end
 end
 
-# source://idlc//lib/idlc/type.rb#18
+# source://idlc//lib/idlc/type.rb#23
 Idl::Type::KINDS = T.let(T.unsafe(nil), Array)
 
-# source://idlc//lib/idlc/type.rb#34
+# source://idlc//lib/idlc/type.rb#39
 Idl::Type::QUALIFIERS = T.let(T.unsafe(nil), Array)
 
-# source://idlc//lib/idlc/type.rb#171
+# source://idlc//lib/idlc/type.rb#190
 Idl::Type::TYPE_FROM_KIND = T.let(T.unsafe(nil), Hash)
 
-# source://idlc//lib/idlc/ast.rb#7822
+# source://idlc//lib/idlc/ast.rb#7908
 Idl::TypeNameAst = T.type_alias { T.any(::Idl::BuiltinTypeNameAst, ::Idl::UserTypeNameAst) }
 
 # source://idlc//lib/idlc/idl_parser.rb#6782
@@ -7171,51 +7245,51 @@ module Idl::UnaryExpression9
   def o; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5943
+# source://idlc//lib/idlc/ast.rb#5964
 class Idl::UnaryOperatorExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5951
+  # source://idlc//lib/idlc/ast.rb#5972
   def initialize(input, interval, op, expression); end
 
-  # source://idlc//lib/idlc/ast.rb#5947
+  # source://idlc//lib/idlc/ast.rb#5968
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6040
+  # source://idlc//lib/idlc/ast.rb#6061
   def exp; end
 
-  # source://idlc//lib/idlc/ast.rb#5949
+  # source://idlc//lib/idlc/ast.rb#5970
   def expression; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#265
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5957
+  # source://idlc//lib/idlc/ast.rb#5978
   def invert(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6045
+  # source://idlc//lib/idlc/ast.rb#6066
   def op; end
 
-  # source://idlc//lib/idlc/ast.rb#6054
+  # source://idlc//lib/idlc/ast.rb#6075
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6051
+  # source://idlc//lib/idlc/ast.rb#6072
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5968
+  # source://idlc//lib/idlc/ast.rb#5989
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5984
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6005
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#6012
+  # source://idlc//lib/idlc/ast.rb#6033
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6062
+    # source://idlc//lib/idlc/ast.rb#6083
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -7226,77 +7300,83 @@ class Idl::UnaryOperatorExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5931
+# source://idlc//lib/idlc/ast.rb#5952
 class Idl::UnaryOperatorExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5932
+  # source://idlc//lib/idlc/ast.rb#5953
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#7067
+# source://idlc//lib/idlc/ast.rb#7128
 class Idl::UnknownLiteral
-  # source://idlc//lib/idlc/ast.rb#7069
+  # source://idlc//lib/idlc/ast.rb#7130
   def initialize(known_value, unknown_mask); end
 
-  # source://idlc//lib/idlc/ast.rb#7077
+  # source://idlc//lib/idlc/ast.rb#7138
   def &(other); end
 
-  # source://idlc//lib/idlc/ast.rb#7098
+  # source://idlc//lib/idlc/ast.rb#7200
+  def <<(shamt); end
+
+  # source://idlc//lib/idlc/ast.rb#7168
+  def <=(other); end
+
+  # source://idlc//lib/idlc/ast.rb#7159
   def ==(other); end
 
-  # source://idlc//lib/idlc/ast.rb#7073
+  # source://idlc//lib/idlc/ast.rb#7134
   def bit_length; end
 
-  # source://idlc//lib/idlc/ast.rb#7068
+  # source://idlc//lib/idlc/ast.rb#7129
   def known_value; end
 
-  # source://idlc//lib/idlc/ast.rb#7128
+  # source://idlc//lib/idlc/ast.rb#7209
   def to_s; end
 
-  # source://idlc//lib/idlc/ast.rb#7068
+  # source://idlc//lib/idlc/ast.rb#7129
   def unknown_mask; end
 
-  # source://idlc//lib/idlc/ast.rb#7076
+  # source://idlc//lib/idlc/ast.rb#7137
   def zero?; end
 
-  # source://idlc//lib/idlc/ast.rb#7107
+  # source://idlc//lib/idlc/ast.rb#7179
   def |(other); end
 end
 
 # source://idlc//lib/idlc/idl_parser.rb#15764
 module Idl::UserTypeName0; end
 
-# source://idlc//lib/idlc/ast.rb#7770
+# source://idlc//lib/idlc/ast.rb#7856
 class Idl::UserTypeNameAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#7774
+  # source://idlc//lib/idlc/ast.rb#7860
   def initialize(input, interval, name); end
 
-  # source://idlc//lib/idlc/ast.rb#7772
+  # source://idlc//lib/idlc/ast.rb#7858
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#66
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#7780
+  # source://idlc//lib/idlc/ast.rb#7866
   def text_value; end
 
-  # source://idlc//lib/idlc/ast.rb#7803
+  # source://idlc//lib/idlc/ast.rb#7889
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#7800
+  # source://idlc//lib/idlc/ast.rb#7886
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#7791
+  # source://idlc//lib/idlc/ast.rb#7877
   sig { params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7783
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#7869
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#7810
+    # source://idlc//lib/idlc/ast.rb#7896
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -7307,13 +7387,13 @@ class Idl::UserTypeNameAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#7764
+# source://idlc//lib/idlc/ast.rb#7850
 class Idl::UserTypeNameSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#7765
+  # source://idlc//lib/idlc/ast.rb#7851
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#28
+# source://idlc//lib/idlc/ast.rb#26
 Idl::ValueRbType = T.type_alias { T.any(::Integer, ::String, T::Array[::Integer], T::Array[::String], T::Array[T::Boolean], T::Boolean, T::Hash[::String, T.any(::Integer, ::String, T::Array[::Integer], T::Array[::String], T::Array[T::Boolean], T::Boolean)]) }
 
 # source://idlc//lib/idlc/symbol_table.rb#17
@@ -7385,56 +7465,56 @@ module Idl::VarWrite0
   def csr_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#2680
+# source://idlc//lib/idlc/ast.rb#2696
 class Idl::VariableAssignmentAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#2704
+  # source://idlc//lib/idlc/ast.rb#2720
   def initialize(input, interval, lhs_ast, rhs_ast); end
 
-  # source://idlc//lib/idlc/ast.rb#2684
+  # source://idlc//lib/idlc/ast.rb#2700
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2735
+  # source://idlc//lib/idlc/ast.rb#2751
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2756
+  # source://idlc//lib/idlc/ast.rb#2772
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#241
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#2699
+  # source://idlc//lib/idlc/ast.rb#2715
   sig { returns(::Idl::IdAst) }
   def lhs; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#74
+  # source://idlc//lib/idlc/passes/prune.rb#81
   def nullify_assignments(symtab); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#69
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#76
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#2702
+  # source://idlc//lib/idlc/ast.rb#2718
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#2773
+  # source://idlc//lib/idlc/ast.rb#2789
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2770
+  # source://idlc//lib/idlc/ast.rb#2786
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2710
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2726
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#2725
+  # source://idlc//lib/idlc/ast.rb#2741
   def var(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2781
+    # source://idlc//lib/idlc/ast.rb#2797
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -7445,17 +7525,17 @@ class Idl::VariableAssignmentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2669
+# source://idlc//lib/idlc/ast.rb#2685
 class Idl::VariableAssignmentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#2670
+  # source://idlc//lib/idlc/ast.rb#2686
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#3536
+# source://idlc//lib/idlc/ast.rb#3552
 class Idl::VariableDeclarationAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#3566
+  # source://idlc//lib/idlc/ast.rb#3582
   sig do
     params(
       input: T.nilable(::String),
@@ -7467,57 +7547,57 @@ class Idl::VariableDeclarationAst < ::Idl::AstNode
   end
   def initialize(input, interval, type_name, id, ary_size); end
 
-  # source://idlc//lib/idlc/ast.rb#3636
+  # source://idlc//lib/idlc/ast.rb#3652
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3552
+  # source://idlc//lib/idlc/ast.rb#3568
   sig { returns(T.nilable(T.all(::Idl::AstNode, ::Idl::Rvalue))) }
   def ary_size; end
 
-  # source://idlc//lib/idlc/ast.rb#3540
+  # source://idlc//lib/idlc/ast.rb#3556
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3582
+  # source://idlc//lib/idlc/ast.rb#3598
   sig { params(symtab: ::Idl::SymbolTable).returns(T.nilable(::Idl::Type)) }
   def decl_type(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#174
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3549
+  # source://idlc//lib/idlc/ast.rb#3565
   sig { returns(::Idl::IdAst) }
   def id; end
 
-  # source://idlc//lib/idlc/ast.rb#3577
+  # source://idlc//lib/idlc/ast.rb#3593
   sig { void }
   def make_global; end
 
-  # source://idlc//lib/idlc/ast.rb#3555
+  # source://idlc//lib/idlc/ast.rb#3571
   sig { returns(::String) }
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#3657
+  # source://idlc//lib/idlc/ast.rb#3673
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#3648
+  # source://idlc//lib/idlc/ast.rb#3664
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#3607
+  # source://idlc//lib/idlc/ast.rb#3623
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3610
-  def type_check(symtab, add_sym = T.unsafe(nil)); end
+  # source://idlc//lib/idlc/ast.rb#3626
+  def type_check(symtab, strict:, add_sym: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3546
+  # source://idlc//lib/idlc/ast.rb#3562
   sig { returns(T.any(::Idl::BuiltinTypeNameAst, ::Idl::UserTypeNameAst)) }
   def type_name; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#3669
+    # source://idlc//lib/idlc/ast.rb#3685
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -7528,18 +7608,18 @@ class Idl::VariableDeclarationAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#3525
+# source://idlc//lib/idlc/ast.rb#3541
 class Idl::VariableDeclarationSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3526
+  # source://idlc//lib/idlc/ast.rb#3542
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#3719
+# source://idlc//lib/idlc/ast.rb#3735
 class Idl::VariableDeclarationWithInitializationAst < ::Idl::AstNode
   include ::Idl::Executable
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#3761
+  # source://idlc//lib/idlc/ast.rb#3777
   sig do
     params(
       input: T.nilable(::String),
@@ -7553,64 +7633,64 @@ class Idl::VariableDeclarationWithInitializationAst < ::Idl::AstNode
   end
   def initialize(input, interval, type_name_ast, var_write_ast, ary_size, rval_ast, is_for_loop_iteration_var); end
 
-  # source://idlc//lib/idlc/ast.rb#3835
+  # source://idlc//lib/idlc/ast.rb#3851
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3742
+  # source://idlc//lib/idlc/ast.rb#3758
   sig { returns(T.nilable(T.all(::Idl::AstNode, ::Idl::Rvalue))) }
   def ary_size; end
 
-  # source://idlc//lib/idlc/ast.rb#3724
+  # source://idlc//lib/idlc/ast.rb#3740
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3865
+  # source://idlc//lib/idlc/ast.rb#3881
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3881
+  # source://idlc//lib/idlc/ast.rb#3897
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#219
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3748
+  # source://idlc//lib/idlc/ast.rb#3764
   sig { returns(::String) }
   def id; end
 
-  # source://idlc//lib/idlc/ast.rb#3739
+  # source://idlc//lib/idlc/ast.rb#3755
   sig { returns(::Idl::IdAst) }
   def lhs; end
 
-  # source://idlc//lib/idlc/ast.rb#3775
+  # source://idlc//lib/idlc/ast.rb#3791
   def lhs_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3771
+  # source://idlc//lib/idlc/ast.rb#3787
   def make_global; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#93
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#111
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3745
+  # source://idlc//lib/idlc/ast.rb#3761
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#3896
+  # source://idlc//lib/idlc/ast.rb#3912
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#3887
+  # source://idlc//lib/idlc/ast.rb#3903
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#3802
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#3818
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#3736
+  # source://idlc//lib/idlc/ast.rb#3752
   sig { returns(T.any(::Idl::BuiltinTypeNameAst, ::Idl::UserTypeNameAst)) }
   def type_name; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#3910
+    # source://idlc//lib/idlc/ast.rb#3926
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -7621,56 +7701,56 @@ class Idl::VariableDeclarationWithInitializationAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#3692
+# source://idlc//lib/idlc/ast.rb#3708
 class Idl::VariableDeclarationWithInitializationSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3693
+  # source://idlc//lib/idlc/ast.rb#3709
   def to_ast; end
 end
 
 # source://idlc//lib/idlc/idl_parser.rb#1394
 module Idl::VersionString0; end
 
-# source://idlc//lib/idlc/type.rb#1003
+# source://idlc//lib/idlc/type.rb#1023
 Idl::VoidType = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#4169
+# source://idlc//lib/idlc/ast.rb#4185
 class Idl::WidthRevealAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#4179
+  # source://idlc//lib/idlc/ast.rb#4195
   sig { params(input: T.nilable(::String), interval: T.nilable(T::Range[::Integer]), e: ::Idl::AstNode).void }
   def initialize(input, interval, e); end
 
-  # source://idlc//lib/idlc/ast.rb#4173
+  # source://idlc//lib/idlc/ast.rb#4189
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4176
+  # source://idlc//lib/idlc/ast.rb#4192
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def expression; end
 
-  # source://idlc//lib/idlc/ast.rb#4211
+  # source://idlc//lib/idlc/ast.rb#4227
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#4208
+  # source://idlc//lib/idlc/ast.rb#4224
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#4192
+  # source://idlc//lib/idlc/ast.rb#4208
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4184
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#4200
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#4201
+  # source://idlc//lib/idlc/ast.rb#4217
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Integer) }
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#4218
+    # source://idlc//lib/idlc/ast.rb#4234
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -7681,21 +7761,21 @@ class Idl::WidthRevealAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#4163
+# source://idlc//lib/idlc/ast.rb#4179
 class Idl::WidthRevealSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#4164
+  # source://idlc//lib/idlc/ast.rb#4180
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/type.rb#981
+# source://idlc//lib/idlc/type.rb#1001
 class Idl::XregType < ::Idl::Type
-  # source://idlc//lib/idlc/type.rb#982
+  # source://idlc//lib/idlc/type.rb#1002
   def initialize(xlen); end
 
-  # source://idlc//lib/idlc/type.rb#990
+  # source://idlc//lib/idlc/type.rb#1010
   def to_cxx; end
 
-  # source://idlc//lib/idlc/type.rb#986
+  # source://idlc//lib/idlc/type.rb#1006
   def to_s; end
 end
 
@@ -7725,14 +7805,14 @@ class Object < ::BasicObject
 
   private
 
-  # source://idlc//lib/idlc/passes/prune.rb#19
+  # source://idlc//lib/idlc/passes/prune.rb#23
   def create_bool_literal(value); end
 
   # source://idlc//lib/idlc/passes/prune.rb#14
-  def create_int_literal(value); end
+  def create_int_literal(value, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#27
-  def create_literal(symtab, value, type); end
+  # source://idlc//lib/idlc/passes/prune.rb#31
+  def create_literal(symtab, value, type, forced_type: T.unsafe(nil)); end
 end
 
 # source://idlc//lib/idlc/syntax_node.rb#11

--- a/tools/ruby-gems/udb-gen/sorbet/rbi/gems/udb@0.1.0.rbi
+++ b/tools/ruby-gems/udb-gen/sorbet/rbi/gems/udb@0.1.0.rbi
@@ -611,49 +611,49 @@ end
 # source://udb//../../udb/lib/udb/config.rb#33
 Udb::AbstractConfig::ParamValueType = T.type_alias { T.any(::Integer, ::String, T::Array[::Integer], T::Array[::String], T::Array[T::Boolean], T::Boolean) }
 
-# source://udb//../../udb/lib/udb/condition.rb#1723
+# source://udb//../../udb/lib/udb/condition.rb#1720
 class Udb::AlwaysFalseCondition < ::Udb::AbstractCondition
-  # source://udb//../../udb/lib/udb/condition.rb#1727
+  # source://udb//../../udb/lib/udb/condition.rb#1724
   sig { params(cfg_arch: ::Udb::ConfiguredArchitecture).void }
   def initialize(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1816
+  # source://udb//../../udb/lib/udb/condition.rb#1813
   sig { override.params(other: ::Udb::AbstractCondition).returns(::Udb::AbstractCondition) }
   def &(other); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1826
+  # source://udb//../../udb/lib/udb/condition.rb#1823
   sig { override.returns(::Udb::AbstractCondition) }
   def -@; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1748
+  # source://udb//../../udb/lib/udb/condition.rb#1745
   sig { override.params(_other: T.untyped).returns(T::Boolean) }
   def compatible?(_other); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1732
+  # source://udb//../../udb/lib/udb/condition.rb#1729
   sig { override.returns(T::Boolean) }
   def empty?; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1783
+  # source://udb//../../udb/lib/udb/condition.rb#1780
   sig { override.returns(T::Boolean) }
   def has_extension_requirement?; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1789
+  # source://udb//../../udb/lib/udb/condition.rb#1786
   sig { override.returns(T::Boolean) }
   def has_param?; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1812
+  # source://udb//../../udb/lib/udb/condition.rb#1809
   sig { override.params(expand: T::Boolean).returns(T::Array[::Udb::ConditionalExtensionRequirement]) }
   def implied_extension_conflicts(expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1809
+  # source://udb//../../udb/lib/udb/condition.rb#1806
   sig { override.params(expand: T::Boolean).returns(T::Array[::Udb::ConditionalExtensionRequirement]) }
   def implied_extension_requirements(expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1786
+  # source://udb//../../udb/lib/udb/condition.rb#1783
   sig { override.params(expand: T::Boolean).returns(::Udb::AbstractCondition) }
   def minimize(expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1774
+  # source://udb//../../udb/lib/udb/condition.rb#1771
   sig do
     override
       .params(
@@ -663,7 +663,7 @@ class Udb::AlwaysFalseCondition < ::Udb::AbstractCondition
   end
   def partial_eval(ext_reqs: T.unsafe(nil), expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1771
+  # source://udb//../../udb/lib/udb/condition.rb#1768
   sig do
     override
       .params(
@@ -673,122 +673,122 @@ class Udb::AlwaysFalseCondition < ::Udb::AbstractCondition
   end
   def partially_evaluate_for_params(cfg_arch, expand:); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1780
+  # source://udb//../../udb/lib/udb/condition.rb#1777
   sig { override.params(ext_req: ::Udb::ExtensionRequirement, include_requirements: T::Boolean).returns(T::Boolean) }
   def satisfiability_depends_on_ext_req?(ext_req, include_requirements: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1831
+  # source://udb//../../udb/lib/udb/condition.rb#1828
   sig { override.returns(T::Boolean) }
   def satisfiable?; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1762
+  # source://udb//../../udb/lib/udb/condition.rb#1759
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(T::Boolean) }
   def satisfiable_by_arch?(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1756
+  # source://udb//../../udb/lib/udb/condition.rb#1753
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(T::Boolean) }
   def satisfiable_by_cfg_arch?(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1768
+  # source://udb//../../udb/lib/udb/condition.rb#1765
   sig { override.params(_cfg_arch: ::Udb::ConfiguredArchitecture).returns(::Udb::SatisfiedResult) }
   def satisfied_by_cfg_arch?(_cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1777
+  # source://udb//../../udb/lib/udb/condition.rb#1774
   sig { override.params(ext_req: ::Udb::ExtensionRequirement, include_requirements: T::Boolean).returns(T::Boolean) }
   def satisfied_by_ext_req?(ext_req, include_requirements: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1806
+  # source://udb//../../udb/lib/udb/condition.rb#1803
   sig { override.returns(::String) }
   def to_asciidoc; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1751
+  # source://udb//../../udb/lib/udb/condition.rb#1748
   sig { override.returns(T.any(T::Boolean, T::Hash[::String, T.untyped])) }
   def to_h; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1792
+  # source://udb//../../udb/lib/udb/condition.rb#1789
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(::String) }
   def to_idl(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1735
+  # source://udb//../../udb/lib/udb/condition.rb#1732
   sig { override.params(expand: T::Boolean).returns(::Udb::LogicNode) }
   def to_logic_tree(expand:); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1743
+  # source://udb//../../udb/lib/udb/condition.rb#1740
   sig { override.returns(::Udb::LogicNode) }
   def to_logic_tree_internal; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1795
+  # source://udb//../../udb/lib/udb/condition.rb#1792
   sig { override.params(expand: T::Boolean).returns(::String) }
   def to_s(expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1798
+  # source://udb//../../udb/lib/udb/condition.rb#1795
   sig { override.returns(::String) }
   def to_s_pretty; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1803
+  # source://udb//../../udb/lib/udb/condition.rb#1800
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture, expand: T::Boolean).returns(::String) }
   def to_s_with_value(cfg_arch, expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1834
+  # source://udb//../../udb/lib/udb/condition.rb#1831
   sig { override.returns(T::Boolean) }
   def unsatisfiable?; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1765
+  # source://udb//../../udb/lib/udb/condition.rb#1762
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(T::Boolean) }
   def unsatisfiable_by_arch?(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1759
+  # source://udb//../../udb/lib/udb/condition.rb#1756
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(T::Boolean) }
   def unsatisfiable_by_cfg_arch?(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1821
+  # source://udb//../../udb/lib/udb/condition.rb#1818
   sig { override.params(other: ::Udb::AbstractCondition).returns(::Udb::AbstractCondition) }
   def |(other); end
 end
 
-# source://udb//../../udb/lib/udb/condition.rb#1609
+# source://udb//../../udb/lib/udb/condition.rb#1606
 class Udb::AlwaysTrueCondition < ::Udb::AbstractCondition
-  # source://udb//../../udb/lib/udb/condition.rb#1613
+  # source://udb//../../udb/lib/udb/condition.rb#1610
   sig { params(cfg_arch: ::Udb::ConfiguredArchitecture).void }
   def initialize(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1702
+  # source://udb//../../udb/lib/udb/condition.rb#1699
   sig { override.params(other: ::Udb::AbstractCondition).returns(::Udb::AbstractCondition) }
   def &(other); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1712
+  # source://udb//../../udb/lib/udb/condition.rb#1709
   sig { override.returns(::Udb::AbstractCondition) }
   def -@; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1635
+  # source://udb//../../udb/lib/udb/condition.rb#1632
   sig { override.params(_other: T.untyped).returns(T::Boolean) }
   def compatible?(_other); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1618
+  # source://udb//../../udb/lib/udb/condition.rb#1615
   sig { override.returns(T::Boolean) }
   def empty?; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1670
+  # source://udb//../../udb/lib/udb/condition.rb#1667
   sig { override.returns(T::Boolean) }
   def has_extension_requirement?; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1676
+  # source://udb//../../udb/lib/udb/condition.rb#1673
   sig { override.returns(T::Boolean) }
   def has_param?; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1699
+  # source://udb//../../udb/lib/udb/condition.rb#1696
   sig { override.params(expand: T::Boolean).returns(T::Array[::Udb::ConditionalExtensionRequirement]) }
   def implied_extension_conflicts(expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1696
+  # source://udb//../../udb/lib/udb/condition.rb#1693
   sig { override.params(expand: T::Boolean).returns(T::Array[::Udb::ConditionalExtensionRequirement]) }
   def implied_extension_requirements(expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1673
+  # source://udb//../../udb/lib/udb/condition.rb#1670
   sig { override.params(expand: T::Boolean).returns(::Udb::AbstractCondition) }
   def minimize(expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1661
+  # source://udb//../../udb/lib/udb/condition.rb#1658
   sig do
     override
       .params(
@@ -798,7 +798,7 @@ class Udb::AlwaysTrueCondition < ::Udb::AbstractCondition
   end
   def partial_eval(ext_reqs: T.unsafe(nil), expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1658
+  # source://udb//../../udb/lib/udb/condition.rb#1655
   sig do
     override
       .params(
@@ -808,75 +808,75 @@ class Udb::AlwaysTrueCondition < ::Udb::AbstractCondition
   end
   def partially_evaluate_for_params(cfg_arch, expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1667
+  # source://udb//../../udb/lib/udb/condition.rb#1664
   sig { override.params(ext_req: ::Udb::ExtensionRequirement, include_requirements: T::Boolean).returns(T::Boolean) }
   def satisfiability_depends_on_ext_req?(ext_req, include_requirements: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1717
+  # source://udb//../../udb/lib/udb/condition.rb#1714
   sig { override.returns(T::Boolean) }
   def satisfiable?; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1649
+  # source://udb//../../udb/lib/udb/condition.rb#1646
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(T::Boolean) }
   def satisfiable_by_arch?(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1643
+  # source://udb//../../udb/lib/udb/condition.rb#1640
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(T::Boolean) }
   def satisfiable_by_cfg_arch?(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1655
+  # source://udb//../../udb/lib/udb/condition.rb#1652
   sig { override.params(_cfg_arch: ::Udb::ConfiguredArchitecture).returns(::Udb::SatisfiedResult) }
   def satisfied_by_cfg_arch?(_cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1664
+  # source://udb//../../udb/lib/udb/condition.rb#1661
   sig { override.params(ext_req: ::Udb::ExtensionRequirement, include_requirements: T::Boolean).returns(T::Boolean) }
   def satisfied_by_ext_req?(ext_req, include_requirements: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1693
+  # source://udb//../../udb/lib/udb/condition.rb#1690
   sig { override.returns(::String) }
   def to_asciidoc; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1638
+  # source://udb//../../udb/lib/udb/condition.rb#1635
   sig { override.returns(T.any(T::Boolean, T::Hash[::String, T.untyped])) }
   def to_h; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1679
+  # source://udb//../../udb/lib/udb/condition.rb#1676
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(::String) }
   def to_idl(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1621
+  # source://udb//../../udb/lib/udb/condition.rb#1618
   sig { override.params(expand: T::Boolean).returns(::Udb::LogicNode) }
   def to_logic_tree(expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1630
+  # source://udb//../../udb/lib/udb/condition.rb#1627
   sig { override.returns(::Udb::LogicNode) }
   def to_logic_tree_internal; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1682
+  # source://udb//../../udb/lib/udb/condition.rb#1679
   sig { override.params(expand: T::Boolean).returns(::String) }
   def to_s(expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1685
+  # source://udb//../../udb/lib/udb/condition.rb#1682
   sig { override.returns(::String) }
   def to_s_pretty; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1690
+  # source://udb//../../udb/lib/udb/condition.rb#1687
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture, expand: T::Boolean).returns(::String) }
   def to_s_with_value(cfg_arch, expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1720
+  # source://udb//../../udb/lib/udb/condition.rb#1717
   sig { override.returns(T::Boolean) }
   def unsatisfiable?; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1652
+  # source://udb//../../udb/lib/udb/condition.rb#1649
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(T::Boolean) }
   def unsatisfiable_by_arch?(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1646
+  # source://udb//../../udb/lib/udb/condition.rb#1643
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(T::Boolean) }
   def unsatisfiable_by_cfg_arch?(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1707
+  # source://udb//../../udb/lib/udb/condition.rb#1704
   sig { override.params(other: ::Udb::AbstractCondition).returns(::Udb::AbstractCondition) }
   def |(other); end
 end
@@ -1008,11 +1008,11 @@ class Udb::Condition < ::Udb::AbstractCondition
   end
   def initialize(yaml, cfg_arch, input_file: T.unsafe(nil), input_line: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1576
+  # source://udb//../../udb/lib/udb/condition.rb#1573
   sig { override.params(other: ::Udb::AbstractCondition).returns(::Udb::AbstractCondition) }
   def &(other); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1586
+  # source://udb//../../udb/lib/udb/condition.rb#1583
   sig { override.returns(::Udb::AbstractCondition) }
   def -@; end
 
@@ -1034,23 +1034,23 @@ class Udb::Condition < ::Udb::AbstractCondition
   sig { params(tree: ::Udb::LogicNode, expansion_clauses: T::Array[::Udb::LogicNode]).void }
   def expand_to_enforce_single_ext_ver(tree, expansion_clauses); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1007
+  # source://udb//../../udb/lib/udb/condition.rb#1004
   sig { override.returns(T::Boolean) }
   def has_extension_requirement?; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1002
+  # source://udb//../../udb/lib/udb/condition.rb#999
   sig { override.returns(T::Boolean) }
   def has_param?; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1394
+  # source://udb//../../udb/lib/udb/condition.rb#1391
   sig { override.params(expand: T::Boolean).returns(T::Array[::Udb::ConditionalExtensionRequirement]) }
   def implied_extension_conflicts(expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1320
+  # source://udb//../../udb/lib/udb/condition.rb#1317
   sig { override.params(expand: T::Boolean).returns(T::Array[::Udb::ConditionalExtensionRequirement]) }
   def implied_extension_requirements(expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1014
+  # source://udb//../../udb/lib/udb/condition.rb#1011
   sig do
     params(
       blk: T.proc.params(term: T.any(::Udb::ExtensionTerm, ::Udb::FreeTerm, ::Udb::ParameterTerm, ::Udb::XlenTerm)).returns(::Udb::SatisfiedResult)
@@ -1058,11 +1058,11 @@ class Udb::Condition < ::Udb::AbstractCondition
   end
   def make_cb_proc(&blk); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#939
+  # source://udb//../../udb/lib/udb/condition.rb#936
   sig { override.params(expand: T::Boolean).returns(::Udb::AbstractCondition) }
   def minimize(expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1225
+  # source://udb//../../udb/lib/udb/condition.rb#1222
   sig do
     override
       .params(
@@ -1072,34 +1072,34 @@ class Udb::Condition < ::Udb::AbstractCondition
   end
   def partial_eval(ext_reqs: T.unsafe(nil), expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1020
+  # source://udb//../../udb/lib/udb/condition.rb#1017
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture, expand: T::Boolean).returns(::Udb::Condition) }
   def partially_evaluate_for_params(cfg_arch, expand:); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#840
+  # source://udb//../../udb/lib/udb/condition.rb#837
   def sat_arch_model(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1216
+  # source://udb//../../udb/lib/udb/condition.rb#1213
   sig { override.params(ext_req: ::Udb::ExtensionRequirement, include_requirements: T::Boolean).returns(T::Boolean) }
   def satisfiability_depends_on_ext_req?(ext_req, include_requirements: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#928
+  # source://udb//../../udb/lib/udb/condition.rb#925
   sig { override.returns(T::Boolean) }
   def satisfiable?; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#907
+  # source://udb//../../udb/lib/udb/condition.rb#904
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(T::Boolean) }
   def satisfiable_by_arch?(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#875
+  # source://udb//../../udb/lib/udb/condition.rb#872
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(T::Boolean) }
   def satisfiable_by_cfg_arch?(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1100
+  # source://udb//../../udb/lib/udb/condition.rb#1097
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(::Udb::SatisfiedResult) }
   def satisfied_by_cfg_arch?(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1200
+  # source://udb//../../udb/lib/udb/condition.rb#1197
   sig { override.params(ext_req: ::Udb::ExtensionRequirement, include_requirements: T::Boolean).returns(T::Boolean) }
   def satisfied_by_ext_req?(ext_req, include_requirements: T.unsafe(nil)); end
 
@@ -1112,18 +1112,18 @@ class Udb::Condition < ::Udb::AbstractCondition
   end
   def solver(&blk); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1315
+  # source://udb//../../udb/lib/udb/condition.rb#1312
   sig { override.returns(::String) }
   def to_asciidoc; end
 
   # source://udb//../../udb/lib/udb/condition.rb#659
   def to_expanded_logic_tree_shallow; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1241
+  # source://udb//../../udb/lib/udb/condition.rb#1238
   sig { override.returns(T.any(T::Boolean, T::Hash[::String, T.untyped])) }
   def to_h; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1246
+  # source://udb//../../udb/lib/udb/condition.rb#1243
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(::String) }
   def to_idl(cfg_arch); end
 
@@ -1131,41 +1131,41 @@ class Udb::Condition < ::Udb::AbstractCondition
   sig { override.params(expand: T::Boolean).returns(::Udb::LogicNode) }
   def to_logic_tree(expand:); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#948
+  # source://udb//../../udb/lib/udb/condition.rb#945
   sig { override.returns(::Udb::LogicNode) }
   def to_logic_tree_internal; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1252
+  # source://udb//../../udb/lib/udb/condition.rb#1249
   sig { override.params(expand: T::Boolean).returns(::String) }
   def to_s(expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1258
+  # source://udb//../../udb/lib/udb/condition.rb#1255
   sig { override.returns(::String) }
   def to_s_pretty; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1263
+  # source://udb//../../udb/lib/udb/condition.rb#1260
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture, expand: T::Boolean).returns(::String) }
   def to_s_with_value(cfg_arch, expand: T.unsafe(nil)); end
 
   # source://udb//../../udb/lib/udb/condition.rb#801
   def unsat_arch_core(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#934
+  # source://udb//../../udb/lib/udb/condition.rb#931
   sig { override.returns(T::Boolean) }
   def unsatisfiable?; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#917
+  # source://udb//../../udb/lib/udb/condition.rb#914
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(T::Boolean) }
   def unsatisfiable_by_arch?(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#885
+  # source://udb//../../udb/lib/udb/condition.rb#882
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(T::Boolean) }
   def unsatisfiable_by_cfg_arch?(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#823
+  # source://udb//../../udb/lib/udb/condition.rb#821
   def z3_assertions(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1581
+  # source://udb//../../udb/lib/udb/condition.rb#1578
   sig { override.params(other: ::Udb::AbstractCondition).returns(::Udb::AbstractCondition) }
   def |(other); end
 
@@ -1203,12 +1203,12 @@ class Udb::Condition < ::Udb::AbstractCondition
   sig { params(tree: ::Udb::LogicNode, expansion_clauses: T::Array[::Udb::LogicNode]).void }
   def expand_xlen(tree, expansion_clauses); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#958
+  # source://udb//../../udb/lib/udb/condition.rb#955
   sig { overridable.params(yaml: T.any(T::Boolean, T::Hash[::String, T.untyped])).returns(::Udb::LogicNode) }
   def to_logic_tree_helper(yaml); end
 
   class << self
-    # source://udb//../../udb/lib/udb/condition.rb#1487
+    # source://udb//../../udb/lib/udb/condition.rb#1484
     sig do
       params(
         conditions: T::Array[::Udb::AbstractCondition],
@@ -1217,7 +1217,7 @@ class Udb::Condition < ::Udb::AbstractCondition
     end
     def conjunction(conditions, cfg_arch); end
 
-    # source://udb//../../udb/lib/udb/condition.rb#1511
+    # source://udb//../../udb/lib/udb/condition.rb#1508
     sig do
       params(
         conditions: T::Array[::Udb::AbstractCondition],
@@ -1235,7 +1235,7 @@ class Udb::Condition < ::Udb::AbstractCondition
     end
     def join(cfg_arch, conds); end
 
-    # source://udb//../../udb/lib/udb/condition.rb#1558
+    # source://udb//../../udb/lib/udb/condition.rb#1555
     sig do
       params(
         condition: ::Udb::AbstractCondition,
@@ -1244,7 +1244,7 @@ class Udb::Condition < ::Udb::AbstractCondition
     end
     def not(condition, cfg_arch); end
 
-    # source://udb//../../udb/lib/udb/condition.rb#1535
+    # source://udb//../../udb/lib/udb/condition.rb#1532
     sig do
       params(
         conditions: T::Array[::Udb::AbstractCondition],
@@ -1256,11 +1256,11 @@ class Udb::Condition < ::Udb::AbstractCondition
     # source://udb//../../udb/lib/udb/condition.rb#711
     def solver; end
 
-    # source://udb//../../udb/lib/udb/condition.rb#895
+    # source://udb//../../udb/lib/udb/condition.rb#892
     sig { params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(::Udb::Z3Solver) }
     def solver_for_arch(cfg_arch); end
 
-    # source://udb//../../udb/lib/udb/condition.rb#863
+    # source://udb//../../udb/lib/udb/condition.rb#860
     sig { params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(::Udb::Z3Solver) }
     def solver_for_cfg_arch(cfg_arch); end
 
@@ -1281,7 +1281,7 @@ class Udb::Condition < ::Udb::AbstractCondition
   end
 end
 
-# source://udb//../../udb/lib/udb/condition.rb#1011
+# source://udb//../../udb/lib/udb/condition.rb#1008
 Udb::Condition::EvalCallbackType = T.type_alias { T.proc.params(term: T.any(::Udb::ExtensionTerm, ::Udb::FreeTerm, ::Udb::ParameterTerm, ::Udb::XlenTerm)).returns(::Udb::SatisfiedResult) }
 
 # source://udb//../../udb/lib/udb/condition.rb#427
@@ -1289,10 +1289,10 @@ class Udb::Condition::MemoizedState < ::T::Struct
   prop :satisfied_by_cfg_arch, T::Hash[::Udb::ConfiguredArchitecture, ::Udb::SatisfiedResult]
 end
 
-# source://udb//../../udb/lib/udb/condition.rb#1997
+# source://udb//../../udb/lib/udb/condition.rb#1994
 Udb::Condition::Xlen32 = T.let(T.unsafe(nil), Udb::XlenCondition)
 
-# source://udb//../../udb/lib/udb/condition.rb#1998
+# source://udb//../../udb/lib/udb/condition.rb#1995
 Udb::Condition::Xlen64 = T.let(T.unsafe(nil), Udb::XlenCondition)
 
 # source://udb//../../udb/lib/udb/condition.rb#26
@@ -1318,17 +1318,13 @@ end
 
 # source://udb//../../udb/lib/udb/condition.rb#19
 class Udb::ConfiguredArchitecture < ::Udb::Architecture
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#610
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#578
   sig { params(name: ::String, config: ::Udb::AbstractConfig).void }
   def initialize(name, config); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1217
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1226
   sig { returns(::Udb::Condition) }
   def arch_condition; end
-
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#521
-  sig { returns(::Idl::SymbolTable) }
-  def arch_symtab; end
 
   # source://udb//../../udb/lib/udb/cfg_arch.rb#51
   sig { returns(::Udb::AbstractConfig) }
@@ -1338,20 +1334,20 @@ class Udb::ConfiguredArchitecture < ::Udb::Architecture
   sig { returns(::Udb::ConfigType) }
   def config_type; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1506
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1515
   sig { params(adoc: ::String).returns(::String) }
   def convert_monospace_to_links(adoc); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def csr(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def csr_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def csrs; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1172
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1181
   sig { params(show_progress: T::Boolean).returns(T::Array[::Udb::Csr]) }
   def csrs_that_must_be_implemented(show_progress: T.unsafe(nil)); end
 
@@ -1359,32 +1355,32 @@ class Udb::ConfiguredArchitecture < ::Udb::Architecture
   sig { override.params(other: ::BasicObject).returns(T::Boolean) }
   def eql?(other); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def exception_code(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def exception_code_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def exception_codes; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#892
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#901
   sig { params(ext_vers: T::Array[::Udb::ExtensionVersion]).returns(T::Array[::Udb::ExtensionVersion]) }
   def expand_implemented_extension_list(ext_vers); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#836
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#845
   def explicitly_implemented_extension_versions; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1054
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1063
   def ext?(ext_name, ext_version_requirements = T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def extension(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def extension_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#842
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#851
   sig do
     params(
       name: ::String,
@@ -1393,14 +1389,14 @@ class Udb::ConfiguredArchitecture < ::Udb::Architecture
   end
   def extension_requirement(name, requirements); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#874
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#883
   sig { params(name: ::String, version: T.any(::String, ::Udb::VersionSpec)).returns(::Udb::ExtensionVersion) }
   def extension_version(name, version); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def extensions; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1120
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1129
   sig { returns(::Idl::FetchAst) }
   def fetch; end
 
@@ -1408,15 +1404,15 @@ class Udb::ConfiguredArchitecture < ::Udb::Architecture
   sig { returns(T::Boolean) }
   def fully_configured?; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1114
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1123
   sig { params(name: ::String).returns(T.nilable(::Idl::FunctionDefAst)) }
   def function(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1109
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1118
   sig { returns(T::Hash[::String, ::Idl::FunctionDefAst]) }
   def function_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1104
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1113
   sig { returns(T::Array[::Idl::FunctionDefAst]) }
   def functions; end
 
@@ -1424,7 +1420,7 @@ class Udb::ConfiguredArchitecture < ::Udb::Architecture
   sig { returns(::Idl::IsaAst) }
   def global_ast; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1126
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1135
   sig { returns(T::Array[T.any(::Idl::GlobalAst, ::Idl::GlobalWithInitializationAst)]) }
   def globals; end
 
@@ -1436,118 +1432,118 @@ class Udb::ConfiguredArchitecture < ::Udb::Architecture
   sig { returns(::Idl::Compiler) }
   def idl_compiler; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1134
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1143
   sig { returns(T::Array[::Udb::Csr]) }
   def implemented_csrs; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1090
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1099
   sig { returns(T::Array[::Udb::ExceptionCode]) }
   def implemented_exception_codes; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#912
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#921
   sig { params(ext_name: ::String).returns(T.nilable(::Udb::ExtensionVersion)) }
   def implemented_extension_version(ext_name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#822
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#831
   sig { returns(T::Array[::Udb::ExtensionVersion]) }
   def implemented_extension_versions; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1392
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1401
   sig { returns(T::Array[::Idl::FunctionDefAst]) }
   def implemented_functions; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1320
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1329
   sig { returns(T::Array[::Udb::Instruction]) }
   def implemented_instructions; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1097
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1106
   sig { returns(T::Array[::Udb::InterruptCode]) }
   def implemented_interrupt_codes; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1647
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1656
   sig { returns(T::Array[T.untyped]) }
   def implemented_non_isa_specs; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1284
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1293
   sig { returns(::Udb::Condition) }
   def in_scope_condition; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1197
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1206
   sig { params(show_progress: T::Boolean).returns(T::Array[::Udb::Csr]) }
   def in_scope_csrs(show_progress: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#631
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#599
   def inspect; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def instruction(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def instruction_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def instruction_subtype(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def instruction_subtype_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def instruction_subtypes; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def instruction_type(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def instruction_type_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def instruction_types; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def instructions; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def interrupt_code(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def interrupt_code_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def interrupt_codes; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1386
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1395
   sig { returns(::Integer) }
   def largest_encoding; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#921
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#930
   sig { returns(T::Array[::Udb::ExtensionRequirement]) }
   def mandatory_extension_reqs; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def manual(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def manual_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def manual_version(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def manual_version_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def manual_versions; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def manuals; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def mmr(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def mmr_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def mmrs; end
 
   # source://udb//../../udb/lib/udb/cfg_arch.rb#81
@@ -1566,45 +1562,45 @@ class Udb::ConfiguredArchitecture < ::Udb::Architecture
   sig { returns(::String) }
   def name; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#940
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#949
   sig { returns(T::Array[::Udb::ExtensionRequirement]) }
   def non_mandatory_extension_reqs; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1169
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1178
   def not_prohibited_csrs(*args, **_arg1, &blk); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#993
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1002
   def not_prohibited_extensions(*args, **_arg1, &blk); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1382
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1391
   def not_prohibited_instructions(*args, **_arg1, &blk); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#960
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#969
   sig { returns(T::Array[::Udb::ExtensionRequirement]) }
   def optional_extension_versions; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#806
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#815
   sig { returns(T::Array[::Udb::Parameter]) }
   def out_of_scope_params; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def param(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def param_hash; end
 
   # source://udb//../../udb/lib/udb/cfg_arch.rb#68
   sig { returns(T::Hash[::String, T.untyped]) }
   def param_values; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def params; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#781
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#790
   sig { returns(T::Array[::Udb::ParameterWithValue]) }
   def params_with_value; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#796
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#805
   sig { returns(T::Array[::Udb::Parameter]) }
   def params_without_value; end
 
@@ -1616,22 +1612,22 @@ class Udb::ConfiguredArchitecture < ::Udb::Architecture
   sig { returns(T::Boolean) }
   def partially_configured?; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1152
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1161
   sig { params(show_progress: T::Boolean).returns(T::Array[::Udb::Csr]) }
   def possible_csrs(show_progress: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1005
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1014
   def possible_extension_versions; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#980
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#989
   sig { returns(T::Array[::Udb::Extension]) }
   def possible_extensions; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1356
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1365
   sig { params(show_progress: T::Boolean).returns(T::Array[::Udb::Instruction]) }
   def possible_instructions(show_progress: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1616
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1625
   sig { returns(T::Array[T.untyped]) }
   def possible_non_isa_specs; end
 
@@ -1639,86 +1635,86 @@ class Udb::ConfiguredArchitecture < ::Udb::Architecture
   sig { returns(T::Array[::Integer]) }
   def possible_xlens; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def prm(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def prm_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def prms; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def proc_cert_class(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def proc_cert_class_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def proc_cert_classes; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def proc_cert_model(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def proc_cert_model_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def proc_cert_models; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def profile(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def profile_families; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def profile_family(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def profile_family_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def profile_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def profile_release(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def profile_release_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def profile_releases; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def profiles; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1030
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1039
   sig { params(ext: T.any(::String, ::Symbol, ::Udb::ExtensionVersion)).returns(T::Boolean) }
   def prohibited_ext?(ext); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#999
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1008
   sig { returns(T::Array[::Udb::ExtensionVersion]) }
   def prohibited_extension_versions; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1337
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1346
   sig { returns(T::Array[::Udb::Instruction]) }
   def prohibited_instructions; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1438
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1447
   sig { params(show_progress: T::Boolean).returns(T::Array[::Idl::FunctionDefAst]) }
   def reachable_functions(show_progress: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#690
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#658
   def register_file(name); end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#682
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#650
   def register_file_hash; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#666
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#634
   def register_files; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1598
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1607
   sig { params(erb_template: ::String, what: ::String).returns(::String) }
   def render_erb(erb_template, what = T.unsafe(nil)); end
 
@@ -1726,26 +1722,26 @@ class Udb::ConfiguredArchitecture < ::Udb::Architecture
   sig { returns(::Idl::SymbolTable) }
   def symtab; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1238
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1247
   sig { returns(::Udb::Condition) }
   def to_condition; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1148
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1157
   def transitive_implemented_csrs; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#839
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#848
   def transitive_implemented_extension_versions; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1333
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1342
   def transitive_implemented_instructions; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1658
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1667
   def transitive_implemented_non_isa_specs; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1352
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1361
   def transitive_prohibited_instructions; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#710
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#678
   sig { params(show_progress: T::Boolean, io: ::IO).void }
   def type_check(show_progress: T.unsafe(nil), io: T.unsafe(nil)); end
 
@@ -1759,11 +1755,11 @@ class Udb::ConfiguredArchitecture < ::Udb::Architecture
 
   private
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#551
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#519
   sig { returns(::Idl::SymbolTable) }
   def create_symtab; end
 
-  # source://udb//../../udb/lib/udb/cfg_arch.rb#1533
+  # source://udb//../../udb/lib/udb/cfg_arch.rb#1542
   sig { returns(::Object) }
   def erb_env; end
 
@@ -1784,13 +1780,13 @@ class Udb::ConfiguredArchitecture < ::Udb::Architecture
   def symtab_enums; end
 
   class << self
-    # source://udb//../../udb/lib/udb/cfg_arch.rb#662
+    # source://udb//../../udb/lib/udb/cfg_arch.rb#630
     sig { params(fn_name: ::String, arch_dir: ::String, obj_class: T.class_of(Udb::TopLevelDatabaseObject)).void }
     def generate_obj_methods(fn_name, arch_dir, obj_class); end
   end
 end
 
-# source://udb//../../udb/lib/udb/cfg_arch.rb#592
+# source://udb//../../udb/lib/udb/cfg_arch.rb#560
 class Udb::ConfiguredArchitecture::MemoizedState < ::T::Struct
   prop :multi_xlen_in_mode, T::Hash[::String, T::Boolean]
   prop :multi_xlen, T.nilable(T::Boolean)
@@ -2014,30 +2010,30 @@ class Udb::CsrField < ::Udb::DatabaseObject
   sig { returns(T.nilable(::Integer)) }
   def base; end
 
-  # source://udb//../../udb/lib/udb/obj/csr_field.rb#699
+  # source://udb//../../udb/lib/udb/obj/csr_field.rb#701
   sig { override.returns(T::Boolean) }
   def base32_only?; end
 
-  # source://udb//../../udb/lib/udb/obj/csr_field.rb#695
+  # source://udb//../../udb/lib/udb/obj/csr_field.rb#697
   sig { override.returns(T::Boolean) }
   def base64_only?; end
 
   # source://udb//../../udb/lib/udb/obj/csr_field.rb#346
   def csr(*args, **_arg1, &blk); end
 
-  # source://udb//../../udb/lib/udb/obj/csr_field.rb#712
+  # source://udb//../../udb/lib/udb/obj/csr_field.rb#714
   sig { override.returns(T::Boolean) }
   def defined_in_all_bases?; end
 
-  # source://udb//../../udb/lib/udb/obj/csr_field.rb#702
+  # source://udb//../../udb/lib/udb/obj/csr_field.rb#704
   sig { override.returns(T::Boolean) }
   def defined_in_base32?; end
 
-  # source://udb//../../udb/lib/udb/obj/csr_field.rb#705
+  # source://udb//../../udb/lib/udb/obj/csr_field.rb#707
   sig { override.returns(T::Boolean) }
   def defined_in_base64?; end
 
-  # source://udb//../../udb/lib/udb/obj/csr_field.rb#708
+  # source://udb//../../udb/lib/udb/obj/csr_field.rb#710
   sig { params(xlen: ::Integer).returns(T::Boolean) }
   def defined_in_base?(xlen); end
 
@@ -2061,34 +2057,34 @@ class Udb::CsrField < ::Udb::DatabaseObject
   def fill_symtab_for_reset(ast); end
 
   # source://udb//../../udb/lib/udb/obj/csr_field.rb#537
-  sig { params(effective_xlen: T.nilable(::Integer), ast: ::Idl::AstNode).returns(::Idl::SymbolTable) }
+  sig { params(effective_xlen: T.nilable(::Integer), ast: T.nilable(::Idl::AstNode)).returns(::Idl::SymbolTable) }
   def fill_symtab_for_sw_write(effective_xlen, ast); end
 
   # source://udb//../../udb/lib/udb/obj/csr_field.rb#569
-  sig { params(effective_xlen: T.nilable(::Integer), ast: ::Idl::AstNode).returns(::Idl::SymbolTable) }
+  sig { params(effective_xlen: T.nilable(::Integer), ast: T.nilable(::Idl::AstNode)).returns(::Idl::SymbolTable) }
   def fill_symtab_for_type(effective_xlen, ast); end
 
   # source://udb//../../udb/lib/udb/obj/csr_field.rb#469
   sig { returns(T::Boolean) }
   def has_custom_sw_write?; end
 
-  # source://udb//../../udb/lib/udb/obj/csr_field.rb#648
+  # source://udb//../../udb/lib/udb/obj/csr_field.rb#650
   sig { override.params(effective_xlen: T.nilable(::Integer)).returns(T::Range[::Integer]) }
   def location(effective_xlen = T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/obj/csr_field.rb#736
+  # source://udb//../../udb/lib/udb/obj/csr_field.rb#758
   sig { returns(::String) }
   def location_cond32; end
 
-  # source://udb//../../udb/lib/udb/obj/csr_field.rb#752
+  # source://udb//../../udb/lib/udb/obj/csr_field.rb#774
   sig { returns(::String) }
   def location_cond64; end
 
-  # source://udb//../../udb/lib/udb/obj/csr_field.rb#770
+  # source://udb//../../udb/lib/udb/obj/csr_field.rb#792
   sig { params(effective_xlen: T.nilable(::Integer)).returns(::String) }
   def location_pretty(effective_xlen = T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/obj/csr_field.rb#722
+  # source://udb//../../udb/lib/udb/obj/csr_field.rb#744
   sig { returns(::Integer) }
   def max_width; end
 
@@ -2104,7 +2100,7 @@ class Udb::CsrField < ::Udb::DatabaseObject
   sig { returns(T.nilable(::Idl::FunctionBodyAst)) }
   def pruned_reset_value_ast; end
 
-  # source://udb//../../udb/lib/udb/obj/csr_field.rb#616
+  # source://udb//../../udb/lib/udb/obj/csr_field.rb#618
   sig { params(effective_xlen: T.nilable(::Integer)).returns(T.nilable(::Idl::AstNode)) }
   def pruned_sw_write_ast(effective_xlen); end
 
@@ -2164,7 +2160,7 @@ class Udb::CsrField < ::Udb::DatabaseObject
   sig { params(effective_xlen: T.nilable(::Integer)).returns(T.nilable(::Idl::FunctionBodyAst)) }
   def type_checked_type_ast(effective_xlen); end
 
-  # source://udb//../../udb/lib/udb/obj/csr_field.rb#856
+  # source://udb//../../udb/lib/udb/obj/csr_field.rb#878
   sig { params(effective_xlen: T.nilable(::Integer)).returns(::String) }
   def type_desc(effective_xlen = T.unsafe(nil)); end
 
@@ -2172,7 +2168,7 @@ class Udb::CsrField < ::Udb::DatabaseObject
   sig { params(effective_xlen: T.nilable(::Integer)).returns(::String) }
   def type_pretty(effective_xlen = T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/obj/csr_field.rb#717
+  # source://udb//../../udb/lib/udb/obj/csr_field.rb#719
   sig { override.params(effective_xlen: T.nilable(::Integer)).returns(::Integer) }
   def width(effective_xlen); end
 end
@@ -2214,7 +2210,7 @@ class Udb::CsrField::MemoizedState < ::T::Struct
   prop :reachable_functions, T::Hash[T.any(::Integer, ::Symbol), T::Array[::Idl::FunctionDefAst]]
 end
 
-# source://udb//../../udb/lib/udb/obj/csr_field.rb#805
+# source://udb//../../udb/lib/udb/obj/csr_field.rb#827
 Udb::CsrField::TYPE_DESC_MAP = T.let(T.unsafe(nil), Hash)
 
 # source://udb//../../udb/lib/udb/condition.rb#16
@@ -2635,23 +2631,23 @@ class Udb::Extension::ConditionallyApplicableParameter < ::T::Struct
   prop :param, ::Udb::Parameter
 end
 
-# source://udb//../../udb/lib/udb/condition.rb#1895
+# source://udb//../../udb/lib/udb/condition.rb#1892
 class Udb::ExtensionCondition < ::Udb::Condition
-  # source://udb//../../udb/lib/udb/condition.rb#1899
+  # source://udb//../../udb/lib/udb/condition.rb#1896
   sig { params(yaml: T::Hash[::String, T.untyped], cfg_arch: ::Udb::ConfiguredArchitecture).void }
   def initialize(yaml, cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1904
+  # source://udb//../../udb/lib/udb/condition.rb#1901
   sig { override.returns(::Udb::LogicNode) }
   def to_logic_tree_internal; end
 
   private
 
-  # source://udb//../../udb/lib/udb/condition.rb#1916
+  # source://udb//../../udb/lib/udb/condition.rb#1913
   sig { params(yaml: T::Hash[::String, T.untyped], cfg_arch: ::Udb::ConfiguredArchitecture).returns(::Udb::LogicNode) }
   def ext_req_to_logic_node(yaml, cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1930
+  # source://udb//../../udb/lib/udb/condition.rb#1927
   sig { override.params(yaml: T.any(T::Boolean, T::Hash[::String, T.untyped])).returns(::Udb::LogicNode) }
   def to_logic_tree_helper(yaml); end
 end
@@ -2836,30 +2832,30 @@ class Udb::ExtensionRequirement
   end
 end
 
-# source://udb//../../udb/lib/udb/condition.rb#2077
+# source://udb//../../udb/lib/udb/condition.rb#2074
 class Udb::ExtensionRequirementList
-  # source://udb//../../udb/lib/udb/condition.rb#2088
+  # source://udb//../../udb/lib/udb/condition.rb#2085
   sig { params(yaml: T::Hash[::String, T.untyped], cfg_arch: ::Udb::ConfiguredArchitecture).void }
   def initialize(yaml, cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#2108
+  # source://udb//../../udb/lib/udb/condition.rb#2105
   sig { params(yaml: T::Hash[::String, T.untyped], l: T::Array[::Udb::ConditionalExtensionRequirement]).void }
   def do_list(yaml, l); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#2128
+  # source://udb//../../udb/lib/udb/condition.rb#2125
   sig { returns(T::Array[::Udb::ConditionalExtensionVersion]) }
   def implied_extension_versions; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#2119
+  # source://udb//../../udb/lib/udb/condition.rb#2116
   sig { returns(T::Array[::Udb::ConditionalExtensionRequirement]) }
   def list; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#2096
+  # source://udb//../../udb/lib/udb/condition.rb#2093
   sig { params(yaml: T::Hash[::String, T.untyped]).returns(::Udb::ConditionalExtensionRequirement) }
   def make_cond_ext_req(yaml); end
 end
 
-# source://udb//../../udb/lib/udb/condition.rb#2080
+# source://udb//../../udb/lib/udb/condition.rb#2077
 class Udb::ExtensionRequirementList::ParseState < ::T::Enum
   enums do
     Condition = new
@@ -3332,9 +3328,9 @@ module Udb::HasFields
   def writable; end
 end
 
-# source://udb//../../udb/lib/udb/condition.rb#2001
+# source://udb//../../udb/lib/udb/condition.rb#1998
 class Udb::IdlCondition < ::Udb::Condition
-  # source://udb//../../udb/lib/udb/condition.rb#2015
+  # source://udb//../../udb/lib/udb/condition.rb#2012
   sig do
     params(
       yaml: T::Hash[::String, T.untyped],
@@ -3345,23 +3341,23 @@ class Udb::IdlCondition < ::Udb::Condition
   end
   def initialize(yaml, cfg_arch, input_file:, input_line:); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#2022
+  # source://udb//../../udb/lib/udb/condition.rb#2019
   sig { returns(::Udb::Constraint) }
   def constraint; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#2004
+  # source://udb//../../udb/lib/udb/condition.rb#2001
   sig { returns(::String) }
   def reason; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#2037
+  # source://udb//../../udb/lib/udb/condition.rb#2034
   sig { override.returns(T.any(T::Boolean, T::Hash[::String, T.untyped])) }
   def to_h; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#2040
+  # source://udb//../../udb/lib/udb/condition.rb#2037
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(::String) }
   def to_idl(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#2032
+  # source://udb//../../udb/lib/udb/condition.rb#2029
   sig { override.returns(::Udb::LogicNode) }
   def to_logic_tree_internal; end
 end
@@ -3393,32 +3389,32 @@ class Udb::Instruction < ::Udb::TopLevelDatabaseObject
   # source://udb//../../udb/lib/udb/obj/instruction.rb#386
   def access_detail; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1146
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1180
   def access_detail?; end
 
   # source://udb//../../udb/lib/udb/obj/instruction.rb#414
   def assembly; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1030
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1064
   def bad_encoding_conflict?(xlen, other_inst); end
 
   # source://udb//../../udb/lib/udb/obj/instruction.rb#391
   sig { returns(T.nilable(::Integer)) }
   def base; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1044
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1078
   def conflicting_instructions(xlen); end
 
   # source://udb//../../udb/lib/udb/obj/instruction.rb#405
   def data_independent_timing?; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1141
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1175
   def decode_variables(base); end
 
   # source://udb//../../udb/lib/udb/obj/instruction.rb#409
   def defined_in_base?(xlen); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1109
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1143
   sig { params(base: ::Integer).returns(::Udb::Instruction::Encoding) }
   def encoding(base); end
 
@@ -3426,14 +3422,14 @@ class Udb::Instruction < ::Udb::TopLevelDatabaseObject
   sig { params(base: ::Integer).returns(::String) }
   def encoding_format(base); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1119
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1153
   sig { returns(::Integer) }
   def encoding_width; end
 
   # source://udb//../../udb/lib/udb/obj/instruction.rb#127
   def eql?(other); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1185
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1219
   def exists_in_cfg?(cfg_arch); end
 
   # source://udb//../../udb/lib/udb/obj/instruction.rb#418
@@ -3443,58 +3439,58 @@ class Udb::Instruction < ::Udb::TopLevelDatabaseObject
   sig { returns(T::Boolean) }
   def has_type?; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1179
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1213
   def hints; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#496
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#530
   def mask_to_array(int); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1136
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1170
   sig { returns(::Integer) }
   def max_encoding_width; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1021
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1055
   def multi_encoding?; end
 
   # source://udb//../../udb/lib/udb/obj/instruction.rb#194
   sig { params(base: ::Integer).returns(T::Array[::Udb::Instruction::Opcode]) }
   def opcodes(base); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1088
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1122
   def operation_ast; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1237
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1271
   sig { params(expand: T::Boolean).returns(T::Array[::Udb::Condition]) }
   def other_requirements(expand: T.unsafe(nil)); end
 
   # source://udb//../../udb/lib/udb/obj/instruction.rb#256
   def processed_wavedrom_desc(base); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1273
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1307
   sig { returns(T::Array[::Udb::Profile]) }
   def profiles_mandating_inst; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1284
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1318
   sig { returns(T::Array[::Udb::Profile]) }
   def profiles_optioning_inst; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#443
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#477
   def pruned_operation_ast(effective_xlen); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#483
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#517
   def reachable_exceptions(effective_xlen); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#511
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#545
   def reachable_exceptions_str(effective_xlen = T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#464
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#498
   sig { params(effective_xlen: ::Integer).returns(T::Array[::Idl::FunctionDefAst]) }
   def reachable_functions(effective_xlen); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1169
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1203
   def rv32?; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1174
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1208
   def rv64?; end
 
   # source://udb//../../udb/lib/udb/obj/instruction.rb#156
@@ -3505,14 +3501,14 @@ class Udb::Instruction < ::Udb::TopLevelDatabaseObject
   sig { params(base: ::Integer).returns(::Udb::InstructionType) }
   def type(base); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1072
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1106
   def type_checked_operation_ast(effective_xlen); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1221
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1255
   sig { params(expand: T::Boolean).returns(T::Array[::Udb::ExtensionRequirement]) }
   def unconditional_extension_conflicts(expand: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1203
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1237
   sig { params(expand: T::Boolean).returns(T::Array[::Udb::ExtensionRequirement]) }
   def unconditional_extension_requirements(expand: T.unsafe(nil)); end
 
@@ -3520,12 +3516,12 @@ class Udb::Instruction < ::Udb::TopLevelDatabaseObject
   sig { override.params(resolver: ::Udb::Resolver).void }
   def validate(resolver); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#1154
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1188
   def wavedrom_desc(base); end
 
   private
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#996
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1030
   def load_encoding; end
 
   class << self
@@ -3541,151 +3537,151 @@ class Udb::Instruction < ::Udb::TopLevelDatabaseObject
   end
 end
 
-# source://udb//../../udb/lib/udb/obj/instruction.rb#612
+# source://udb//../../udb/lib/udb/obj/instruction.rb#646
 class Udb::Instruction::DecodeVariable
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#758
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#792
   def initialize(name, field_data); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#621
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#655
   def alias; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#802
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#836
   def bits; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#631
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#665
   def encoding_fields; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#699
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#733
   def encoding_repl(encoding, value); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#783
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#817
   def eql?(other); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#629
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#663
   def excludes; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#833
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#867
   def extract; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#656
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#690
   def extract_location(location); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#734
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#768
   def grouped_encoding_fields; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#787
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#821
   def hash; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#682
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#716
   def inst_pos_to_var_pos; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#626
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#660
   def left_shift; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#634
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#668
   sig { returns(::String) }
   def location; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#638
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#672
   sig { returns(T::Array[::Integer]) }
   def location_bits; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#616
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#650
   def name; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#824
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#858
   sig { params(other: T.any(::Udb::Instruction::DecodeVariable, ::Udb::Instruction::Opcode)).returns(T::Boolean) }
   def overlaps?(other); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#646
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#680
   def pretty_name; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#819
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#853
   def sext?; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#809
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#843
   def size; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#814
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#848
   def size_in_encoding; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#792
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#826
   def split?; end
 
   private
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#715
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#749
   def inst_range_to_var_range(r); end
 end
 
-# source://udb//../../udb/lib/udb/obj/instruction.rb#860
+# source://udb//../../udb/lib/udb/obj/instruction.rb#894
 class Udb::Instruction::Encoding
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#953
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#987
   def initialize(format, decode_vars, opcode_fields = T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#872
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#906
   def decode_variables; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#864
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#898
   def format; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#914
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#948
   def indistinguishable?(other_encoding, check_other: T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#869
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#903
   def opcode_fields; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#991
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#1025
   def size; end
 
   class << self
-    # source://udb//../../udb/lib/udb/obj/instruction.rb#903
+    # source://udb//../../udb/lib/udb/obj/instruction.rb#937
     def overlapping_format?(format1, format2); end
   end
 end
 
-# source://udb//../../udb/lib/udb/obj/instruction.rb#875
+# source://udb//../../udb/lib/udb/obj/instruction.rb#909
 class Udb::Instruction::Encoding::Field
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#888
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#922
   def initialize(name, range); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#881
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#915
   def name; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#894
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#928
   def opcode?; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#884
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#918
   def range; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#898
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#932
   def to_s; end
 end
 
-# source://udb//../../udb/lib/udb/obj/instruction.rb#572
+# source://udb//../../udb/lib/udb/obj/instruction.rb#606
 class Udb::Instruction::EncodingField
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#579
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#613
   def initialize(name, range, pretty = T.unsafe(nil)); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#591
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#625
   def eql?(other); end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#595
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#629
   def hash; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#574
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#608
   def name; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#586
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#620
   def opcode?; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#599
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#633
   def pretty_to_s; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#577
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#611
   def range; end
 
-  # source://udb//../../udb/lib/udb/obj/instruction.rb#605
+  # source://udb//../../udb/lib/udb/obj/instruction.rb#639
   def size; end
 end
 
@@ -3844,17 +3840,17 @@ class Udb::LogLevel < ::T::Enum
   def rank; end
 end
 
-# source://udb//../../udb/lib/udb/condition.rb#1591
+# source://udb//../../udb/lib/udb/condition.rb#1588
 class Udb::LogicCondition < ::Udb::Condition
-  # source://udb//../../udb/lib/udb/condition.rb#1594
+  # source://udb//../../udb/lib/udb/condition.rb#1591
   sig { params(logic_node: ::Udb::LogicNode, cfg_arch: ::Udb::ConfiguredArchitecture).void }
   def initialize(logic_node, cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1601
+  # source://udb//../../udb/lib/udb/condition.rb#1598
   sig { override.returns(T::Boolean) }
   def empty?; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1604
+  # source://udb//../../udb/lib/udb/condition.rb#1601
   sig { override.returns(::Udb::LogicNode) }
   def to_logic_tree_internal; end
 end
@@ -4603,17 +4599,17 @@ class Udb::NonIsaSpecification
   def valid_id_naming?(id); end
 end
 
-# source://udb//../../udb/lib/udb/condition.rb#1837
+# source://udb//../../udb/lib/udb/condition.rb#1834
 class Udb::ParamCondition < ::Udb::Condition
-  # source://udb//../../udb/lib/udb/condition.rb#1841
+  # source://udb//../../udb/lib/udb/condition.rb#1838
   sig { params(yaml: T::Hash[::String, T.untyped], cfg_arch: ::Udb::ConfiguredArchitecture).void }
   def initialize(yaml, cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1890
+  # source://udb//../../udb/lib/udb/condition.rb#1887
   sig { override.returns(::Udb::LogicNode) }
   def to_logic_tree_internal; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1851
+  # source://udb//../../udb/lib/udb/condition.rb#1848
   sig { params(yaml: T.any(T::Boolean, T::Hash[::String, T.untyped])).returns(::Udb::LogicNode) }
   def to_param_logic_tree_helper(yaml); end
 end
@@ -6017,21 +6013,21 @@ end
 # source://udb//../../udb/lib/udb/version_spec.rb#41
 Udb::VersionSpec::VERSION_REGEX = T.let(T.unsafe(nil), Regexp)
 
-# source://udb//../../udb/lib/udb/condition.rb#1969
+# source://udb//../../udb/lib/udb/condition.rb#1966
 class Udb::XlenCondition < ::Udb::Condition
-  # source://udb//../../udb/lib/udb/condition.rb#1973
+  # source://udb//../../udb/lib/udb/condition.rb#1970
   sig { params(xlen: ::Integer).void }
   def initialize(xlen); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1989
+  # source://udb//../../udb/lib/udb/condition.rb#1986
   sig { override.returns(T.any(T::Boolean, T::Hash[::String, T.untyped])) }
   def to_h; end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1992
+  # source://udb//../../udb/lib/udb/condition.rb#1989
   sig { override.params(cfg_arch: ::Udb::ConfiguredArchitecture).returns(::String) }
   def to_idl(cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/condition.rb#1978
+  # source://udb//../../udb/lib/udb/condition.rb#1975
   sig { override.returns(::Udb::LogicNode) }
   def to_logic_tree_internal; end
 end
@@ -6088,9 +6084,9 @@ class Udb::XlenTerm
   def xlen; end
 end
 
-# source://udb//../../udb/lib/udb/z3.rb#870
+# source://udb//../../udb/lib/udb/z3.rb#872
 class Udb::Z3ExtensionRequirement
-  # source://udb//../../udb/lib/udb/z3.rb#874
+  # source://udb//../../udb/lib/udb/z3.rb#876
   sig do
     params(
       name: ::String,
@@ -6101,14 +6097,14 @@ class Udb::Z3ExtensionRequirement
   end
   def initialize(name, req, solver, cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#918
+  # source://udb//../../udb/lib/udb/z3.rb#920
   sig { returns(::Z3::BoolExpr) }
   def term; end
 end
 
-# source://udb//../../udb/lib/udb/z3.rb#930
+# source://udb//../../udb/lib/udb/z3.rb#932
 class Udb::Z3ExtensionVersion
-  # source://udb//../../udb/lib/udb/z3.rb#937
+  # source://udb//../../udb/lib/udb/z3.rb#939
   sig do
     params(
       name: ::String,
@@ -6119,31 +6115,31 @@ class Udb::Z3ExtensionVersion
   end
   def initialize(name, version, solver, cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#968
+  # source://udb//../../udb/lib/udb/z3.rb#970
   sig { params(ver: T.any(::String, ::Udb::VersionSpec)).returns(::Z3::BoolExpr) }
   def !=(ver); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1015
+  # source://udb//../../udb/lib/udb/z3.rb#1017
   sig { params(ver: T.any(::String, ::Udb::VersionSpec)).returns(::Z3::BoolExpr) }
   def <(ver); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1005
+  # source://udb//../../udb/lib/udb/z3.rb#1007
   sig { params(ver: T.any(::String, ::Udb::VersionSpec)).returns(::Z3::BoolExpr) }
   def <=(ver); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#961
+  # source://udb//../../udb/lib/udb/z3.rb#963
   sig { params(ver: T.any(::String, ::Udb::VersionSpec)).returns(::Z3::BoolExpr) }
   def ==(ver); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#987
+  # source://udb//../../udb/lib/udb/z3.rb#989
   sig { params(ver: T.any(::String, ::Udb::VersionSpec)).returns(::Z3::BoolExpr) }
   def >(ver); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#975
+  # source://udb//../../udb/lib/udb/z3.rb#977
   sig { params(ver: T.any(::String, ::Udb::VersionSpec)).returns(::Z3::BoolExpr) }
   def >=(ver); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#934
+  # source://udb//../../udb/lib/udb/z3.rb#936
   sig { returns(::Z3::BoolExpr) }
   def term; end
 end
@@ -6215,11 +6211,11 @@ class Udb::Z3Loader::Z3LoadError < ::StandardError; end
 
 # source://udb//../../udb/lib/udb/z3.rb#303
 class Udb::Z3ParameterTerm
-  # source://udb//../../udb/lib/udb/z3.rb#741
+  # source://udb//../../udb/lib/udb/z3.rb#743
   sig { params(name: ::String, solver: ::Udb::Z3Solver, schema_hsh: T::Hash[::String, T.untyped]).void }
   def initialize(name, solver, schema_hsh); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#825
+  # source://udb//../../udb/lib/udb/z3.rb#827
   sig do
     params(
       val: T.any(::Integer, ::String, T::Array[::Integer], T::Array[::String], T::Array[T::Boolean], T::Boolean)
@@ -6227,15 +6223,15 @@ class Udb::Z3ParameterTerm
   end
   def !=(val); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#842
+  # source://udb//../../udb/lib/udb/z3.rb#844
   sig { params(val: ::Integer).returns(::Z3::BoolExpr) }
   def <(val); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#837
+  # source://udb//../../udb/lib/udb/z3.rb#839
   sig { params(val: ::Integer).returns(::Z3::BoolExpr) }
   def <=(val); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#812
+  # source://udb//../../udb/lib/udb/z3.rb#814
   sig do
     params(
       val: T.any(::Integer, ::String, T::Array[::Integer], T::Array[::String], T::Array[T::Boolean], T::Boolean)
@@ -6243,23 +6239,23 @@ class Udb::Z3ParameterTerm
   end
   def ==(val); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#852
+  # source://udb//../../udb/lib/udb/z3.rb#854
   sig { params(val: ::Integer).returns(::Z3::BoolExpr) }
   def >(val); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#847
+  # source://udb//../../udb/lib/udb/z3.rb#849
   sig { params(val: ::Integer).returns(::Z3::BoolExpr) }
   def >=(val); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#796
+  # source://udb//../../udb/lib/udb/z3.rb#798
   sig { params(idx: ::Integer).returns(T.any(::Z3::BitvecExpr, ::Z3::BoolExpr, ::Z3::IntExpr)) }
   def [](idx); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#791
+  # source://udb//../../udb/lib/udb/z3.rb#793
   sig { params(msb: ::Integer, lsb: ::Integer).returns(::Z3::BitvecExpr) }
   def extract(msb, lsb); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#804
+  # source://udb//../../udb/lib/udb/z3.rb#806
   sig { params(val: T.any(::Integer, ::String, ::Z3::Expr, T::Boolean)).returns(::Z3::Expr) }
   def has_value?(val); end
 
@@ -6267,7 +6263,7 @@ class Udb::Z3ParameterTerm
   sig { returns(::String) }
   def name; end
 
-  # source://udb//../../udb/lib/udb/z3.rb#785
+  # source://udb//../../udb/lib/udb/z3.rb#787
   sig { returns(::Z3::IntExpr) }
   def size_term; end
 
@@ -6322,7 +6318,7 @@ class Udb::Z3ParameterTerm
     end
     def constrain_string(solver, term, schema_hsh, name: T.unsafe(nil), assert: T.unsafe(nil)); end
 
-    # source://udb//../../udb/lib/udb/z3.rb#718
+    # source://udb//../../udb/lib/udb/z3.rb#720
     sig { params(schema_hsh: T::Hash[::String, T.untyped]).returns(::Symbol) }
     def detect_array_subtype(schema_hsh); end
 
@@ -6332,43 +6328,43 @@ class Udb::Z3ParameterTerm
   end
 end
 
-# source://udb//../../udb/lib/udb/z3.rb#1044
+# source://udb//../../udb/lib/udb/z3.rb#1046
 class Udb::Z3Solver
   extend ::Forwardable
 
-  # source://udb//../../udb/lib/udb/z3.rb#1059
+  # source://udb//../../udb/lib/udb/z3.rb#1061
   sig { void }
   def initialize; end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1049
+  # source://udb//../../udb/lib/udb/z3.rb#1051
   def assert(*args, **_arg1, &block); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1049
+  # source://udb//../../udb/lib/udb/z3.rb#1051
   def assert_as(*args, **_arg1, &block); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1049
+  # source://udb//../../udb/lib/udb/z3.rb#1051
   def assertions(*args, **_arg1, &block); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1049
+  # source://udb//../../udb/lib/udb/z3.rb#1051
   def check(*args, **_arg1, &block); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1162
+  # source://udb//../../udb/lib/udb/z3.rb#1164
   sig { params(name: ::String).returns(::Z3::IntExpr) }
   def ext_major(name); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1172
+  # source://udb//../../udb/lib/udb/z3.rb#1174
   sig { params(name: ::String).returns(::Z3::IntExpr) }
   def ext_minor(name); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1182
+  # source://udb//../../udb/lib/udb/z3.rb#1184
   sig { params(name: ::String).returns(::Z3::IntExpr) }
   def ext_patch(name); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1192
+  # source://udb//../../udb/lib/udb/z3.rb#1194
   sig { params(name: ::String).returns(::Z3::BoolExpr) }
   def ext_pre(name); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1148
+  # source://udb//../../udb/lib/udb/z3.rb#1150
   sig do
     params(
       name: ::String,
@@ -6378,7 +6374,7 @@ class Udb::Z3Solver
   end
   def ext_req(name, req, cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1129
+  # source://udb//../../udb/lib/udb/z3.rb#1131
   sig do
     params(
       name: ::String,
@@ -6388,35 +6384,35 @@ class Udb::Z3Solver
   end
   def ext_ver(name, version, cfg_arch); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1049
+  # source://udb//../../udb/lib/udb/z3.rb#1051
   def model(*args, **_arg1, &block); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1207
+  # source://udb//../../udb/lib/udb/z3.rb#1209
   sig { params(name: ::String, schema_hsh: T::Hash[::String, T.untyped]).returns(::Udb::Z3ParameterTerm) }
   def param(name, schema_hsh); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1080
+  # source://udb//../../udb/lib/udb/z3.rb#1082
   sig { void }
   def pop; end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1049
+  # source://udb//../../udb/lib/udb/z3.rb#1051
   def prove!(*args, **_arg1, &block); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1100
+  # source://udb//../../udb/lib/udb/z3.rb#1102
   sig { void }
   def push; end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1049
+  # source://udb//../../udb/lib/udb/z3.rb#1051
   def satisfiable?(*args, **_arg1, &block); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1056
+  # source://udb//../../udb/lib/udb/z3.rb#1058
   sig { returns(::Z3::Solver) }
   def solver; end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1049
+  # source://udb//../../udb/lib/udb/z3.rb#1051
   def unsatisfiable?(*args, **_arg1, &block); end
 
-  # source://udb//../../udb/lib/udb/z3.rb#1116
+  # source://udb//../../udb/lib/udb/z3.rb#1118
   sig { returns(::Z3::IntExpr) }
   def xlen; end
 end

--- a/tools/ruby-gems/udb/sorbet/rbi/gems/idlc@0.1.0.rbi
+++ b/tools/ruby-gems/udb/sorbet/rbi/gems/idlc@0.1.0.rbi
@@ -326,11 +326,11 @@ module Idl
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1375
+# source://idlc//lib/idlc/ast.rb#1391
 class Idl::ArrayIncludesAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#1385
+  # source://idlc//lib/idlc/ast.rb#1401
   sig do
     params(
       input: T.nilable(::String),
@@ -341,43 +341,43 @@ class Idl::ArrayIncludesAst < ::Idl::AstNode
   end
   def initialize(input, interval, ary, value); end
 
-  # source://idlc//lib/idlc/ast.rb#1379
+  # source://idlc//lib/idlc/ast.rb#1395
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def ary; end
 
-  # source://idlc//lib/idlc/ast.rb#1413
+  # source://idlc//lib/idlc/ast.rb#1429
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1382
+  # source://idlc//lib/idlc/ast.rb#1398
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def expr; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#305
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#1419
+  # source://idlc//lib/idlc/ast.rb#1435
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1416
+  # source://idlc//lib/idlc/ast.rb#1432
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1403
+  # source://idlc//lib/idlc/ast.rb#1419
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1390
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1406
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1408
+  # source://idlc//lib/idlc/ast.rb#1424
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1427
+    # source://idlc//lib/idlc/ast.rb#1443
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -388,45 +388,45 @@ class Idl::ArrayIncludesAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1369
+# source://idlc//lib/idlc/ast.rb#1385
 class Idl::ArrayIncludesSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1370
+  # source://idlc//lib/idlc/ast.rb#1386
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5259
+# source://idlc//lib/idlc/ast.rb#5282
 class Idl::ArrayLiteralAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5263
+  # source://idlc//lib/idlc/ast.rb#5286
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5267
+  # source://idlc//lib/idlc/ast.rb#5290
   def element_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#5265
+  # source://idlc//lib/idlc/ast.rb#5288
   def entries; end
 
-  # source://idlc//lib/idlc/ast.rb#5294
+  # source://idlc//lib/idlc/ast.rb#5317
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5291
+  # source://idlc//lib/idlc/ast.rb#5314
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5282
+  # source://idlc//lib/idlc/ast.rb#5305
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5272
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5295
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5286
+  # source://idlc//lib/idlc/ast.rb#5309
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5301
+    # source://idlc//lib/idlc/ast.rb#5324
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -437,49 +437,49 @@ class Idl::ArrayLiteralAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5253
+# source://idlc//lib/idlc/ast.rb#5276
 class Idl::ArrayLiteralSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5254
+  # source://idlc//lib/idlc/ast.rb#5277
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#1446
+# source://idlc//lib/idlc/ast.rb#1462
 class Idl::ArraySizeAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#1455
+  # source://idlc//lib/idlc/ast.rb#1471
   def initialize(input, interval, expression); end
 
-  # source://idlc//lib/idlc/ast.rb#1453
+  # source://idlc//lib/idlc/ast.rb#1469
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1450
+  # source://idlc//lib/idlc/ast.rb#1466
   def expression; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#299
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#1487
+  # source://idlc//lib/idlc/ast.rb#1503
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1484
+  # source://idlc//lib/idlc/ast.rb#1500
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1466
+  # source://idlc//lib/idlc/ast.rb#1482
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1459
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1475
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1477
+  # source://idlc//lib/idlc/ast.rb#1493
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Integer) }
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1494
+    # source://idlc//lib/idlc/ast.rb#1510
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -490,9 +490,9 @@ class Idl::ArraySizeAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1440
+# source://idlc//lib/idlc/ast.rb#1456
 class Idl::ArraySizeSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1441
+  # source://idlc//lib/idlc/ast.rb#1457
   def to_ast; end
 end
 
@@ -520,51 +520,51 @@ module Idl::AryAccess2
   def brackets; end
 end
 
-# source://idlc//lib/idlc/ast.rb#2381
+# source://idlc//lib/idlc/ast.rb#2397
 class Idl::AryAccessSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#2385
+  # source://idlc//lib/idlc/ast.rb#2401
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#2401
+# source://idlc//lib/idlc/ast.rb#2417
 class Idl::AryElementAccessAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#2416
+  # source://idlc//lib/idlc/ast.rb#2432
   def initialize(input, interval, var, index); end
 
-  # source://idlc//lib/idlc/ast.rb#2405
+  # source://idlc//lib/idlc/ast.rb#2421
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#229
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#2414
+  # source://idlc//lib/idlc/ast.rb#2430
   def index; end
 
-  # source://idlc//lib/idlc/ast.rb#2489
+  # source://idlc//lib/idlc/ast.rb#2505
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2486
+  # source://idlc//lib/idlc/ast.rb#2502
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2451
+  # source://idlc//lib/idlc/ast.rb#2467
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2421
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2437
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#2466
+  # source://idlc//lib/idlc/ast.rb#2482
   def value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2413
+  # source://idlc//lib/idlc/ast.rb#2429
   def var; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2497
+    # source://idlc//lib/idlc/ast.rb#2513
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -575,48 +575,48 @@ class Idl::AryElementAccessAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2804
+# source://idlc//lib/idlc/ast.rb#2820
 class Idl::AryElementAssignmentAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#2826
+  # source://idlc//lib/idlc/ast.rb#2842
   def initialize(input, interval, lhs, idx, rhs); end
 
-  # source://idlc//lib/idlc/ast.rb#2808
+  # source://idlc//lib/idlc/ast.rb#2824
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2865
+  # source://idlc//lib/idlc/ast.rb#2881
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2895
+  # source://idlc//lib/idlc/ast.rb#2911
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#253
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#2823
+  # source://idlc//lib/idlc/ast.rb#2839
   def idx; end
 
-  # source://idlc//lib/idlc/ast.rb#2822
+  # source://idlc//lib/idlc/ast.rb#2838
   def lhs; end
 
-  # source://idlc//lib/idlc/ast.rb#2824
+  # source://idlc//lib/idlc/ast.rb#2840
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#2933
+  # source://idlc//lib/idlc/ast.rb#2949
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2930
+  # source://idlc//lib/idlc/ast.rb#2946
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2831
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2847
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2942
+    # source://idlc//lib/idlc/ast.rb#2958
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -627,55 +627,55 @@ class Idl::AryElementAssignmentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2794
+# source://idlc//lib/idlc/ast.rb#2810
 class Idl::AryElementAssignmentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#2795
+  # source://idlc//lib/idlc/ast.rb#2811
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#2510
+# source://idlc//lib/idlc/ast.rb#2526
 class Idl::AryRangeAccessAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#2528
+  # source://idlc//lib/idlc/ast.rb#2544
   def initialize(input, interval, var, msb, lsb); end
 
-  # source://idlc//lib/idlc/ast.rb#2514
+  # source://idlc//lib/idlc/ast.rb#2530
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#168
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#2526
+  # source://idlc//lib/idlc/ast.rb#2542
   def lsb; end
 
-  # source://idlc//lib/idlc/ast.rb#2525
+  # source://idlc//lib/idlc/ast.rb#2541
   def msb; end
 
-  # source://idlc//lib/idlc/ast.rb#2584
+  # source://idlc//lib/idlc/ast.rb#2600
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2581
+  # source://idlc//lib/idlc/ast.rb#2597
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2558
+  # source://idlc//lib/idlc/ast.rb#2574
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2533
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2549
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#2574
+  # source://idlc//lib/idlc/ast.rb#2590
   def value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2524
+  # source://idlc//lib/idlc/ast.rb#2540
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def var; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2595
+    # source://idlc//lib/idlc/ast.rb#2611
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -686,54 +686,54 @@ class Idl::AryRangeAccessAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2966
+# source://idlc//lib/idlc/ast.rb#2982
 class Idl::AryRangeAssignmentAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#2989
+  # source://idlc//lib/idlc/ast.rb#3005
   def initialize(input, interval, variable, msb, lsb, write_value); end
 
-  # source://idlc//lib/idlc/ast.rb#2970
+  # source://idlc//lib/idlc/ast.rb#2986
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3026
+  # source://idlc//lib/idlc/ast.rb#3042
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3054
+  # source://idlc//lib/idlc/ast.rb#3070
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#20
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#2986
+  # source://idlc//lib/idlc/ast.rb#3002
   def lsb; end
 
-  # source://idlc//lib/idlc/ast.rb#2985
+  # source://idlc//lib/idlc/ast.rb#3001
   def msb; end
 
-  # source://idlc//lib/idlc/ast.rb#3021
+  # source://idlc//lib/idlc/ast.rb#3037
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#3063
+  # source://idlc//lib/idlc/ast.rb#3079
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#3060
+  # source://idlc//lib/idlc/ast.rb#3076
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2994
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#3010
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#2984
+  # source://idlc//lib/idlc/ast.rb#3000
   def variable; end
 
-  # source://idlc//lib/idlc/ast.rb#2987
+  # source://idlc//lib/idlc/ast.rb#3003
   def write_value; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#3075
+    # source://idlc//lib/idlc/ast.rb#3091
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -744,9 +744,9 @@ class Idl::AryRangeAssignmentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2956
+# source://idlc//lib/idlc/ast.rb#2972
 class Idl::AryRangeAssignmentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#2957
+  # source://idlc//lib/idlc/ast.rb#2973
   def to_ast; end
 end
 
@@ -841,7 +841,7 @@ end
 class Idl::AstNode
   abstract!
 
-  # source://idlc//lib/idlc/ast.rb#204
+  # source://idlc//lib/idlc/ast.rb#202
   sig do
     params(
       input: T.nilable(::String),
@@ -851,19 +851,19 @@ class Idl::AstNode
   end
   def initialize(input, interval, children); end
 
-  # source://idlc//lib/idlc/ast.rb#80
+  # source://idlc//lib/idlc/ast.rb#78
   sig { returns(T::Array[::Idl::AstNode]) }
   def children; end
 
-  # source://idlc//lib/idlc/ast.rb#198
+  # source://idlc//lib/idlc/ast.rb#196
   sig { abstract.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#259
+  # source://idlc//lib/idlc/ast.rb#257
   sig { params(klass: ::Class).returns(T.nilable(::Idl::AstNode)) }
   def find_ancestor(klass); end
 
-  # source://idlc//lib/idlc/ast.rb#436
+  # source://idlc//lib/idlc/ast.rb#434
   sig { params(global_symtab: ::Idl::SymbolTable).returns(::Idl::AstNode) }
   def freeze_tree(global_symtab); end
 
@@ -873,54 +873,54 @@ class Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#16
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#61
+  # source://idlc//lib/idlc/ast.rb#59
   sig { returns(T.nilable(::String)) }
   def input; end
 
-  # source://idlc//lib/idlc/ast.rb#53
+  # source://idlc//lib/idlc/ast.rb#51
   sig { returns(T.nilable(::Pathname)) }
   def input_file; end
 
-  # source://idlc//lib/idlc/ast.rb#587
+  # source://idlc//lib/idlc/ast.rb#585
   sig { returns(::String) }
   def inspect; end
 
-  # source://idlc//lib/idlc/ast.rb#370
+  # source://idlc//lib/idlc/ast.rb#368
   sig { params(reason: ::String).returns(T.noreturn) }
   def internal_error(reason); end
 
-  # source://idlc//lib/idlc/ast.rb#65
+  # source://idlc//lib/idlc/ast.rb#63
   sig { returns(T.nilable(T::Range[::Integer])) }
   def interval; end
 
-  # source://idlc//lib/idlc/ast.rb#252
+  # source://idlc//lib/idlc/ast.rb#250
   sig { returns(::Integer) }
   def lineno; end
 
-  # source://idlc//lib/idlc/ast.rb#277
+  # source://idlc//lib/idlc/ast.rb#275
   sig { returns(::Idl::AstNode::LinesDescriptor) }
   def lines_around; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#64
+  # source://idlc//lib/idlc/passes/prune.rb#71
   def nullify_assignments(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#76
+  # source://idlc//lib/idlc/ast.rb#74
   sig { returns(T.nilable(::Idl::AstNode)) }
   def parent; end
 
   # source://idlc//lib/idlc/passes/find_return_values.rb#11
   def pass_find_return_values(values, current_conditions); end
 
-  # source://idlc//lib/idlc/ast.rb#445
+  # source://idlc//lib/idlc/ast.rb#443
   sig { returns(::String) }
   def path; end
 
-  # source://idlc//lib/idlc/ast.rb#419
+  # source://idlc//lib/idlc/ast.rb#417
   sig { params(indent: ::Integer, indent_size: ::Integer, io: ::IO).void }
   def print_ast(indent = T.unsafe(nil), indent_size: T.unsafe(nil), io: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#45
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#52
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
   # source://idlc//lib/idlc/passes/reachable_exceptions.rb#13
   def reachable_exceptions(symtab, cache = T.unsafe(nil)); end
@@ -928,68 +928,68 @@ class Idl::AstNode
   # source://idlc//lib/idlc/passes/reachable_functions.rb#12
   def reachable_functions(symtab, cache = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#241
+  # source://idlc//lib/idlc/ast.rb#239
   sig { params(filename: T.any(::Pathname, ::String), starting_line: ::Integer).void }
   def set_input_file(filename, starting_line = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#225
+  # source://idlc//lib/idlc/ast.rb#223
   sig { params(filename: T.any(::Pathname, ::String), starting_line: ::Integer).void }
   def set_input_file_unless_already_set(filename, starting_line = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#484
+  # source://idlc//lib/idlc/ast.rb#482
   sig { returns(T::Hash[::String, T.untyped]) }
   def source_yaml; end
 
-  # source://idlc//lib/idlc/ast.rb#57
+  # source://idlc//lib/idlc/ast.rb#55
   sig { returns(::Integer) }
   def starting_line; end
 
-  # source://idlc//lib/idlc/ast.rb#69
+  # source://idlc//lib/idlc/ast.rb#67
   sig { returns(::String) }
   def text_value; end
 
-  # source://idlc//lib/idlc/ast.rb#504
+  # source://idlc//lib/idlc/ast.rb#502
   sig { abstract.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#477
+  # source://idlc//lib/idlc/ast.rb#475
   sig { abstract.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#480
+  # source://idlc//lib/idlc/ast.rb#478
   sig { overridable.returns(::String) }
   def to_idl_verbose; end
 
-  # source://idlc//lib/idlc/ast.rb#305
+  # source://idlc//lib/idlc/ast.rb#303
   sig { params(reason: ::String).void }
   def truncation_warn(reason); end
 
-  # source://idlc//lib/idlc/ast.rb#467
-  sig { abstract.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#465
+  sig { abstract.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#321
+  # source://idlc//lib/idlc/ast.rb#319
   sig { params(reason: ::String).returns(T.noreturn) }
   def type_error(reason); end
 
-  # source://idlc//lib/idlc/ast.rb#409
+  # source://idlc//lib/idlc/ast.rb#407
   sig { params(s: ::String).returns(::String) }
   def unindent(s); end
 
-  # source://idlc//lib/idlc/ast.rb#192
+  # source://idlc//lib/idlc/ast.rb#190
   sig { params(value_result: T.untyped, block: T.proc.returns(T.untyped)).returns(T.untyped) }
   def value_else(value_result, &block); end
 
-  # source://idlc//lib/idlc/ast.rb#400
+  # source://idlc//lib/idlc/ast.rb#398
   sig { params(reason: ::String).returns(T.noreturn) }
   def value_error(reason); end
 
-  # source://idlc//lib/idlc/ast.rb#182
+  # source://idlc//lib/idlc/ast.rb#180
   sig { params(block: T.proc.params(arg0: ::Object).returns(T.untyped)).returns(T.untyped) }
   def value_try(&block); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#507
+    # source://idlc//lib/idlc/ast.rb#505
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -998,7 +998,7 @@ class Idl::AstNode
     end
     def from_h(yaml, source_mapper); end
 
-    # source://idlc//lib/idlc/ast.rb#493
+    # source://idlc//lib/idlc/ast.rb#491
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1007,190 +1007,190 @@ class Idl::AstNode
     end
     def input_from_source_yaml(yaml, source_mapper); end
 
-    # source://idlc//lib/idlc/ast.rb#499
+    # source://idlc//lib/idlc/ast.rb#497
     sig { params(yaml: T::Hash[::String, T.untyped]).returns(T.nilable(T::Range[::Integer])) }
     def interval_from_source_yaml(yaml); end
 
-    # source://idlc//lib/idlc/ast.rb#185
+    # source://idlc//lib/idlc/ast.rb#183
     sig { params(value_result: T.untyped, _block: T.proc.returns(T.untyped)).returns(T.untyped) }
     def value_else(value_result, &_block); end
 
-    # source://idlc//lib/idlc/ast.rb#391
+    # source://idlc//lib/idlc/ast.rb#389
     sig { params(reason: ::String, ast: T.nilable(::Idl::AstNode)).returns(T.noreturn) }
     def value_error(reason, ast = T.unsafe(nil)); end
 
-    # source://idlc//lib/idlc/ast.rb#383
+    # source://idlc//lib/idlc/ast.rb#381
     def value_error_ast; end
 
-    # source://idlc//lib/idlc/ast.rb#383
+    # source://idlc//lib/idlc/ast.rb#381
     def value_error_ast=(_arg0); end
 
-    # source://idlc//lib/idlc/ast.rb#383
+    # source://idlc//lib/idlc/ast.rb#381
     def value_error_reason; end
 
-    # source://idlc//lib/idlc/ast.rb#383
+    # source://idlc//lib/idlc/ast.rb#381
     def value_error_reason=(_arg0); end
 
-    # source://idlc//lib/idlc/ast.rb#178
+    # source://idlc//lib/idlc/ast.rb#176
     sig { params(block: T.proc.params(arg0: ::Object).returns(T.untyped)).returns(T.untyped) }
     def value_try(&block); end
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#40
+# source://idlc//lib/idlc/ast.rb#38
 Idl::AstNode::Bits1Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#42
+# source://idlc//lib/idlc/ast.rb#40
 Idl::AstNode::Bits32Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#44
+# source://idlc//lib/idlc/ast.rb#42
 Idl::AstNode::Bits64Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#47
+# source://idlc//lib/idlc/ast.rb#45
 Idl::AstNode::BoolType = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#46
+# source://idlc//lib/idlc/ast.rb#44
 Idl::AstNode::ConstBoolType = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#113
+# source://idlc//lib/idlc/ast.rb#111
 class Idl::AstNode::InternalError < ::StandardError
-  # source://idlc//lib/idlc/ast.rb#129
+  # source://idlc//lib/idlc/ast.rb#127
   sig { params(what: ::String).void }
   def initialize(what); end
 
-  # source://idlc//lib/idlc/ast.rb#126
+  # source://idlc//lib/idlc/ast.rb#124
   sig { returns(T::Array[::String]) }
   def bt; end
 
-  # source://idlc//lib/idlc/ast.rb#118
+  # source://idlc//lib/idlc/ast.rb#116
   sig { returns(::String) }
   def what; end
 end
 
-# source://idlc//lib/idlc/ast.rb#269
+# source://idlc//lib/idlc/ast.rb#267
 class Idl::AstNode::LinesDescriptor < ::T::Struct
   const :lines, ::String
   const :problem_interval, T::Range[T.untyped]
   const :lines_interval, T::Range[T.untyped]
 end
 
-# source://idlc//lib/idlc/ast.rb#41
+# source://idlc//lib/idlc/ast.rb#39
 Idl::AstNode::PossiblyUnknownBits1Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#43
+# source://idlc//lib/idlc/ast.rb#41
 Idl::AstNode::PossiblyUnknownBits32Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#45
+# source://idlc//lib/idlc/ast.rb#43
 Idl::AstNode::PossiblyUnknownBits64Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#49
+# source://idlc//lib/idlc/ast.rb#47
 Idl::AstNode::StringType = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#83
+# source://idlc//lib/idlc/ast.rb#81
 class Idl::AstNode::TypeError < ::StandardError
-  # source://idlc//lib/idlc/ast.rb#100
+  # source://idlc//lib/idlc/ast.rb#98
   sig { params(what: ::String).void }
   def initialize(what); end
 
-  # source://idlc//lib/idlc/ast.rb#96
+  # source://idlc//lib/idlc/ast.rb#94
   sig { returns(T::Array[::String]) }
   def bt; end
 
-  # source://idlc//lib/idlc/ast.rb#88
+  # source://idlc//lib/idlc/ast.rb#86
   sig { returns(::String) }
   def what; end
 end
 
-# source://idlc//lib/idlc/ast.rb#143
+# source://idlc//lib/idlc/ast.rb#141
 class Idl::AstNode::ValueError < ::StandardError
-  # source://idlc//lib/idlc/ast.rb#156
+  # source://idlc//lib/idlc/ast.rb#154
   sig { params(lineno: ::Integer, file: ::String, reason: ::String).void }
   def initialize(lineno, file, reason); end
 
-  # source://idlc//lib/idlc/ast.rb#150
+  # source://idlc//lib/idlc/ast.rb#148
   sig { returns(::String) }
   def file; end
 
-  # source://idlc//lib/idlc/ast.rb#147
+  # source://idlc//lib/idlc/ast.rb#145
   sig { returns(::Integer) }
   def lineno; end
 
-  # source://idlc//lib/idlc/ast.rb#167
+  # source://idlc//lib/idlc/ast.rb#165
   sig { returns(::String) }
   def message; end
 
-  # source://idlc//lib/idlc/ast.rb#153
+  # source://idlc//lib/idlc/ast.rb#151
   sig { returns(::String) }
   def reason; end
 
-  # source://idlc//lib/idlc/ast.rb#164
+  # source://idlc//lib/idlc/ast.rb#162
   sig { returns(::String) }
   def what; end
 end
 
-# source://idlc//lib/idlc/ast.rb#48
+# source://idlc//lib/idlc/ast.rb#46
 Idl::AstNode::VoidType = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#17
+# source://idlc//lib/idlc/ast.rb#15
 Idl::BasicValueRbType = T.type_alias { T.any(::Integer, ::String, T::Array[::Integer], T::Array[::String], T::Array[T::Boolean], T::Boolean) }
 
-# source://idlc//lib/idlc/ast.rb#4392
+# source://idlc//lib/idlc/ast.rb#4413
 class Idl::BinaryExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#4411
+  # source://idlc//lib/idlc/ast.rb#4432
   def initialize(input, interval, lhs, op, rhs); end
 
-  # source://idlc//lib/idlc/ast.rb#4681
+  # source://idlc//lib/idlc/ast.rb#4702
   def bits_needed(value, signed); end
 
-  # source://idlc//lib/idlc/ast.rb#4401
+  # source://idlc//lib/idlc/ast.rb#4422
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#235
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#4418
+  # source://idlc//lib/idlc/ast.rb#4439
   def invert(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4407
+  # source://idlc//lib/idlc/ast.rb#4428
   def lhs; end
 
-  # source://idlc//lib/idlc/ast.rb#4708
+  # source://idlc//lib/idlc/ast.rb#4729
   def max_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4851
+  # source://idlc//lib/idlc/ast.rb#4872
   def min_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5195
+  # source://idlc//lib/idlc/ast.rb#5218
   def op; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#239
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#269
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#4408
+  # source://idlc//lib/idlc/ast.rb#4429
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#4454
+  # source://idlc//lib/idlc/ast.rb#4475
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#4449
+  # source://idlc//lib/idlc/ast.rb#4470
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#4477
+  # source://idlc//lib/idlc/ast.rb#4498
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4577
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#4598
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5001
+  # source://idlc//lib/idlc/ast.rb#5022
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#4463
+    # source://idlc//lib/idlc/ast.rb#4484
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1201,25 +1201,25 @@ class Idl::BinaryExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#4397
+# source://idlc//lib/idlc/ast.rb#4418
 Idl::BinaryExpressionAst::ARITH_OPS = T.let(T.unsafe(nil), Array)
 
-# source://idlc//lib/idlc/ast.rb#4396
+# source://idlc//lib/idlc/ast.rb#4417
 Idl::BinaryExpressionAst::BIT_OPS = T.let(T.unsafe(nil), Array)
 
-# source://idlc//lib/idlc/ast.rb#4395
+# source://idlc//lib/idlc/ast.rb#4416
 Idl::BinaryExpressionAst::LOGICAL_OPS = T.let(T.unsafe(nil), Array)
 
-# source://idlc//lib/idlc/ast.rb#4398
+# source://idlc//lib/idlc/ast.rb#4419
 Idl::BinaryExpressionAst::OPS = T.let(T.unsafe(nil), Array)
 
-# source://idlc//lib/idlc/ast.rb#3937
+# source://idlc//lib/idlc/ast.rb#3953
 class Idl::BinaryExpressionRightSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3941
+  # source://idlc//lib/idlc/ast.rb#3957
   def to_ast; end
 
-  # source://idlc//lib/idlc/ast.rb#3958
-  def type_check(_symtab); end
+  # source://idlc//lib/idlc/ast.rb#3974
+  def type_check(_symtab, strict:); end
 end
 
 # source://idlc//lib/idlc/idl_parser.rb#847
@@ -1258,54 +1258,54 @@ module Idl::BitfieldDefinition3
   def user_type_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#2113
+# source://idlc//lib/idlc/ast.rb#2129
 class Idl::BitfieldDefinitionAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#2119
+  # source://idlc//lib/idlc/ast.rb#2135
   def initialize(input, interval, name, size, fields); end
 
-  # source://idlc//lib/idlc/ast.rb#2172
+  # source://idlc//lib/idlc/ast.rb#2188
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2117
+  # source://idlc//lib/idlc/ast.rb#2133
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2144
+  # source://idlc//lib/idlc/ast.rb#2160
   def element_names; end
 
-  # source://idlc//lib/idlc/ast.rb#2152
+  # source://idlc//lib/idlc/ast.rb#2168
   def element_ranges(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2128
+  # source://idlc//lib/idlc/ast.rb#2144
   def freeze_tree(global_symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2194
+  # source://idlc//lib/idlc/ast.rb#2210
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#2139
+  # source://idlc//lib/idlc/ast.rb#2155
   def size(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2211
+  # source://idlc//lib/idlc/ast.rb#2227
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2201
+  # source://idlc//lib/idlc/ast.rb#2217
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2182
+  # source://idlc//lib/idlc/ast.rb#2198
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2159
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2175
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#2197
+  # source://idlc//lib/idlc/ast.rb#2213
   def value(_symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2220
+    # source://idlc//lib/idlc/ast.rb#2236
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1316,40 +1316,40 @@ class Idl::BitfieldDefinitionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2082
+# source://idlc//lib/idlc/ast.rb#2098
 class Idl::BitfieldDefinitionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#2083
+  # source://idlc//lib/idlc/ast.rb#2099
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#1997
+# source://idlc//lib/idlc/ast.rb#2013
 class Idl::BitfieldFieldDefinitionAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#2004
+  # source://idlc//lib/idlc/ast.rb#2020
   def initialize(input, interval, name, msb, lsb); end
 
-  # source://idlc//lib/idlc/ast.rb#2002
+  # source://idlc//lib/idlc/ast.rb#2018
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1999
+  # source://idlc//lib/idlc/ast.rb#2015
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#2039
+  # source://idlc//lib/idlc/ast.rb#2055
   def range(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2057
+  # source://idlc//lib/idlc/ast.rb#2073
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2048
+  # source://idlc//lib/idlc/ast.rb#2064
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2017
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2033
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2068
+    # source://idlc//lib/idlc/ast.rb#2084
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1360,28 +1360,31 @@ class Idl::BitfieldFieldDefinitionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/type.rb#711
+# source://idlc//lib/idlc/type.rb#730
 class Idl::BitfieldType < ::Idl::Type
-  # source://idlc//lib/idlc/type.rb#712
+  # source://idlc//lib/idlc/type.rb#732
   def initialize(type_name, width, field_names, field_ranges); end
 
-  # source://idlc//lib/idlc/type.rb#732
+  # source://idlc//lib/idlc/type.rb#752
   def clone; end
 
-  # source://idlc//lib/idlc/type.rb#728
+  # source://idlc//lib/idlc/type.rb#748
   def field_names; end
 
-  # source://idlc//lib/idlc/type.rb#721
+  # source://idlc//lib/idlc/type.rb#741
   def range(field_name); end
+
+  # source://idlc//lib/idlc/type.rb#731
+  def width; end
 end
 
-# source://idlc//lib/idlc/type.rb#996
+# source://idlc//lib/idlc/type.rb#1016
 Idl::Bits1Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/type.rb#997
+# source://idlc//lib/idlc/type.rb#1017
 Idl::Bits32Type = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/type.rb#998
+# source://idlc//lib/idlc/type.rb#1018
 Idl::Bits64Type = T.let(T.unsafe(nil), Idl::Type)
 
 # source://idlc//lib/idlc/idl_parser.rb#6569
@@ -1390,45 +1393,45 @@ module Idl::BitsCast0
   def expr; end
 end
 
-# source://idlc//lib/idlc/ast.rb#4303
+# source://idlc//lib/idlc/ast.rb#4320
 class Idl::BitsCastAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#4314
+  # source://idlc//lib/idlc/ast.rb#4331
   def initialize(input, interval, exp); end
 
-  # source://idlc//lib/idlc/ast.rb#4307
+  # source://idlc//lib/idlc/ast.rb#4324
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4312
+  # source://idlc//lib/idlc/ast.rb#4329
   def expr; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#102
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#506
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#615
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#4373
+  # source://idlc//lib/idlc/ast.rb#4394
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#4370
+  # source://idlc//lib/idlc/ast.rb#4391
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#4326
+  # source://idlc//lib/idlc/ast.rb#4343
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4317
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#4334
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#4347
+  # source://idlc//lib/idlc/ast.rb#4366
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#4380
+    # source://idlc//lib/idlc/ast.rb#4401
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1439,13 +1442,13 @@ class Idl::BitsCastAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#4292
+# source://idlc//lib/idlc/ast.rb#4309
 class Idl::BitsCastSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#4293
+  # source://idlc//lib/idlc/ast.rb#4310
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/type.rb#999
+# source://idlc//lib/idlc/type.rb#1019
 Idl::BitsUnknownType = T.let(T.unsafe(nil), Idl::Type)
 
 # source://idlc//lib/idlc/idl_parser.rb#9522
@@ -1526,14 +1529,14 @@ module Idl::BodyFunctionDefinition8
   def type; end
 end
 
-# source://idlc//lib/idlc/type.rb#1002
+# source://idlc//lib/idlc/type.rb#1022
 Idl::BoolType = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#1932
+# source://idlc//lib/idlc/ast.rb#1948
 class Idl::BuiltinEnumDefinitionAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#1939
+  # source://idlc//lib/idlc/ast.rb#1955
   sig do
     params(
       input: T.nilable(::String),
@@ -1543,38 +1546,38 @@ class Idl::BuiltinEnumDefinitionAst < ::Idl::AstNode
   end
   def initialize(input, interval, user_type); end
 
-  # source://idlc//lib/idlc/ast.rb#1966
+  # source://idlc//lib/idlc/ast.rb#1982
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1936
+  # source://idlc//lib/idlc/ast.rb#1952
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1952
+  # source://idlc//lib/idlc/ast.rb#1968
   def element_names(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1956
+  # source://idlc//lib/idlc/ast.rb#1972
   def element_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1971
+  # source://idlc//lib/idlc/ast.rb#1987
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#1978
+  # source://idlc//lib/idlc/ast.rb#1994
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1975
+  # source://idlc//lib/idlc/ast.rb#1991
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1961
+  # source://idlc//lib/idlc/ast.rb#1977
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1945
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1961
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1985
+    # source://idlc//lib/idlc/ast.rb#2001
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1585,9 +1588,9 @@ class Idl::BuiltinEnumDefinitionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1921
+# source://idlc//lib/idlc/ast.rb#1937
 class Idl::BuiltinEnumDefinitionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1922
+  # source://idlc//lib/idlc/ast.rb#1938
   def to_ast; end
 end
 
@@ -1651,41 +1654,41 @@ module Idl::BuiltinTypeName4; end
 # source://idlc//lib/idlc/idl_parser.rb#14708
 module Idl::BuiltinTypeName5; end
 
-# source://idlc//lib/idlc/ast.rb#6868
+# source://idlc//lib/idlc/ast.rb#6929
 class Idl::BuiltinTypeNameAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#6875
+  # source://idlc//lib/idlc/ast.rb#6936
   def initialize(input, interval, type_name, bits_expression); end
 
-  # source://idlc//lib/idlc/ast.rb#6873
+  # source://idlc//lib/idlc/ast.rb#6934
   def bits_expression; end
 
-  # source://idlc//lib/idlc/ast.rb#6871
+  # source://idlc//lib/idlc/ast.rb#6932
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6902
+  # source://idlc//lib/idlc/ast.rb#6963
   def freeze_tree(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#192
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#6964
+  # source://idlc//lib/idlc/ast.rb#7025
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6955
+  # source://idlc//lib/idlc/ast.rb#7016
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6921
+  # source://idlc//lib/idlc/ast.rb#6982
   sig { params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6885
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6946
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6981
+    # source://idlc//lib/idlc/ast.rb#7042
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1696,52 +1699,52 @@ class Idl::BuiltinTypeNameAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6847
+# source://idlc//lib/idlc/ast.rb#6908
 class Idl::BuiltinTypeNameSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6848
+  # source://idlc//lib/idlc/ast.rb#6909
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5575
+# source://idlc//lib/idlc/ast.rb#5606
 class Idl::BuiltinVariableAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5594
+  # source://idlc//lib/idlc/ast.rb#5625
   sig { params(input: T.nilable(::String), interval: T.nilable(T::Range[::Integer]), name: ::String).void }
   def initialize(input, interval, name); end
 
-  # source://idlc//lib/idlc/ast.rb#5579
+  # source://idlc//lib/idlc/ast.rb#5610
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#213
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5590
+  # source://idlc//lib/idlc/ast.rb#5621
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#5591
+  # source://idlc//lib/idlc/ast.rb#5622
   def text_value; end
 
-  # source://idlc//lib/idlc/ast.rb#5626
+  # source://idlc//lib/idlc/ast.rb#5657
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5623
+  # source://idlc//lib/idlc/ast.rb#5654
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5603
+  # source://idlc//lib/idlc/ast.rb#5634
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5599
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5630
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5618
+  # source://idlc//lib/idlc/ast.rb#5649
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5633
+    # source://idlc//lib/idlc/ast.rb#5664
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1752,9 +1755,9 @@ class Idl::BuiltinVariableAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5645
+# source://idlc//lib/idlc/ast.rb#5676
 class Idl::BuiltinVariableSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5646
+  # source://idlc//lib/idlc/ast.rb#5677
   def to_ast; end
 end
 
@@ -1767,34 +1770,34 @@ module Idl::Comment1
   def content; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6805
+# source://idlc//lib/idlc/ast.rb#6866
 class Idl::CommentAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#6809
+  # source://idlc//lib/idlc/ast.rb#6870
   def initialize(input, interval, text); end
 
-  # source://idlc//lib/idlc/ast.rb#6807
+  # source://idlc//lib/idlc/ast.rb#6868
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6822
+  # source://idlc//lib/idlc/ast.rb#6883
   def content; end
 
-  # source://idlc//lib/idlc/ast.rb#6814
+  # source://idlc//lib/idlc/ast.rb#6875
   def text_value; end
 
-  # source://idlc//lib/idlc/ast.rb#6828
+  # source://idlc//lib/idlc/ast.rb#6889
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6825
+  # source://idlc//lib/idlc/ast.rb#6886
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6817
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6878
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6835
+    # source://idlc//lib/idlc/ast.rb#6896
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1805,9 +1808,9 @@ class Idl::CommentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6800
+# source://idlc//lib/idlc/ast.rb#6861
 class Idl::CommentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6801
+  # source://idlc//lib/idlc/ast.rb#6862
   def to_ast; end
 end
 
@@ -1872,39 +1875,42 @@ module Idl::ConcatenationExpression1
   def rest; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5323
+# source://idlc//lib/idlc/ast.rb#5346
 class Idl::ConcatenationExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5327
+  # source://idlc//lib/idlc/ast.rb#5350
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5329
+  # source://idlc//lib/idlc/ast.rb#5352
   def expressions; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#97
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5395
+  # source://idlc//lib/idlc/passes/prune.rb#493
+  def prune(symtab, forced_type: T.unsafe(nil)); end
+
+  # source://idlc//lib/idlc/ast.rb#5422
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5392
+  # source://idlc//lib/idlc/ast.rb#5419
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5345
+  # source://idlc//lib/idlc/ast.rb#5368
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5332
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5355
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5380
+  # source://idlc//lib/idlc/ast.rb#5403
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5402
+    # source://idlc//lib/idlc/ast.rb#5429
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1915,31 +1921,31 @@ class Idl::ConcatenationExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5313
+# source://idlc//lib/idlc/ast.rb#5336
 class Idl::ConcatenationExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5314
+  # source://idlc//lib/idlc/ast.rb#5337
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6720
+# source://idlc//lib/idlc/ast.rb#6781
 class Idl::ConditionalReturnStatementAst < ::Idl::AstNode
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#6729
+  # source://idlc//lib/idlc/ast.rb#6790
   def initialize(input, interval, return_expression, condition); end
 
-  # source://idlc//lib/idlc/ast.rb#6727
+  # source://idlc//lib/idlc/ast.rb#6788
   def condition; end
 
-  # source://idlc//lib/idlc/ast.rb#6724
+  # source://idlc//lib/idlc/ast.rb#6785
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#25
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#413
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#450
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
   # source://idlc//lib/idlc/passes/reachable_exceptions.rb#150
   def reachable_exceptions(symtab, cache = T.unsafe(nil)); end
@@ -1947,34 +1953,34 @@ class Idl::ConditionalReturnStatementAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/reachable_functions.rb#137
   def reachable_functions(symtab, cache); end
 
-  # source://idlc//lib/idlc/ast.rb#6726
+  # source://idlc//lib/idlc/ast.rb#6787
   def return_expression; end
 
-  # source://idlc//lib/idlc/ast.rb#6741
+  # source://idlc//lib/idlc/ast.rb#6802
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6746
+  # source://idlc//lib/idlc/ast.rb#6807
   def return_types(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6752
+  # source://idlc//lib/idlc/ast.rb#6813
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6761
+  # source://idlc//lib/idlc/ast.rb#6822
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6778
+  # source://idlc//lib/idlc/ast.rb#6839
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6775
+  # source://idlc//lib/idlc/ast.rb#6836
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6734
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6795
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6786
+    # source://idlc//lib/idlc/ast.rb#6847
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -1985,38 +1991,38 @@ class Idl::ConditionalReturnStatementAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6714
+# source://idlc//lib/idlc/ast.rb#6775
 class Idl::ConditionalReturnStatementSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6715
+  # source://idlc//lib/idlc/ast.rb#6776
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6329
+# source://idlc//lib/idlc/ast.rb#6390
 class Idl::ConditionalStatementAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#6336
+  # source://idlc//lib/idlc/ast.rb#6397
   def initialize(input, interval, action, condition); end
 
-  # source://idlc//lib/idlc/ast.rb#6330
+  # source://idlc//lib/idlc/ast.rb#6391
   def action; end
 
-  # source://idlc//lib/idlc/ast.rb#6331
+  # source://idlc//lib/idlc/ast.rb#6392
   def condition; end
 
-  # source://idlc//lib/idlc/ast.rb#6334
+  # source://idlc//lib/idlc/ast.rb#6395
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6350
+  # source://idlc//lib/idlc/ast.rb#6411
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6366
+  # source://idlc//lib/idlc/ast.rb#6427
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#283
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#428
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#465
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
   # source://idlc//lib/idlc/passes/reachable_exceptions.rb#166
   def reachable_exceptions(symtab, cache = T.unsafe(nil)); end
@@ -2024,19 +2030,19 @@ class Idl::ConditionalStatementAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/reachable_functions.rb#154
   def reachable_functions(symtab, cache = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#6377
+  # source://idlc//lib/idlc/ast.rb#6438
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6372
+  # source://idlc//lib/idlc/ast.rb#6433
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6341
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6402
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6385
+    # source://idlc//lib/idlc/ast.rb#6446
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2047,16 +2053,16 @@ class Idl::ConditionalStatementAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6319
+# source://idlc//lib/idlc/ast.rb#6380
 class Idl::ConditionalStatementSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6320
+  # source://idlc//lib/idlc/ast.rb#6381
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/type.rb#1000
+# source://idlc//lib/idlc/type.rb#1020
 Idl::ConstBitsUnknownType = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/type.rb#1001
+# source://idlc//lib/idlc/type.rb#1021
 Idl::ConstBoolType = T.let(T.unsafe(nil), Idl::Type)
 
 # source://idlc//lib/idlc/idl_parser.rb#8601
@@ -2071,9 +2077,9 @@ module Idl::ConstraintBody1
   def b; end
 end
 
-# source://idlc//lib/idlc/ast.rb#4106
+# source://idlc//lib/idlc/ast.rb#4122
 class Idl::ConstraintBodyAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#4114
+  # source://idlc//lib/idlc/ast.rb#4130
   sig do
     params(
       input: T.nilable(::String),
@@ -2083,32 +2089,32 @@ class Idl::ConstraintBodyAst < ::Idl::AstNode
   end
   def initialize(input, interval, stmts); end
 
-  # source://idlc//lib/idlc/ast.rb#4119
+  # source://idlc//lib/idlc/ast.rb#4135
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4132
+  # source://idlc//lib/idlc/ast.rb#4148
   sig { params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def satisfied?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4122
+  # source://idlc//lib/idlc/ast.rb#4138
   sig { returns(T::Array[T.any(::Idl::ForLoopAst, ::Idl::ImplicationStatementAst)]) }
   def stmts; end
 
-  # source://idlc//lib/idlc/ast.rb#4144
+  # source://idlc//lib/idlc/ast.rb#4160
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#4139
+  # source://idlc//lib/idlc/ast.rb#4155
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#4125
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#4141
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#4151
+    # source://idlc//lib/idlc/ast.rb#4167
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2119,14 +2125,14 @@ class Idl::ConstraintBodyAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#4095
+# source://idlc//lib/idlc/ast.rb#4111
 class Idl::ConstraintBodySyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#4097
+  # source://idlc//lib/idlc/ast.rb#4113
   sig { override.returns(::Idl::ConstraintBodyAst) }
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/interfaces.rb#110
+# source://idlc//lib/idlc/type.rb#15
 module Idl::Csr
   interface!
 
@@ -2216,11 +2222,11 @@ module Idl::CsrFieldAccessExpression0
   def csr_field_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#3237
+# source://idlc//lib/idlc/ast.rb#3253
 class Idl::CsrFieldAssignmentAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#3247
+  # source://idlc//lib/idlc/ast.rb#3263
   sig do
     params(
       input: T.nilable(::String),
@@ -2231,48 +2237,48 @@ class Idl::CsrFieldAssignmentAst < ::Idl::AstNode
   end
   def initialize(input, interval, csr_field, write_value); end
 
-  # source://idlc//lib/idlc/ast.rb#3241
+  # source://idlc//lib/idlc/ast.rb#3257
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3243
+  # source://idlc//lib/idlc/ast.rb#3259
   def csr_field; end
 
-  # source://idlc//lib/idlc/ast.rb#3268
+  # source://idlc//lib/idlc/ast.rb#3284
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3273
+  # source://idlc//lib/idlc/ast.rb#3289
   def execute_unknown(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3256
+  # source://idlc//lib/idlc/ast.rb#3272
   def field(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#112
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#476
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#579
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3279
+  # source://idlc//lib/idlc/ast.rb#3295
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#3276
+  # source://idlc//lib/idlc/ast.rb#3292
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#3252
+  # source://idlc//lib/idlc/ast.rb#3268
   sig { params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3260
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#3276
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#3244
+  # source://idlc//lib/idlc/ast.rb#3260
   def write_value; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#3287
+    # source://idlc//lib/idlc/ast.rb#3303
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2283,20 +2289,20 @@ class Idl::CsrFieldAssignmentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#3231
+# source://idlc//lib/idlc/ast.rb#3247
 class Idl::CsrFieldAssignmentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3232
+  # source://idlc//lib/idlc/ast.rb#3248
   def to_ast; end
 end
 
 # source://idlc//lib/idlc/idl_parser.rb#16453
 module Idl::CsrFieldName0; end
 
-# source://idlc//lib/idlc/ast.rb#9276
+# source://idlc//lib/idlc/ast.rb#9362
 class Idl::CsrFieldReadExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#9290
+  # source://idlc//lib/idlc/ast.rb#9376
   sig do
     params(
       input: T.nilable(::String),
@@ -2307,61 +2313,61 @@ class Idl::CsrFieldReadExpressionAst < ::Idl::AstNode
   end
   def initialize(input, interval, csr, field_name); end
 
-  # source://idlc//lib/idlc/ast.rb#9371
+  # source://idlc//lib/idlc/ast.rb#9460
   sig { params(symtab: ::Idl::SymbolTable).returns(T.nilable(::Idl::Type)) }
   def calc_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9404
+  # source://idlc//lib/idlc/ast.rb#9489
   sig { params(symtab: ::Idl::SymbolTable).void }
   def calc_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9287
+  # source://idlc//lib/idlc/ast.rb#9373
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9319
+  # source://idlc//lib/idlc/ast.rb#9408
   sig { params(symtab: ::Idl::SymbolTable).returns(::Idl::Csr) }
   def csr_def(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9324
+  # source://idlc//lib/idlc/ast.rb#9413
   sig { returns(::String) }
   def csr_name; end
 
-  # source://idlc//lib/idlc/ast.rb#9299
+  # source://idlc//lib/idlc/ast.rb#9385
   sig { params(symtab: ::Idl::SymbolTable).returns(::Idl::Csr) }
   def csr_obj(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9327
+  # source://idlc//lib/idlc/ast.rb#9416
   sig { params(symtab: ::Idl::SymbolTable).returns(::Idl::CsrField) }
   def field_def(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9332
+  # source://idlc//lib/idlc/ast.rb#9421
   sig { params(symtab: ::Idl::SymbolTable).returns(::String) }
   def field_name(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#317
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#482
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#585
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#9343
+  # source://idlc//lib/idlc/ast.rb#9432
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#9338
+  # source://idlc//lib/idlc/ast.rb#9427
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#9365
+  # source://idlc//lib/idlc/ast.rb#9454
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9311
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#9397
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#9391
+  # source://idlc//lib/idlc/ast.rb#9476
   sig do
     override
       .params(
@@ -2371,7 +2377,7 @@ class Idl::CsrFieldReadExpressionAst < ::Idl::AstNode
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#9351
+    # source://idlc//lib/idlc/ast.rb#9440
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2382,7 +2388,7 @@ class Idl::CsrFieldReadExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#9279
+# source://idlc//lib/idlc/ast.rb#9365
 class Idl::CsrFieldReadExpressionAst::MemoizedState < ::T::Struct
   prop :csr, T.nilable(::Idl::Csr)
   prop :type, T.nilable(::Idl::Type)
@@ -2390,63 +2396,63 @@ class Idl::CsrFieldReadExpressionAst::MemoizedState < ::T::Struct
   prop :value, T.nilable(::Integer)
 end
 
-# source://idlc//lib/idlc/ast.rb#9431
+# source://idlc//lib/idlc/ast.rb#9516
 class Idl::CsrFieldReadExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#9432
+  # source://idlc//lib/idlc/ast.rb#9517
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#9599
+# source://idlc//lib/idlc/ast.rb#9687
 class Idl::CsrFunctionCallAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#9617
+  # source://idlc//lib/idlc/ast.rb#9705
   def initialize(input, interval, function_name, csr, args); end
 
-  # source://idlc//lib/idlc/ast.rb#9615
+  # source://idlc//lib/idlc/ast.rb#9703
   def args; end
 
-  # source://idlc//lib/idlc/ast.rb#9603
+  # source://idlc//lib/idlc/ast.rb#9691
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9614
+  # source://idlc//lib/idlc/ast.rb#9702
   def csr; end
 
-  # source://idlc//lib/idlc/ast.rb#9655
+  # source://idlc//lib/idlc/ast.rb#9743
   def csr_def(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9649
+  # source://idlc//lib/idlc/ast.rb#9737
   def csr_known?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9653
+  # source://idlc//lib/idlc/ast.rb#9741
   def csr_name; end
 
-  # source://idlc//lib/idlc/ast.rb#9612
+  # source://idlc//lib/idlc/ast.rb#9700
   def function_name; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#76
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#9684
+  # source://idlc//lib/idlc/ast.rb#9772
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#9679
+  # source://idlc//lib/idlc/ast.rb#9767
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#9632
+  # source://idlc//lib/idlc/ast.rb#9720
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9622
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#9710
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#9660
+  # source://idlc//lib/idlc/ast.rb#9748
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#9693
+    # source://idlc//lib/idlc/ast.rb#9781
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2457,63 +2463,63 @@ class Idl::CsrFunctionCallAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#9584
+# source://idlc//lib/idlc/ast.rb#9672
 class Idl::CsrFunctionCallSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#9585
+  # source://idlc//lib/idlc/ast.rb#9673
   def to_ast; end
 end
 
 # source://idlc//lib/idlc/idl_parser.rb#16398
 module Idl::CsrName0; end
 
-# source://idlc//lib/idlc/ast.rb#9437
+# source://idlc//lib/idlc/ast.rb#9522
 class Idl::CsrReadExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#9445
+  # source://idlc//lib/idlc/ast.rb#9535
   def initialize(input, interval, csr_name); end
 
-  # source://idlc//lib/idlc/ast.rb#9441
+  # source://idlc//lib/idlc/ast.rb#9531
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9471
+  # source://idlc//lib/idlc/ast.rb#9559
   def csr_def(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9475
+  # source://idlc//lib/idlc/ast.rb#9563
   def csr_known?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9443
+  # source://idlc//lib/idlc/ast.rb#9533
   def csr_name; end
 
-  # source://idlc//lib/idlc/ast.rb#9451
+  # source://idlc//lib/idlc/ast.rb#9542
   def freeze_tree(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#325
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#494
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#600
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#9493
+  # source://idlc//lib/idlc/ast.rb#9581
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#9490
+  # source://idlc//lib/idlc/ast.rb#9578
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#9464
+  # source://idlc//lib/idlc/ast.rb#9552
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9467
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#9555
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#9480
+  # source://idlc//lib/idlc/ast.rb#9568
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#9500
+    # source://idlc//lib/idlc/ast.rb#9588
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2524,9 +2530,15 @@ class Idl::CsrReadExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#9425
+# source://idlc//lib/idlc/ast.rb#9525
+class Idl::CsrReadExpressionAst::Memo < ::T::Struct
+  prop :csr_obj, T.nilable(::Idl::Csr)
+  prop :type, T.nilable(::Idl::Type)
+end
+
+# source://idlc//lib/idlc/ast.rb#9510
 class Idl::CsrReadExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#9426
+  # source://idlc//lib/idlc/ast.rb#9511
   def to_ast; end
 end
 
@@ -2536,54 +2548,54 @@ module Idl::CsrRegisterAccessExpression0
   def csr_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#9517
+# source://idlc//lib/idlc/ast.rb#9605
 class Idl::CsrSoftwareWriteAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#9526
+  # source://idlc//lib/idlc/ast.rb#9614
   def initialize(input, interval, csr, expression); end
 
-  # source://idlc//lib/idlc/ast.rb#9521
+  # source://idlc//lib/idlc/ast.rb#9609
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9523
+  # source://idlc//lib/idlc/ast.rb#9611
   def csr; end
 
-  # source://idlc//lib/idlc/ast.rb#9540
+  # source://idlc//lib/idlc/ast.rb#9628
   def csr_known?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9544
+  # source://idlc//lib/idlc/ast.rb#9632
   def csr_name; end
 
-  # source://idlc//lib/idlc/ast.rb#9552
+  # source://idlc//lib/idlc/ast.rb#9640
   def execute(_symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9555
+  # source://idlc//lib/idlc/ast.rb#9643
   def execute_unknown(_symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9524
+  # source://idlc//lib/idlc/ast.rb#9612
   def expression; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#82
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#9562
+  # source://idlc//lib/idlc/ast.rb#9650
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#9559
+  # source://idlc//lib/idlc/ast.rb#9647
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#9530
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#9618
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#9547
+  # source://idlc//lib/idlc/ast.rb#9635
   def value(_symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#9570
+    # source://idlc//lib/idlc/ast.rb#9658
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2594,69 +2606,69 @@ class Idl::CsrSoftwareWriteAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#9511
+# source://idlc//lib/idlc/ast.rb#9599
 class Idl::CsrSoftwareWriteSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#9512
+  # source://idlc//lib/idlc/ast.rb#9600
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/type.rb#744
+# source://idlc//lib/idlc/type.rb#764
 class Idl::CsrType < ::Idl::Type
-  # source://idlc//lib/idlc/type.rb#751
+  # source://idlc//lib/idlc/type.rb#771
   sig { params(csr: ::Idl::Csr, qualifiers: T::Array[::Symbol]).void }
   def initialize(csr, qualifiers: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/type.rb#748
+  # source://idlc//lib/idlc/type.rb#768
   sig { returns(::Idl::Csr) }
   def csr; end
 
-  # source://idlc//lib/idlc/type.rb#756
+  # source://idlc//lib/idlc/type.rb#776
   sig { returns(T::Array[::Idl::CsrField]) }
   def fields; end
 end
 
-# source://idlc//lib/idlc/ast.rb#9711
+# source://idlc//lib/idlc/ast.rb#9799
 class Idl::CsrWriteAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#9719
+  # source://idlc//lib/idlc/ast.rb#9807
   def initialize(input, interval, idx); end
 
-  # source://idlc//lib/idlc/ast.rb#9715
+  # source://idlc//lib/idlc/ast.rb#9803
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9735
+  # source://idlc//lib/idlc/ast.rb#9823
   def csr_def(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9754
+  # source://idlc//lib/idlc/ast.rb#9842
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9759
+  # source://idlc//lib/idlc/ast.rb#9847
   def execute_unknown(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9717
+  # source://idlc//lib/idlc/ast.rb#9805
   def idx; end
 
-  # source://idlc//lib/idlc/ast.rb#9749
+  # source://idlc//lib/idlc/ast.rb#9837
   def name(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9766
+  # source://idlc//lib/idlc/ast.rb#9854
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#9763
+  # source://idlc//lib/idlc/ast.rb#9851
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#9745
+  # source://idlc//lib/idlc/ast.rb#9833
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9724
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#9812
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#9773
+    # source://idlc//lib/idlc/ast.rb#9861
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2667,17 +2679,17 @@ class Idl::CsrWriteAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#9707
+# source://idlc//lib/idlc/ast.rb#9795
 class Idl::CsrWriteSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#9708
+  # source://idlc//lib/idlc/ast.rb#9796
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#820
+# source://idlc//lib/idlc/ast.rb#818
 module Idl::Declaration
   interface!
 
-  # source://idlc//lib/idlc/ast.rb#830
+  # source://idlc//lib/idlc/ast.rb#828
   sig { abstract.params(symtab: ::Idl::SymbolTable).void }
   def add_symbol(symtab); end
 end
@@ -2700,36 +2712,36 @@ module Idl::Declaration1
   def type_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6471
+# source://idlc//lib/idlc/ast.rb#6532
 class Idl::DontCareLvalueAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#6477
+  # source://idlc//lib/idlc/ast.rb#6538
   def initialize(input, interval); end
 
-  # source://idlc//lib/idlc/ast.rb#6475
+  # source://idlc//lib/idlc/ast.rb#6536
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6496
+  # source://idlc//lib/idlc/ast.rb#6557
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6493
+  # source://idlc//lib/idlc/ast.rb#6554
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6485
+  # source://idlc//lib/idlc/ast.rb#6546
   def type(_symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6480
-  def type_check(_symtab); end
+  # source://idlc//lib/idlc/ast.rb#6541
+  def type_check(_symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#6490
+  # source://idlc//lib/idlc/ast.rb#6551
   def value(_symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6502
+    # source://idlc//lib/idlc/ast.rb#6563
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2740,48 +2752,48 @@ class Idl::DontCareLvalueAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6467
+# source://idlc//lib/idlc/ast.rb#6528
 class Idl::DontCareLvalueSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6468
+  # source://idlc//lib/idlc/ast.rb#6529
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6408
+# source://idlc//lib/idlc/ast.rb#6469
 class Idl::DontCareReturnAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#6414
+  # source://idlc//lib/idlc/ast.rb#6475
   def initialize(input, interval); end
 
-  # source://idlc//lib/idlc/ast.rb#6412
+  # source://idlc//lib/idlc/ast.rb#6473
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#61
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#6442
+  # source://idlc//lib/idlc/ast.rb#6503
   def set_expected_type(t); end
 
-  # source://idlc//lib/idlc/ast.rb#6450
+  # source://idlc//lib/idlc/ast.rb#6511
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6447
+  # source://idlc//lib/idlc/ast.rb#6508
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6424
+  # source://idlc//lib/idlc/ast.rb#6485
   def type(_symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6419
-  def type_check(_symtab); end
+  # source://idlc//lib/idlc/ast.rb#6480
+  def type_check(_symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#6429
+  # source://idlc//lib/idlc/ast.rb#6490
   def value(_symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6456
+    # source://idlc//lib/idlc/ast.rb#6517
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2792,20 +2804,20 @@ class Idl::DontCareReturnAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6398
+# source://idlc//lib/idlc/ast.rb#6459
 class Idl::DontCareReturnSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6399
+  # source://idlc//lib/idlc/ast.rb#6460
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#35
+# source://idlc//lib/idlc/ast.rb#33
 Idl::EMPTY_ARRAY = T.let(T.unsafe(nil), Array)
 
-# source://idlc//lib/idlc/ast.rb#8862
+# source://idlc//lib/idlc/ast.rb#8948
 class Idl::ElseIfAst < ::Idl::AstNode
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#8877
+  # source://idlc//lib/idlc/ast.rb#8963
   sig do
     params(
       input: T.nilable(::String),
@@ -2817,44 +2829,44 @@ class Idl::ElseIfAst < ::Idl::AstNode
   end
   def initialize(input, interval, body_interval, cond, body_stmts); end
 
-  # source://idlc//lib/idlc/ast.rb#8874
+  # source://idlc//lib/idlc/ast.rb#8960
   sig { returns(::Idl::IfBodyAst) }
   def body; end
 
-  # source://idlc//lib/idlc/ast.rb#8871
+  # source://idlc//lib/idlc/ast.rb#8957
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def cond; end
 
-  # source://idlc//lib/idlc/ast.rb#8866
+  # source://idlc//lib/idlc/ast.rb#8952
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#343
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#380
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#8898
+  # source://idlc//lib/idlc/ast.rb#8984
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8903
+  # source://idlc//lib/idlc/ast.rb#8989
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8914
+  # source://idlc//lib/idlc/ast.rb#9000
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8931
+  # source://idlc//lib/idlc/ast.rb#9017
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#8926
+  # source://idlc//lib/idlc/ast.rb#9012
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#8882
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8968
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#8939
+    # source://idlc//lib/idlc/ast.rb#9025
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2865,11 +2877,11 @@ class Idl::ElseIfAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1714
+# source://idlc//lib/idlc/ast.rb#1730
 class Idl::EnumArrayCastAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#1723
+  # source://idlc//lib/idlc/ast.rb#1739
   sig do
     params(
       input: T.nilable(::String),
@@ -2879,35 +2891,35 @@ class Idl::EnumArrayCastAst < ::Idl::AstNode
   end
   def initialize(input, interval, enum_class_name); end
 
-  # source://idlc//lib/idlc/ast.rb#1720
+  # source://idlc//lib/idlc/ast.rb#1736
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1717
+  # source://idlc//lib/idlc/ast.rb#1733
   def enum_class; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#132
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#1748
+  # source://idlc//lib/idlc/ast.rb#1764
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1745
+  # source://idlc//lib/idlc/ast.rb#1761
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1731
+  # source://idlc//lib/idlc/ast.rb#1747
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1727
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1743
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1740
+  # source://idlc//lib/idlc/ast.rb#1756
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1755
+    # source://idlc//lib/idlc/ast.rb#1771
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2918,17 +2930,17 @@ class Idl::EnumArrayCastAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1705
+# source://idlc//lib/idlc/ast.rb#1721
 class Idl::EnumArrayCastSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1706
+  # source://idlc//lib/idlc/ast.rb#1722
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#1630
+# source://idlc//lib/idlc/ast.rb#1646
 class Idl::EnumCastAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#1651
+  # source://idlc//lib/idlc/ast.rb#1667
   sig do
     params(
       input: T.nilable(::String),
@@ -2939,38 +2951,38 @@ class Idl::EnumCastAst < ::Idl::AstNode
   end
   def initialize(input, interval, user_type_name, expression); end
 
-  # source://idlc//lib/idlc/ast.rb#1634
+  # source://idlc//lib/idlc/ast.rb#1650
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1637
+  # source://idlc//lib/idlc/ast.rb#1653
   def enum_name; end
 
-  # source://idlc//lib/idlc/ast.rb#1640
+  # source://idlc//lib/idlc/ast.rb#1656
   def expression; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#107
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#1684
+  # source://idlc//lib/idlc/ast.rb#1700
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1681
+  # source://idlc//lib/idlc/ast.rb#1697
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1673
+  # source://idlc//lib/idlc/ast.rb#1689
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1655
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1671
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1678
+  # source://idlc//lib/idlc/ast.rb#1694
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1692
+    # source://idlc//lib/idlc/ast.rb#1708
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -2981,9 +2993,9 @@ class Idl::EnumCastAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1624
+# source://idlc//lib/idlc/ast.rb#1640
 class Idl::EnumCastSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1625
+  # source://idlc//lib/idlc/ast.rb#1641
   def to_ast; end
 end
 
@@ -3021,7 +3033,7 @@ end
 class Idl::EnumDefinitionAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#1815
+  # source://idlc//lib/idlc/ast.rb#1831
   sig do
     params(
       input: T.nilable(::String),
@@ -3033,43 +3045,43 @@ class Idl::EnumDefinitionAst < ::Idl::AstNode
   end
   def initialize(input, interval, user_type, element_names, element_values); end
 
-  # source://idlc//lib/idlc/ast.rb#1864
+  # source://idlc//lib/idlc/ast.rb#1880
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1804
+  # source://idlc//lib/idlc/ast.rb#1820
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1839
+  # source://idlc//lib/idlc/ast.rb#1855
   sig { returns(T::Array[::String]) }
   def element_names; end
 
-  # source://idlc//lib/idlc/ast.rb#1849
+  # source://idlc//lib/idlc/ast.rb#1865
   sig { returns(T::Array[::Integer]) }
   def element_values; end
 
-  # source://idlc//lib/idlc/ast.rb#1880
+  # source://idlc//lib/idlc/ast.rb#1896
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#1894
+  # source://idlc//lib/idlc/ast.rb#1910
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1884
+  # source://idlc//lib/idlc/ast.rb#1900
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1872
+  # source://idlc//lib/idlc/ast.rb#1888
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1852
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1868
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1877
+  # source://idlc//lib/idlc/ast.rb#1893
   def value(_symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1907
+    # source://idlc//lib/idlc/ast.rb#1923
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3080,17 +3092,17 @@ class Idl::EnumDefinitionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1767
+# source://idlc//lib/idlc/ast.rb#1783
 class Idl::EnumDefinitionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1768
+  # source://idlc//lib/idlc/ast.rb#1784
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#1576
+# source://idlc//lib/idlc/ast.rb#1592
 class Idl::EnumElementSizeAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#1585
+  # source://idlc//lib/idlc/ast.rb#1601
   sig do
     params(
       input: T.nilable(::String),
@@ -3100,35 +3112,35 @@ class Idl::EnumElementSizeAst < ::Idl::AstNode
   end
   def initialize(input, interval, enum_class_name); end
 
-  # source://idlc//lib/idlc/ast.rb#1582
+  # source://idlc//lib/idlc/ast.rb#1598
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1579
+  # source://idlc//lib/idlc/ast.rb#1595
   def enum_class; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#127
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#1605
+  # source://idlc//lib/idlc/ast.rb#1621
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1602
+  # source://idlc//lib/idlc/ast.rb#1618
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1593
+  # source://idlc//lib/idlc/ast.rb#1609
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1589
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1605
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1597
+  # source://idlc//lib/idlc/ast.rb#1613
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1612
+    # source://idlc//lib/idlc/ast.rb#1628
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3139,9 +3151,9 @@ class Idl::EnumElementSizeAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1567
+# source://idlc//lib/idlc/ast.rb#1583
 class Idl::EnumElementSizeSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1568
+  # source://idlc//lib/idlc/ast.rb#1584
   def to_ast; end
 end
 
@@ -3154,22 +3166,22 @@ module Idl::EnumRef0
   def member; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5843
+# source://idlc//lib/idlc/ast.rb#5874
 class Idl::EnumRefAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5852
+  # source://idlc//lib/idlc/ast.rb#5887
   def initialize(input, interval, class_name, member_name); end
 
-  # source://idlc//lib/idlc/ast.rb#5849
+  # source://idlc//lib/idlc/ast.rb#5884
   def class_name; end
 
-  # source://idlc//lib/idlc/ast.rb#5847
+  # source://idlc//lib/idlc/ast.rb#5882
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5861
-  def freeze_tree(global_symtab); end
+  # source://idlc//lib/idlc/ast.rb#5895
+  def enum_def_type(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#117
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
@@ -3177,28 +3189,28 @@ class Idl::EnumRefAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#148
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#5850
+  # source://idlc//lib/idlc/ast.rb#5885
   def member_name; end
 
-  # source://idlc//lib/idlc/ast.rb#5910
+  # source://idlc//lib/idlc/ast.rb#5931
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5907
+  # source://idlc//lib/idlc/ast.rb#5928
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5884
+  # source://idlc//lib/idlc/ast.rb#5915
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5874
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5907
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5900
+  # source://idlc//lib/idlc/ast.rb#5922
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5918
+    # source://idlc//lib/idlc/ast.rb#5939
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3209,48 +3221,53 @@ class Idl::EnumRefAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5832
+# source://idlc//lib/idlc/ast.rb#5877
+class Idl::EnumRefAst::Memo < ::T::Struct
+  prop :enum_def_type, T::Hash[::Idl::SymbolTable, ::Idl::EnumerationType], default: T.unsafe(nil)
+end
+
+# source://idlc//lib/idlc/ast.rb#5863
 class Idl::EnumRefSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5833
+  # source://idlc//lib/idlc/ast.rb#5864
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#1516
+# source://idlc//lib/idlc/ast.rb#1532
 class Idl::EnumSizeAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#1524
+  # source://idlc//lib/idlc/ast.rb#1540
   def initialize(input, interval, enum_class_name); end
 
-  # source://idlc//lib/idlc/ast.rb#1522
+  # source://idlc//lib/idlc/ast.rb#1538
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1519
+  # source://idlc//lib/idlc/ast.rb#1535
   def enum_class; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#122
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#1548
+  # source://idlc//lib/idlc/ast.rb#1564
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1545
+  # source://idlc//lib/idlc/ast.rb#1561
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1532
+  # source://idlc//lib/idlc/ast.rb#1548
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1528
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1544
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1540
+  # source://idlc//lib/idlc/ast.rb#1556
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1555
+    # source://idlc//lib/idlc/ast.rb#1571
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3261,9 +3278,9 @@ class Idl::EnumSizeAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1507
+# source://idlc//lib/idlc/ast.rb#1523
 class Idl::EnumSizeSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1508
+  # source://idlc//lib/idlc/ast.rb#1524
   def to_ast; end
 end
 
@@ -3273,9 +3290,9 @@ module Idl::EnumToA0
   def user_type_name; end
 end
 
-# source://idlc//lib/idlc/type.rb#641
+# source://idlc//lib/idlc/type.rb#14
 class Idl::EnumerationType < ::Idl::Type
-  # source://idlc//lib/idlc/type.rb#671
+  # source://idlc//lib/idlc/type.rb#690
   sig do
     params(
       type_name: ::String,
@@ -3286,53 +3303,53 @@ class Idl::EnumerationType < ::Idl::Type
   end
   def initialize(type_name, element_names, element_values, builtin: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/type.rb#686
+  # source://idlc//lib/idlc/type.rb#705
   sig { returns(T::Boolean) }
   def builtin?; end
 
-  # source://idlc//lib/idlc/type.rb#689
+  # source://idlc//lib/idlc/type.rb#708
   sig { returns(::Idl::EnumerationType) }
   def clone; end
 
-  # source://idlc//lib/idlc/type.rb#702
+  # source://idlc//lib/idlc/type.rb#721
   sig { params(element_value: ::Integer).returns(T.nilable(::String)) }
   def element_name(element_value); end
 
-  # source://idlc//lib/idlc/type.rb#650
+  # source://idlc//lib/idlc/type.rb#669
   sig { returns(T::Array[::String]) }
   def element_names; end
 
-  # source://idlc//lib/idlc/type.rb#654
+  # source://idlc//lib/idlc/type.rb#673
   sig { returns(T::Array[::Integer]) }
   def element_values; end
 
-  # source://idlc//lib/idlc/type.rb#658
+  # source://idlc//lib/idlc/type.rb#677
   sig { returns(::Idl::Type) }
   def ref_type; end
 
-  # source://idlc//lib/idlc/type.rb#694
+  # source://idlc//lib/idlc/type.rb#713
   sig { params(element_name: ::String).returns(T.nilable(::Integer)) }
   def value(element_name); end
 
-  # source://idlc//lib/idlc/type.rb#646
+  # source://idlc//lib/idlc/type.rb#665
   sig { returns(::Integer) }
   def width; end
 end
 
-# source://idlc//lib/idlc/ast.rb#591
+# source://idlc//lib/idlc/ast.rb#589
 module Idl::Executable
   interface!
 
-  # source://idlc//lib/idlc/ast.rb#613
+  # source://idlc//lib/idlc/ast.rb#611
   sig { abstract.params(symtab: ::Idl::SymbolTable).void }
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#617
+  # source://idlc//lib/idlc/ast.rb#615
   sig { abstract.params(symtab: ::Idl::SymbolTable).void }
   def execute_unknown(symtab); end
 end
 
-# source://idlc//lib/idlc/ast.rb#620
+# source://idlc//lib/idlc/ast.rb#618
 Idl::ExecutableAst = T.type_alias { T.all(::Idl::AstNode, ::Idl::Executable) }
 
 # source://idlc//lib/idlc/idl_parser.rb#13702
@@ -3383,15 +3400,15 @@ module Idl::ExecuteIfBlock5
   def if_cond; end
 end
 
-# source://idlc//lib/idlc/ast.rb#916
+# source://idlc//lib/idlc/ast.rb#914
 class Idl::FalseExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#920
+  # source://idlc//lib/idlc/ast.rb#918
   sig { params(input: ::String, interval: T::Range[::Integer]).void }
   def initialize(input, interval); end
 
-  # source://idlc//lib/idlc/ast.rb#925
+  # source://idlc//lib/idlc/ast.rb#923
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
@@ -3401,28 +3418,28 @@ class Idl::FalseExpressionAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#93
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#940
+  # source://idlc//lib/idlc/ast.rb#938
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#937
+  # source://idlc//lib/idlc/ast.rb#935
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#931
+  # source://idlc//lib/idlc/ast.rb#929
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#928
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#926
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#934
+  # source://idlc//lib/idlc/ast.rb#932
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::FalseClass) }
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#946
+    # source://idlc//lib/idlc/ast.rb#944
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3433,9 +3450,9 @@ class Idl::FalseExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#912
+# source://idlc//lib/idlc/ast.rb#910
 class Idl::FalseExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#913
+  # source://idlc//lib/idlc/ast.rb#911
   def to_ast; end
 end
 
@@ -3445,9 +3462,9 @@ module Idl::Fetch0
   def function_body; end
 end
 
-# source://idlc//lib/idlc/ast.rb#7982
+# source://idlc//lib/idlc/ast.rb#1250
 class Idl::FetchAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#7989
+  # source://idlc//lib/idlc/ast.rb#8075
   sig do
     params(
       input: T.nilable(::String),
@@ -3457,29 +3474,29 @@ class Idl::FetchAst < ::Idl::AstNode
   end
   def initialize(input, interval, body); end
 
-  # source://idlc//lib/idlc/ast.rb#7986
+  # source://idlc//lib/idlc/ast.rb#8072
   def body; end
 
-  # source://idlc//lib/idlc/ast.rb#7984
+  # source://idlc//lib/idlc/ast.rb#8070
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7997
+  # source://idlc//lib/idlc/ast.rb#8083
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8011
+  # source://idlc//lib/idlc/ast.rb#8097
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#8002
+  # source://idlc//lib/idlc/ast.rb#8088
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#7993
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8079
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#8018
+    # source://idlc//lib/idlc/ast.rb#8104
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3490,9 +3507,9 @@ class Idl::FetchAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#7976
+# source://idlc//lib/idlc/ast.rb#8062
 class Idl::FetchSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#7977
+  # source://idlc//lib/idlc/ast.rb#8063
   def to_ast; end
 end
 
@@ -3505,11 +3522,11 @@ module Idl::FieldAccessExpression0
   def field_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5744
+# source://idlc//lib/idlc/ast.rb#5775
 class Idl::FieldAccessExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5754
+  # source://idlc//lib/idlc/ast.rb#5785
   sig do
     params(
       input: T.nilable(::String),
@@ -3520,39 +3537,39 @@ class Idl::FieldAccessExpressionAst < ::Idl::AstNode
   end
   def initialize(input, interval, bitfield, field_name); end
 
-  # source://idlc//lib/idlc/ast.rb#5748
+  # source://idlc//lib/idlc/ast.rb#5779
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#87
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5760
+  # source://idlc//lib/idlc/ast.rb#5791
   def kind(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5751
+  # source://idlc//lib/idlc/ast.rb#5782
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def obj; end
 
-  # source://idlc//lib/idlc/ast.rb#5811
+  # source://idlc//lib/idlc/ast.rb#5842
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5808
+  # source://idlc//lib/idlc/ast.rb#5839
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5765
+  # source://idlc//lib/idlc/ast.rb#5796
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5777
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5808
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5795
+  # source://idlc//lib/idlc/ast.rb#5826
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5819
+    # source://idlc//lib/idlc/ast.rb#5850
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3563,17 +3580,17 @@ class Idl::FieldAccessExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5734
+# source://idlc//lib/idlc/ast.rb#5765
 class Idl::FieldAccessExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5735
+  # source://idlc//lib/idlc/ast.rb#5766
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#3102
+# source://idlc//lib/idlc/ast.rb#3118
 class Idl::FieldAssignmentAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#3130
+  # source://idlc//lib/idlc/ast.rb#3146
   sig do
     params(
       input: T.nilable(::String),
@@ -3585,47 +3602,47 @@ class Idl::FieldAssignmentAst < ::Idl::AstNode
   end
   def initialize(input, interval, id, field_name, rhs); end
 
-  # source://idlc//lib/idlc/ast.rb#3115
+  # source://idlc//lib/idlc/ast.rb#3131
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3175
+  # source://idlc//lib/idlc/ast.rb#3191
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3198
+  # source://idlc//lib/idlc/ast.rb#3214
   def execute_unknown(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3112
+  # source://idlc//lib/idlc/ast.rb#3128
   sig { returns(::String) }
   def field_name; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#92
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3106
+  # source://idlc//lib/idlc/ast.rb#3122
   sig { returns(::Idl::IdAst) }
   def id; end
 
-  # source://idlc//lib/idlc/ast.rb#3109
+  # source://idlc//lib/idlc/ast.rb#3125
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#3208
+  # source://idlc//lib/idlc/ast.rb#3224
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#3205
+  # source://idlc//lib/idlc/ast.rb#3221
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#3136
+  # source://idlc//lib/idlc/ast.rb#3152
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3150
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#3166
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#3217
+    # source://idlc//lib/idlc/ast.rb#3233
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3636,9 +3653,9 @@ class Idl::FieldAssignmentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#3090
+# source://idlc//lib/idlc/ast.rb#3106
 class Idl::FieldAssignmentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3091
+  # source://idlc//lib/idlc/ast.rb#3107
   def to_ast; end
 end
 
@@ -3666,38 +3683,38 @@ module Idl::ForLoop1
   def stmts; end
 end
 
-# source://idlc//lib/idlc/ast.rb#8511
+# source://idlc//lib/idlc/ast.rb#8597
 class Idl::ForLoopAst < ::Idl::AstNode
   include ::Idl::Executable
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#8536
+  # source://idlc//lib/idlc/ast.rb#8622
   def initialize(input, interval, init, condition, update, stmts); end
 
-  # source://idlc//lib/idlc/ast.rb#8527
+  # source://idlc//lib/idlc/ast.rb#8613
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def condition; end
 
-  # source://idlc//lib/idlc/ast.rb#8516
+  # source://idlc//lib/idlc/ast.rb#8602
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8654
+  # source://idlc//lib/idlc/ast.rb#8740
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8657
+  # source://idlc//lib/idlc/ast.rb#8743
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#202
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#8524
+  # source://idlc//lib/idlc/ast.rb#8610
   sig { returns(::Idl::VariableDeclarationWithInitializationAst) }
   def init; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#118
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#136
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
   # source://idlc//lib/idlc/passes/reachable_exceptions.rb#197
   def reachable_exceptions(symtab, cache = T.unsafe(nil)); end
@@ -3705,43 +3722,43 @@ class Idl::ForLoopAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/reachable_functions.rb#174
   def reachable_functions(symtab, cache = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#8603
+  # source://idlc//lib/idlc/ast.rb#8689
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8570
+  # source://idlc//lib/idlc/ast.rb#8656
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8609
+  # source://idlc//lib/idlc/ast.rb#8695
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8553
+  # source://idlc//lib/idlc/ast.rb#8639
   sig { params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def satisfied?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8534
+  # source://idlc//lib/idlc/ast.rb#8620
   sig do
     returns(T::Array[T.any(::Idl::ForLoopAst, ::Idl::IfAst, ::Idl::ImplicationStatementAst, ::Idl::ReturnStatementAst, ::Idl::StatementAst)])
   end
   def stmts; end
 
-  # source://idlc//lib/idlc/ast.rb#8689
+  # source://idlc//lib/idlc/ast.rb#8775
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#8679
+  # source://idlc//lib/idlc/ast.rb#8765
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#8541
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8627
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#8530
+  # source://idlc//lib/idlc/ast.rb#8616
   sig { returns(T.all(::Idl::AstNode, ::Idl::Executable)) }
   def update; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#8699
+    # source://idlc//lib/idlc/ast.rb#8785
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3752,7 +3769,7 @@ class Idl::ForLoopAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#8532
+# source://idlc//lib/idlc/ast.rb#8618
 Idl::ForLoopAst::StmtType = T.type_alias { T.any(::Idl::ForLoopAst, ::Idl::IfAst, ::Idl::ImplicationStatementAst, ::Idl::ReturnStatementAst, ::Idl::StatementAst) }
 
 # source://idlc//lib/idlc/idl_parser.rb#12060
@@ -3770,15 +3787,15 @@ module Idl::ForLoopIterationVariableDeclaration0
   def type_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#3703
+# source://idlc//lib/idlc/ast.rb#3719
 class Idl::ForLoopIterationVariableDeclarationSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3704
+  # source://idlc//lib/idlc/ast.rb#3720
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#8499
+# source://idlc//lib/idlc/ast.rb#8585
 class Idl::ForLoopSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#8500
+  # source://idlc//lib/idlc/ast.rb#8586
   def to_ast; end
 end
 
@@ -3809,12 +3826,12 @@ module Idl::FunctionBody1
   def func_stmt_list; end
 end
 
-# source://idlc//lib/idlc/ast.rb#7837
+# source://idlc//lib/idlc/ast.rb#7923
 class Idl::FunctionBodyAst < ::Idl::AstNode
   include ::Idl::Executable
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#7849
+  # source://idlc//lib/idlc/ast.rb#7935
   sig do
     params(
       input: T.nilable(::String),
@@ -3824,14 +3841,14 @@ class Idl::FunctionBodyAst < ::Idl::AstNode
   end
   def initialize(input, interval, stmts); end
 
-  # source://idlc//lib/idlc/ast.rb#7842
+  # source://idlc//lib/idlc/ast.rb#7928
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7912
+  # source://idlc//lib/idlc/ast.rb#7998
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7915
+  # source://idlc//lib/idlc/ast.rb#8001
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def execute_unknown(symtab); end
 
@@ -3844,37 +3861,37 @@ class Idl::FunctionBodyAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/find_return_values.rb#67
   def pass_find_return_values(symtab); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#161
-  def prune(symtab, args_already_applied: T.unsafe(nil)); end
+  # source://idlc//lib/idlc/passes/prune.rb#191
+  def prune(symtab, forced_type: T.unsafe(nil), args_already_applied: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#7881
+  # source://idlc//lib/idlc/ast.rb#7967
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7896
+  # source://idlc//lib/idlc/ast.rb#7982
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7922
+  # source://idlc//lib/idlc/ast.rb#8008
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7853
+  # source://idlc//lib/idlc/ast.rb#7939
   def statements; end
 
-  # source://idlc//lib/idlc/ast.rb#7855
+  # source://idlc//lib/idlc/ast.rb#7941
   def stmts; end
 
-  # source://idlc//lib/idlc/ast.rb#7957
+  # source://idlc//lib/idlc/ast.rb#8043
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#7952
+  # source://idlc//lib/idlc/ast.rb#8038
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#7858
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#7944
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#7964
+    # source://idlc//lib/idlc/ast.rb#8050
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -3885,9 +3902,9 @@ class Idl::FunctionBodyAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#7830
+# source://idlc//lib/idlc/ast.rb#7916
 class Idl::FunctionBodySyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#7832
+  # source://idlc//lib/idlc/ast.rb#7918
   def to_ast; end
 end
 
@@ -3930,31 +3947,31 @@ module Idl::FunctionCall3
   def t; end
 end
 
-# source://idlc//lib/idlc/ast.rb#7504
+# source://idlc//lib/idlc/ast.rb#7590
 class Idl::FunctionCallExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#7519
+  # source://idlc//lib/idlc/ast.rb#7605
   def initialize(input, interval, function_name, targs, args); end
 
-  # source://idlc//lib/idlc/ast.rb#7561
+  # source://idlc//lib/idlc/ast.rb#7647
   def arg_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#7517
+  # source://idlc//lib/idlc/ast.rb#7603
   def args; end
 
-  # source://idlc//lib/idlc/ast.rb#7510
+  # source://idlc//lib/idlc/ast.rb#7596
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7717
+  # source://idlc//lib/idlc/ast.rb#7803
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7725
+  # source://idlc//lib/idlc/ast.rb#7811
   def execute_unknown(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7565
+  # source://idlc//lib/idlc/ast.rb#7651
   def func_type(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#289
@@ -3963,11 +3980,11 @@ class Idl::FunctionCallExpressionAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#28
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#7719
+  # source://idlc//lib/idlc/ast.rb#7805
   def name; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#82
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#89
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
   # source://idlc//lib/idlc/passes/reachable_exceptions.rb#25
   def reachable_exceptions(symtab, cache = T.unsafe(nil)); end
@@ -3975,37 +3992,37 @@ class Idl::FunctionCallExpressionAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/reachable_functions.rb#21
   def reachable_functions(symtab, cache = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#7516
+  # source://idlc//lib/idlc/ast.rb#7602
   def targs; end
 
-  # source://idlc//lib/idlc/ast.rb#7532
+  # source://idlc//lib/idlc/ast.rb#7618
   def template?; end
 
-  # source://idlc//lib/idlc/ast.rb#7537
+  # source://idlc//lib/idlc/ast.rb#7623
   def template_arg_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#7541
+  # source://idlc//lib/idlc/ast.rb#7627
   def template_values(symtab, unknown_ok: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#7738
+  # source://idlc//lib/idlc/ast.rb#7824
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#7729
+  # source://idlc//lib/idlc/ast.rb#7815
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#7631
+  # source://idlc//lib/idlc/ast.rb#7717
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7580
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#7666
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#7640
+  # source://idlc//lib/idlc/ast.rb#7726
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#7749
+    # source://idlc//lib/idlc/ast.rb#7835
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4016,9 +4033,9 @@ class Idl::FunctionCallExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#7494
+# source://idlc//lib/idlc/ast.rb#7580
 class Idl::FunctionCallExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#7495
+  # source://idlc//lib/idlc/ast.rb#7581
   def to_ast; end
 end
 
@@ -4037,120 +4054,120 @@ module Idl::FunctionCallTemplateArguments1
   def rest; end
 end
 
-# source://idlc//lib/idlc/ast.rb#8050
+# source://idlc//lib/idlc/ast.rb#8136
 class Idl::FunctionDefAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#8074
+  # source://idlc//lib/idlc/ast.rb#8160
   def initialize(input, interval, name, targs, return_types, arguments, desc, type, body); end
 
-  # source://idlc//lib/idlc/ast.rb#8055
+  # source://idlc//lib/idlc/ast.rb#8141
   def <=>(other); end
 
-  # source://idlc//lib/idlc/ast.rb#8342
+  # source://idlc//lib/idlc/ast.rb#8428
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8304
+  # source://idlc//lib/idlc/ast.rb#8390
   def apply_template_and_arg_syms(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8095
+  # source://idlc//lib/idlc/ast.rb#8181
   def argument_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#8125
+  # source://idlc//lib/idlc/ast.rb#8211
   def arguments(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8156
+  # source://idlc//lib/idlc/ast.rb#8242
   def arguments_list_str; end
 
-  # source://idlc//lib/idlc/ast.rb#8394
+  # source://idlc//lib/idlc/ast.rb#8480
   def body; end
 
-  # source://idlc//lib/idlc/ast.rb#8400
+  # source://idlc//lib/idlc/ast.rb#8486
   def builtin?; end
 
-  # source://idlc//lib/idlc/ast.rb#8236
+  # source://idlc//lib/idlc/ast.rb#8322
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8110
+  # source://idlc//lib/idlc/ast.rb#8196
   def description; end
 
-  # source://idlc//lib/idlc/ast.rb#8061
+  # source://idlc//lib/idlc/ast.rb#8147
   def eql?(other); end
 
-  # source://idlc//lib/idlc/ast.rb#8408
+  # source://idlc//lib/idlc/ast.rb#8494
   def external?; end
 
-  # source://idlc//lib/idlc/ast.rb#8098
+  # source://idlc//lib/idlc/ast.rb#8184
   def freeze_tree(global_symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8404
+  # source://idlc//lib/idlc/ast.rb#8490
   def generated?; end
 
-  # source://idlc//lib/idlc/ast.rb#8265
+  # source://idlc//lib/idlc/ast.rb#8351
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#8120
+  # source://idlc//lib/idlc/ast.rb#8206
   def num_args; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#141
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#159
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#8412
+  # source://idlc//lib/idlc/ast.rb#8498
   def qualifier_str; end
 
-  # source://idlc//lib/idlc/ast.rb#8095
+  # source://idlc//lib/idlc/ast.rb#8181
   def reachable_functions_cache; end
 
-  # source://idlc//lib/idlc/ast.rb#8161
+  # source://idlc//lib/idlc/ast.rb#8247
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8224
+  # source://idlc//lib/idlc/ast.rb#8310
   def return_type_list_str; end
 
-  # source://idlc//lib/idlc/ast.rb#8053
+  # source://idlc//lib/idlc/ast.rb#8139
   def return_type_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#8356
+  # source://idlc//lib/idlc/ast.rb#8442
   def template_names; end
 
-  # source://idlc//lib/idlc/ast.rb#8362
+  # source://idlc//lib/idlc/ast.rb#8448
   def template_types(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8115
+  # source://idlc//lib/idlc/ast.rb#8201
   def templated?; end
 
-  # source://idlc//lib/idlc/ast.rb#8468
+  # source://idlc//lib/idlc/ast.rb#8554
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#8425
+  # source://idlc//lib/idlc/ast.rb#8511
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#8315
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8401
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#8384
-  def type_check_args(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8470
+  def type_check_args(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#8388
-  def type_check_body(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8474
+  def type_check_body(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#8288
-  def type_check_from_call(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8374
+  def type_check_from_call(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#8380
-  def type_check_return(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8466
+  def type_check_return(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#8375
+  # source://idlc//lib/idlc/ast.rb#8461
   def type_check_targs(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8270
-  def type_check_template_instance(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8356
+  def type_check_template_instance(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#8481
+    # source://idlc//lib/idlc/ast.rb#8567
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4161,9 +4178,9 @@ class Idl::FunctionDefAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#8030
+# source://idlc//lib/idlc/ast.rb#8116
 class Idl::FunctionDefSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#8031
+  # source://idlc//lib/idlc/ast.rb#8117
   def to_ast; end
 end
 
@@ -4218,12 +4235,12 @@ end
 # source://idlc//lib/idlc/idl_parser.rb#9334
 module Idl::FunctionName0; end
 
-# source://idlc//lib/idlc/type.rb#763
+# source://idlc//lib/idlc/type.rb#783
 class Idl::FunctionType < ::Idl::Type
-  # source://idlc//lib/idlc/type.rb#766
+  # source://idlc//lib/idlc/type.rb#786
   def initialize(func_name, func_def_ast, symtab); end
 
-  # source://idlc//lib/idlc/type.rb#845
+  # source://idlc//lib/idlc/type.rb#865
   sig do
     params(
       symtab: ::Idl::SymbolTable,
@@ -4234,40 +4251,40 @@ class Idl::FunctionType < ::Idl::Type
   end
   def apply_arguments(symtab, argument_nodes, call_site_symtab, func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#816
+  # source://idlc//lib/idlc/type.rb#836
   def apply_template_values(template_values, func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#949
+  # source://idlc//lib/idlc/type.rb#969
   def argument_name(index, template_values = T.unsafe(nil), func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#934
+  # source://idlc//lib/idlc/type.rb#954
   def argument_type(index, template_values, argument_nodes, call_site_symtab, func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#866
+  # source://idlc//lib/idlc/type.rb#886
   def argument_values(symtab, argument_nodes, call_site_symtab, func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#964
+  # source://idlc//lib/idlc/type.rb#984
   def body; end
 
-  # source://idlc//lib/idlc/type.rb#778
+  # source://idlc//lib/idlc/type.rb#798
   def builtin?; end
 
-  # source://idlc//lib/idlc/type.rb#774
+  # source://idlc//lib/idlc/type.rb#794
   def clone; end
 
-  # source://idlc//lib/idlc/type.rb#782
+  # source://idlc//lib/idlc/type.rb#802
   def external?; end
 
-  # source://idlc//lib/idlc/type.rb#764
+  # source://idlc//lib/idlc/type.rb#784
   def func_def_ast; end
 
-  # source://idlc//lib/idlc/type.rb#780
+  # source://idlc//lib/idlc/type.rb#800
   def generated?; end
 
-  # source://idlc//lib/idlc/type.rb#784
+  # source://idlc//lib/idlc/type.rb#804
   def num_args; end
 
-  # source://idlc//lib/idlc/type.rb#892
+  # source://idlc//lib/idlc/type.rb#912
   sig do
     params(
       template_values: T::Array[::Integer],
@@ -4277,61 +4294,61 @@ class Idl::FunctionType < ::Idl::Type
   end
   def return_type(template_values, argument_nodes, func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#921
+  # source://idlc//lib/idlc/type.rb#941
   def return_types(template_values, argument_nodes, call_site_symtab, func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#905
+  # source://idlc//lib/idlc/type.rb#925
   def return_value(template_values, argument_nodes, call_site_symtab, func_call_ast); end
 
-  # source://idlc//lib/idlc/type.rb#810
+  # source://idlc//lib/idlc/type.rb#830
   def template_names; end
 
-  # source://idlc//lib/idlc/type.rb#812
+  # source://idlc//lib/idlc/type.rb#832
   def template_types(symtab); end
 
-  # source://idlc//lib/idlc/type.rb#814
+  # source://idlc//lib/idlc/type.rb#834
   def templated?; end
 
-  # source://idlc//lib/idlc/type.rb#786
+  # source://idlc//lib/idlc/type.rb#806
   def type_check_call(template_values, argument_nodes, call_site_symtab, func_call_ast); end
 end
 
-# source://idlc//lib/idlc/ast.rb#1182
+# source://idlc//lib/idlc/ast.rb#1180
 class Idl::GlobalAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#1197
+  # source://idlc//lib/idlc/ast.rb#1195
   def initialize(input, interval, declaration); end
 
-  # source://idlc//lib/idlc/ast.rb#1210
+  # source://idlc//lib/idlc/ast.rb#1208
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1186
+  # source://idlc//lib/idlc/ast.rb#1184
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1193
+  # source://idlc//lib/idlc/ast.rb#1191
   def declaration; end
 
-  # source://idlc//lib/idlc/ast.rb#1188
+  # source://idlc//lib/idlc/ast.rb#1186
   def id; end
 
-  # source://idlc//lib/idlc/ast.rb#1220
+  # source://idlc//lib/idlc/ast.rb#1218
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1217
+  # source://idlc//lib/idlc/ast.rb#1215
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1206
+  # source://idlc//lib/idlc/ast.rb#1204
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1202
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1200
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1227
+    # source://idlc//lib/idlc/ast.rb#1225
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4360,64 +4377,64 @@ module Idl::GlobalDefinition2
   def declaration; end
 end
 
-# source://idlc//lib/idlc/ast.rb#1176
+# source://idlc//lib/idlc/ast.rb#1174
 class Idl::GlobalSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1177
+  # source://idlc//lib/idlc/ast.rb#1175
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#1102
+# source://idlc//lib/idlc/ast.rb#1100
 class Idl::GlobalWithInitializationAst < ::Idl::AstNode
   include ::Idl::Executable
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#1117
+  # source://idlc//lib/idlc/ast.rb#1115
   def initialize(input, interval, var_decl_with_init); end
 
-  # source://idlc//lib/idlc/ast.rb#1144
+  # source://idlc//lib/idlc/ast.rb#1142
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1110
+  # source://idlc//lib/idlc/ast.rb#1108
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1138
+  # source://idlc//lib/idlc/ast.rb#1136
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1141
+  # source://idlc//lib/idlc/ast.rb#1139
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def execute_unknown(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1106
+  # source://idlc//lib/idlc/ast.rb#1104
   def id; end
 
-  # source://idlc//lib/idlc/ast.rb#1107
+  # source://idlc//lib/idlc/ast.rb#1105
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#1158
+  # source://idlc//lib/idlc/ast.rb#1156
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1153
+  # source://idlc//lib/idlc/ast.rb#1151
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1128
+  # source://idlc//lib/idlc/ast.rb#1126
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1123
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1121
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1133
+  # source://idlc//lib/idlc/ast.rb#1131
   def value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1113
+  # source://idlc//lib/idlc/ast.rb#1111
   def var_decl_with_init; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1165
+    # source://idlc//lib/idlc/ast.rb#1163
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4428,28 +4445,28 @@ class Idl::GlobalWithInitializationAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1087
+# source://idlc//lib/idlc/ast.rb#1085
 class Idl::GlobalWithInitializationSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1088
+  # source://idlc//lib/idlc/ast.rb#1086
   def to_ast; end
 end
 
 # source://idlc//lib/idlc/idl_parser.rb#16283
 module Idl::Id0; end
 
-# source://idlc//lib/idlc/ast.rb#964
+# source://idlc//lib/idlc/ast.rb#962
 class Idl::IdAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#978
+  # source://idlc//lib/idlc/ast.rb#976
   sig { params(input: ::String, interval: T::Range[::Integer], name: ::String).void }
   def initialize(input, interval, name); end
 
-  # source://idlc//lib/idlc/ast.rb#1009
+  # source://idlc//lib/idlc/ast.rb#1007
   sig { returns(T::Boolean) }
   def const?; end
 
-  # source://idlc//lib/idlc/ast.rb#968
+  # source://idlc//lib/idlc/ast.rb#966
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
@@ -4459,42 +4476,42 @@ class Idl::IdAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#97
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#1025
+  # source://idlc//lib/idlc/ast.rb#1023
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T.any(::Integer, ::Symbol)) }
   def max_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1043
+  # source://idlc//lib/idlc/ast.rb#1041
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T.any(::Integer, ::Symbol)) }
   def min_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#972
+  # source://idlc//lib/idlc/ast.rb#970
   sig { returns(::String) }
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#975
+  # source://idlc//lib/idlc/ast.rb#973
   sig { override.returns(::String) }
   def text_value; end
 
-  # source://idlc//lib/idlc/ast.rb#1065
+  # source://idlc//lib/idlc/ast.rb#1063
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1062
+  # source://idlc//lib/idlc/ast.rb#1060
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#991
+  # source://idlc//lib/idlc/ast.rb#989
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#985
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#983
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#1012
+  # source://idlc//lib/idlc/ast.rb#1010
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1072
+    # source://idlc//lib/idlc/ast.rb#1070
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4505,35 +4522,35 @@ class Idl::IdAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#957
+# source://idlc//lib/idlc/ast.rb#955
 class Idl::IdSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#958
+  # source://idlc//lib/idlc/ast.rb#956
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#8989
+# source://idlc//lib/idlc/ast.rb#9075
 class Idl::IfAst < ::Idl::AstNode
   include ::Idl::Executable
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#9013
+  # source://idlc//lib/idlc/ast.rb#9099
   def initialize(input, interval, if_cond, if_body, elseifs, final_else_body); end
 
-  # source://idlc//lib/idlc/ast.rb#8994
+  # source://idlc//lib/idlc/ast.rb#9080
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9008
+  # source://idlc//lib/idlc/ast.rb#9094
   sig { returns(T::Array[::Idl::ElseIfAst]) }
   def elseifs; end
 
-  # source://idlc//lib/idlc/ast.rb#9182
+  # source://idlc//lib/idlc/ast.rb#9268
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9228
+  # source://idlc//lib/idlc/ast.rb#9314
   def execute_unknown(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9011
+  # source://idlc//lib/idlc/ast.rb#9097
   sig { returns(::Idl::IfBodyAst) }
   def final_else_body; end
 
@@ -4543,19 +4560,19 @@ class Idl::IfAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#34
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#9005
+  # source://idlc//lib/idlc/ast.rb#9091
   sig { returns(::Idl::IfBodyAst) }
   def if_body; end
 
-  # source://idlc//lib/idlc/ast.rb#9002
+  # source://idlc//lib/idlc/ast.rb#9088
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def if_cond; end
 
   # source://idlc//lib/idlc/passes/find_return_values.rb#35
   def pass_find_return_values(values, current_conditions, symtab); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#355
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#392
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
   # source://idlc//lib/idlc/passes/reachable_exceptions.rb#101
   def reachable_exceptions(symtab, cache = T.unsafe(nil)); end
@@ -4563,43 +4580,43 @@ class Idl::IfAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/reachable_functions.rb#84
   def reachable_functions(symtab, cache = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#9075
+  # source://idlc//lib/idlc/ast.rb#9161
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9084
+  # source://idlc//lib/idlc/ast.rb#9170
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9125
+  # source://idlc//lib/idlc/ast.rb#9211
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9062
+  # source://idlc//lib/idlc/ast.rb#9148
   def taken_body(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9251
+  # source://idlc//lib/idlc/ast.rb#9337
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#9235
+  # source://idlc//lib/idlc/ast.rb#9321
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#9024
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#9110
+  def type_check(symtab, strict:); end
 
   private
 
-  # source://idlc//lib/idlc/ast.rb#9143
+  # source://idlc//lib/idlc/ast.rb#9229
   def execute_after_if(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9219
+  # source://idlc//lib/idlc/ast.rb#9305
   def execute_unknown_after_if(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#9093
+  # source://idlc//lib/idlc/ast.rb#9179
   def return_values_after_if(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#9261
+    # source://idlc//lib/idlc/ast.rb#9347
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4610,12 +4627,12 @@ class Idl::IfAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#8714
+# source://idlc//lib/idlc/ast.rb#8800
 class Idl::IfBodyAst < ::Idl::AstNode
   include ::Idl::Executable
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#8727
+  # source://idlc//lib/idlc/ast.rb#8813
   sig do
     params(
       input: T.nilable(::String),
@@ -4625,14 +4642,14 @@ class Idl::IfBodyAst < ::Idl::AstNode
   end
   def initialize(input, interval, body_stmts); end
 
-  # source://idlc//lib/idlc/ast.rb#8719
+  # source://idlc//lib/idlc/ast.rb#8805
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8804
+  # source://idlc//lib/idlc/ast.rb#8890
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8830
+  # source://idlc//lib/idlc/ast.rb#8916
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#35
@@ -4641,36 +4658,36 @@ class Idl::IfBodyAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#71
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#331
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#368
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#8749
+  # source://idlc//lib/idlc/ast.rb#8835
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8755
+  # source://idlc//lib/idlc/ast.rb#8841
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8776
+  # source://idlc//lib/idlc/ast.rb#8862
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#8724
+  # source://idlc//lib/idlc/ast.rb#8810
   sig { returns(T::Array[::Idl::StatementAst]) }
   def stmts; end
 
-  # source://idlc//lib/idlc/ast.rb#8843
+  # source://idlc//lib/idlc/ast.rb#8929
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#8838
+  # source://idlc//lib/idlc/ast.rb#8924
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#8736
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#8822
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#8850
+    # source://idlc//lib/idlc/ast.rb#8936
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4681,9 +4698,9 @@ class Idl::IfBodyAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#8954
+# source://idlc//lib/idlc/ast.rb#9040
 class Idl::IfSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#8955
+  # source://idlc//lib/idlc/ast.rb#9041
   def to_ast; end
 end
 
@@ -4705,9 +4722,9 @@ module Idl::ImplicationExpression1
   def consequent; end
 end
 
-# source://idlc//lib/idlc/ast.rb#3974
+# source://idlc//lib/idlc/ast.rb#3990
 class Idl::ImplicationExpressionAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#3983
+  # source://idlc//lib/idlc/ast.rb#3999
   sig do
     params(
       input: T.nilable(::String),
@@ -4718,36 +4735,36 @@ class Idl::ImplicationExpressionAst < ::Idl::AstNode
   end
   def initialize(input, interval, antecedent, consequent); end
 
-  # source://idlc//lib/idlc/ast.rb#3994
+  # source://idlc//lib/idlc/ast.rb#4010
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def antecedent; end
 
-  # source://idlc//lib/idlc/ast.rb#3997
+  # source://idlc//lib/idlc/ast.rb#4013
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def consequent; end
 
-  # source://idlc//lib/idlc/ast.rb#3989
+  # source://idlc//lib/idlc/ast.rb#4005
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4006
+  # source://idlc//lib/idlc/ast.rb#4022
   sig { params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def satisfied?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4015
+  # source://idlc//lib/idlc/ast.rb#4031
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#4012
+  # source://idlc//lib/idlc/ast.rb#4028
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#4000
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#4016
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#4023
+    # source://idlc//lib/idlc/ast.rb#4039
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4758,9 +4775,9 @@ class Idl::ImplicationExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#3963
+# source://idlc//lib/idlc/ast.rb#3979
 class Idl::ImplicationExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3965
+  # source://idlc//lib/idlc/ast.rb#3981
   sig { override.returns(::Idl::ImplicationExpressionAst) }
   def to_ast; end
 end
@@ -4792,9 +4809,9 @@ module Idl::ImplicationStatement0
   def implication_expression; end
 end
 
-# source://idlc//lib/idlc/ast.rb#4043
+# source://idlc//lib/idlc/ast.rb#4059
 class Idl::ImplicationStatementAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#4051
+  # source://idlc//lib/idlc/ast.rb#4067
   sig do
     params(
       input: ::String,
@@ -4804,32 +4821,32 @@ class Idl::ImplicationStatementAst < ::Idl::AstNode
   end
   def initialize(input, interval, implication_expression); end
 
-  # source://idlc//lib/idlc/ast.rb#4056
+  # source://idlc//lib/idlc/ast.rb#4072
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4059
+  # source://idlc//lib/idlc/ast.rb#4075
   sig { returns(::Idl::ImplicationExpressionAst) }
   def expression; end
 
-  # source://idlc//lib/idlc/ast.rb#4067
+  # source://idlc//lib/idlc/ast.rb#4083
   sig { params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def satisfied?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4075
+  # source://idlc//lib/idlc/ast.rb#4091
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#4072
+  # source://idlc//lib/idlc/ast.rb#4088
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#4062
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#4078
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#4082
+    # source://idlc//lib/idlc/ast.rb#4098
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -4840,9 +4857,9 @@ class Idl::ImplicationStatementAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#4036
+# source://idlc//lib/idlc/ast.rb#4052
 class Idl::ImplicationStatementSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#4038
+  # source://idlc//lib/idlc/ast.rb#4054
   sig { override.returns(::Idl::ImplicationStatementAst) }
   def to_ast; end
 end
@@ -4853,35 +4870,35 @@ module Idl::IncludeStatement0
   def string; end
 end
 
-# source://idlc//lib/idlc/ast.rb#841
+# source://idlc//lib/idlc/ast.rb#839
 class Idl::IncludeStatementAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#850
+  # source://idlc//lib/idlc/ast.rb#848
   sig { params(input: ::String, interval: T::Range[T.untyped], filename: ::Idl::AstNode).void }
   def initialize(input, interval, filename); end
 
-  # source://idlc//lib/idlc/ast.rb#843
+  # source://idlc//lib/idlc/ast.rb#841
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#847
+  # source://idlc//lib/idlc/ast.rb#845
   sig { returns(::String) }
   def filename; end
 
-  # source://idlc//lib/idlc/ast.rb#860
+  # source://idlc//lib/idlc/ast.rb#858
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#855
+  # source://idlc//lib/idlc/ast.rb#853
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#858
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#856
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 end
 
-# source://idlc//lib/idlc/ast.rb#833
+# source://idlc//lib/idlc/ast.rb#831
 class Idl::IncludeStatementSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#835
+  # source://idlc//lib/idlc/ast.rb#833
   sig { override.returns(::Idl::IncludeStatementAst) }
   def to_ast; end
 end
@@ -4898,9 +4915,9 @@ module Idl::InstructionOperation1
   def op_stmt_list; end
 end
 
-# source://idlc//lib/idlc/ast.rb#7824
+# source://idlc//lib/idlc/ast.rb#7910
 class Idl::InstructionOperationSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#7825
+  # source://idlc//lib/idlc/ast.rb#7911
   def to_ast; end
 end
 
@@ -4955,19 +4972,19 @@ module Idl::Int8; end
 # source://idlc//lib/idlc/idl_parser.rb#1505
 module Idl::Int9; end
 
-# source://idlc//lib/idlc/ast.rb#7150
+# source://idlc//lib/idlc/ast.rb#7231
 class Idl::IntLiteralAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#7157
+  # source://idlc//lib/idlc/ast.rb#7238
   sig { params(input: T.nilable(::String), interval: T.nilable(T::Range[::Integer]), text: ::String).void }
   def initialize(input, interval, text); end
 
-  # source://idlc//lib/idlc/ast.rb#7154
+  # source://idlc//lib/idlc/ast.rb#7235
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7164
+  # source://idlc//lib/idlc/ast.rb#7245
   def freeze_tree(global_symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#142
@@ -4976,46 +4993,49 @@ class Idl::IntLiteralAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#103
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#7421
+  # source://idlc//lib/idlc/passes/prune.rb#547
+  def prune(symtab, forced_type: T.unsafe(nil)); end
+
+  # source://idlc//lib/idlc/ast.rb#7507
   sig { returns(::Integer) }
   def radix; end
 
-  # source://idlc//lib/idlc/ast.rb#7404
+  # source://idlc//lib/idlc/ast.rb#7490
   sig { returns(T::Boolean) }
   def signed?; end
 
-  # source://idlc//lib/idlc/ast.rb#7162
+  # source://idlc//lib/idlc/ast.rb#7243
   def text_value; end
 
-  # source://idlc//lib/idlc/ast.rb#7459
+  # source://idlc//lib/idlc/ast.rb#7545
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#7392
+  # source://idlc//lib/idlc/ast.rb#7478
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#7395
+  # source://idlc//lib/idlc/ast.rb#7481
   sig { override.returns(::String) }
   def to_idl_verbose; end
 
-  # source://idlc//lib/idlc/ast.rb#7190
+  # source://idlc//lib/idlc/ast.rb#7271
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7174
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#7255
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#7311
+  # source://idlc//lib/idlc/ast.rb#7397
   def unsigned_value; end
 
-  # source://idlc//lib/idlc/ast.rb#7264
+  # source://idlc//lib/idlc/ast.rb#7350
   def value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7225
+  # source://idlc//lib/idlc/ast.rb#7311
   def width(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#7482
+    # source://idlc//lib/idlc/ast.rb#7568
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5024,14 +5044,14 @@ class Idl::IntLiteralAst < ::Idl::AstNode
     end
     def from_h(yaml, source_mapper); end
 
-    # source://idlc//lib/idlc/ast.rb#7470
+    # source://idlc//lib/idlc/ast.rb#7556
     def radix_to_verilog(r); end
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#7060
+# source://idlc//lib/idlc/ast.rb#7121
 module Idl::IntLiteralSyntaxNode
-  # source://idlc//lib/idlc/ast.rb#7061
+  # source://idlc//lib/idlc/ast.rb#7122
   def to_ast; end
 end
 
@@ -5046,50 +5066,60 @@ end
 
 # source://idlc//lib/idlc/ast.rb#1253
 class Idl::IsaAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#1280
+  # source://idlc//lib/idlc/ast.rb#1259
+  sig do
+    params(
+      input: T.nilable(::String),
+      interval: T.nilable(T::Range[::Integer]),
+      children: T::Array[::Idl::AstNode]
+    ).void
+  end
+  def initialize(input, interval, children); end
+
+  # source://idlc//lib/idlc/ast.rb#1297
   def add_global_symbols(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1266
+  # source://idlc//lib/idlc/ast.rb#1276
   def bitfields; end
 
-  # source://idlc//lib/idlc/ast.rb#1257
+  # source://idlc//lib/idlc/ast.rb#1267
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#1254
+  # source://idlc//lib/idlc/ast.rb#1264
   def definitions; end
 
-  # source://idlc//lib/idlc/ast.rb#1263
+  # source://idlc//lib/idlc/ast.rb#1273
   def enums; end
 
-  # source://idlc//lib/idlc/ast.rb#1275
+  # source://idlc//lib/idlc/ast.rb#1285
   def fetch; end
 
-  # source://idlc//lib/idlc/ast.rb#1272
+  # source://idlc//lib/idlc/ast.rb#1282
   def functions; end
 
-  # source://idlc//lib/idlc/ast.rb#1260
+  # source://idlc//lib/idlc/ast.rb#1270
   def globals; end
 
-  # source://idlc//lib/idlc/ast.rb#1295
+  # source://idlc//lib/idlc/ast.rb#1312
   def replace_include!(include_ast, isa_ast); end
 
-  # source://idlc//lib/idlc/ast.rb#1269
+  # source://idlc//lib/idlc/ast.rb#1279
   def structs; end
 
-  # source://idlc//lib/idlc/ast.rb#1328
+  # source://idlc//lib/idlc/ast.rb#1344
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#1314
+  # source://idlc//lib/idlc/ast.rb#1330
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#1305
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#1322
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#1335
+    # source://idlc//lib/idlc/ast.rb#1351
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5100,9 +5130,14 @@ class Idl::IsaAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#1240
+# source://idlc//lib/idlc/ast.rb#1254
+class Idl::IsaAst::Memo < ::T::Struct
+  prop :fetch, T.nilable(::Idl::FetchAst)
+end
+
+# source://idlc//lib/idlc/ast.rb#1238
 class Idl::IsaSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#1241
+  # source://idlc//lib/idlc/ast.rb#1239
   def to_ast; end
 end
 
@@ -5154,51 +5189,51 @@ module Idl::Keyword8; end
 # source://idlc//lib/idlc/idl_parser.rb#15067
 module Idl::Keyword9; end
 
-# source://idlc//lib/idlc/ast.rb#3310
+# source://idlc//lib/idlc/ast.rb#3326
 class Idl::MultiVariableAssignmentAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#3332
+  # source://idlc//lib/idlc/ast.rb#3348
   def initialize(input, interval, variables, function_call); end
 
-  # source://idlc//lib/idlc/ast.rb#3314
+  # source://idlc//lib/idlc/ast.rb#3330
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3377
+  # source://idlc//lib/idlc/ast.rb#3393
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3401
+  # source://idlc//lib/idlc/ast.rb#3417
   def execute_unknown(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3330
+  # source://idlc//lib/idlc/ast.rb#3346
   def function_call; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#71
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3341
+  # source://idlc//lib/idlc/ast.rb#3357
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#3412
+  # source://idlc//lib/idlc/ast.rb#3428
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#3409
+  # source://idlc//lib/idlc/ast.rb#3425
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#3346
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#3362
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#3329
+  # source://idlc//lib/idlc/ast.rb#3345
   def variables; end
 
-  # source://idlc//lib/idlc/ast.rb#3337
+  # source://idlc//lib/idlc/ast.rb#3353
   def vars; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#3420
+    # source://idlc//lib/idlc/ast.rb#3436
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5209,17 +5244,17 @@ class Idl::MultiVariableAssignmentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#3300
+# source://idlc//lib/idlc/ast.rb#3316
 class Idl::MultiVariableAssignmentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3301
+  # source://idlc//lib/idlc/ast.rb#3317
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#3444
+# source://idlc//lib/idlc/ast.rb#3460
 class Idl::MultiVariableDeclarationAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#3460
+  # source://idlc//lib/idlc/ast.rb#3476
   sig do
     params(
       input: T.nilable(::String),
@@ -5230,44 +5265,44 @@ class Idl::MultiVariableDeclarationAst < ::Idl::AstNode
   end
   def initialize(input, interval, type_name, var_names); end
 
-  # source://idlc//lib/idlc/ast.rb#3493
+  # source://idlc//lib/idlc/ast.rb#3509
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3448
+  # source://idlc//lib/idlc/ast.rb#3464
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#180
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3467
+  # source://idlc//lib/idlc/ast.rb#3483
   def make_global; end
 
-  # source://idlc//lib/idlc/ast.rb#3504
+  # source://idlc//lib/idlc/ast.rb#3520
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#3501
+  # source://idlc//lib/idlc/ast.rb#3517
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#3484
+  # source://idlc//lib/idlc/ast.rb#3500
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3477
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#3493
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#3454
+  # source://idlc//lib/idlc/ast.rb#3470
   def type_name; end
 
-  # source://idlc//lib/idlc/ast.rb#3457
+  # source://idlc//lib/idlc/ast.rb#3473
   def var_name_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#3472
+  # source://idlc//lib/idlc/ast.rb#3488
   def var_names; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#3512
+    # source://idlc//lib/idlc/ast.rb#3528
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5278,43 +5313,43 @@ class Idl::MultiVariableDeclarationAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#3433
+# source://idlc//lib/idlc/ast.rb#3449
 class Idl::MultiVariableDeclarationSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3434
+  # source://idlc//lib/idlc/ast.rb#3450
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6217
+# source://idlc//lib/idlc/ast.rb#6278
 class Idl::NoopAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#6221
+  # source://idlc//lib/idlc/ast.rb#6282
   def initialize; end
 
-  # source://idlc//lib/idlc/ast.rb#6219
+  # source://idlc//lib/idlc/ast.rb#6280
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6229
+  # source://idlc//lib/idlc/ast.rb#6290
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6232
+  # source://idlc//lib/idlc/ast.rb#6293
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#17
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#6239
+  # source://idlc//lib/idlc/ast.rb#6300
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6236
+  # source://idlc//lib/idlc/ast.rb#6297
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6226
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6287
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6245
+    # source://idlc//lib/idlc/ast.rb#6306
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5517,45 +5552,48 @@ module Idl::ParenExpression0
   def e; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5208
+# source://idlc//lib/idlc/ast.rb#5231
 class Idl::ParenExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5214
+  # source://idlc//lib/idlc/ast.rb#5237
   def initialize(input, interval, exp); end
 
-  # source://idlc//lib/idlc/ast.rb#5212
+  # source://idlc//lib/idlc/ast.rb#5235
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5216
+  # source://idlc//lib/idlc/ast.rb#5239
   def expression; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#137
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5218
+  # source://idlc//lib/idlc/ast.rb#5241
   def invert(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5234
+  # source://idlc//lib/idlc/passes/prune.rb#179
+  def prune(symtab, forced_type: T.unsafe(nil)); end
+
+  # source://idlc//lib/idlc/ast.rb#5257
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5231
+  # source://idlc//lib/idlc/ast.rb#5254
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5224
+  # source://idlc//lib/idlc/ast.rb#5247
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5221
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5244
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5227
+  # source://idlc//lib/idlc/ast.rb#5250
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5241
+    # source://idlc//lib/idlc/ast.rb#5264
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5566,17 +5604,17 @@ class Idl::ParenExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5198
+# source://idlc//lib/idlc/ast.rb#5221
 class Idl::ParenExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5199
+  # source://idlc//lib/idlc/ast.rb#5222
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#2616
+# source://idlc//lib/idlc/ast.rb#2632
 class Idl::PcAssignmentAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#2627
+  # source://idlc//lib/idlc/ast.rb#2643
   sig do
     params(
       input: T.nilable(::String),
@@ -5586,39 +5624,39 @@ class Idl::PcAssignmentAst < ::Idl::AstNode
   end
   def initialize(input, interval, rval); end
 
-  # source://idlc//lib/idlc/ast.rb#2620
+  # source://idlc//lib/idlc/ast.rb#2636
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2633
+  # source://idlc//lib/idlc/ast.rb#2649
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2637
+  # source://idlc//lib/idlc/ast.rb#2653
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#247
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#2624
+  # source://idlc//lib/idlc/ast.rb#2640
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#2650
+  # source://idlc//lib/idlc/ast.rb#2666
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2647
+  # source://idlc//lib/idlc/ast.rb#2663
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2641
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2657
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2657
+    # source://idlc//lib/idlc/ast.rb#2673
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5629,9 +5667,9 @@ class Idl::PcAssignmentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2610
+# source://idlc//lib/idlc/ast.rb#2626
 class Idl::PcAssignmentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#2611
+  # source://idlc//lib/idlc/ast.rb#2627
   def to_ast; end
 end
 
@@ -5641,46 +5679,46 @@ module Idl::PostDec0
   def rval; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5506
+# source://idlc//lib/idlc/ast.rb#5537
 class Idl::PostDecrementExpressionAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#5515
+  # source://idlc//lib/idlc/ast.rb#5546
   def initialize(input, interval, rval); end
 
-  # source://idlc//lib/idlc/ast.rb#5510
+  # source://idlc//lib/idlc/ast.rb#5541
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5532
+  # source://idlc//lib/idlc/ast.rb#5563
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5548
+  # source://idlc//lib/idlc/ast.rb#5579
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#50
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5513
+  # source://idlc//lib/idlc/ast.rb#5544
   sig { returns(T.any(::Idl::BuiltinVariableAst, ::Idl::IdAst, ::Idl::IntLiteralAst, ::Idl::StringLiteralAst)) }
   def rval; end
 
-  # source://idlc//lib/idlc/ast.rb#5556
+  # source://idlc//lib/idlc/ast.rb#5587
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5553
+  # source://idlc//lib/idlc/ast.rb#5584
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5527
+  # source://idlc//lib/idlc/ast.rb#5558
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5519
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5550
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5563
+    # source://idlc//lib/idlc/ast.rb#5594
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5691,9 +5729,9 @@ class Idl::PostDecrementExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5496
+# source://idlc//lib/idlc/ast.rb#5527
 class Idl::PostDecrementExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5497
+  # source://idlc//lib/idlc/ast.rb#5528
   def to_ast; end
 end
 
@@ -5703,45 +5741,45 @@ module Idl::PostInc0
   def rval; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5661
+# source://idlc//lib/idlc/ast.rb#5692
 class Idl::PostIncrementExpressionAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#5669
+  # source://idlc//lib/idlc/ast.rb#5700
   def initialize(input, interval, rval); end
 
-  # source://idlc//lib/idlc/ast.rb#5665
+  # source://idlc//lib/idlc/ast.rb#5696
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5689
+  # source://idlc//lib/idlc/ast.rb#5720
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5706
+  # source://idlc//lib/idlc/ast.rb#5737
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#45
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5667
+  # source://idlc//lib/idlc/ast.rb#5698
   def rval; end
 
-  # source://idlc//lib/idlc/ast.rb#5715
+  # source://idlc//lib/idlc/ast.rb#5746
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5712
+  # source://idlc//lib/idlc/ast.rb#5743
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5684
+  # source://idlc//lib/idlc/ast.rb#5715
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5674
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5705
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5722
+    # source://idlc//lib/idlc/ast.rb#5753
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5752,9 +5790,9 @@ class Idl::PostIncrementExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5651
+# source://idlc//lib/idlc/ast.rb#5682
 class Idl::PostIncrementExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5652
+  # source://idlc//lib/idlc/ast.rb#5683
   def to_ast; end
 end
 
@@ -5767,45 +5805,48 @@ module Idl::ReplicationExpression0
   def v; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5424
+# source://idlc//lib/idlc/ast.rb#5451
 class Idl::ReplicationExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5434
+  # source://idlc//lib/idlc/ast.rb#5461
   def initialize(input, interval, n, v); end
 
-  # source://idlc//lib/idlc/ast.rb#5428
+  # source://idlc//lib/idlc/ast.rb#5455
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#277
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5431
+  # source://idlc//lib/idlc/ast.rb#5458
   def n; end
 
-  # source://idlc//lib/idlc/ast.rb#5475
+  # source://idlc//lib/idlc/passes/prune.rb#521
+  def prune(symtab, forced_type: T.unsafe(nil)); end
+
+  # source://idlc//lib/idlc/ast.rb#5506
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#5472
+  # source://idlc//lib/idlc/ast.rb#5503
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5460
+  # source://idlc//lib/idlc/ast.rb#5491
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5439
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#5466
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#5432
+  # source://idlc//lib/idlc/ast.rb#5459
   def v; end
 
-  # source://idlc//lib/idlc/ast.rb#5451
+  # source://idlc//lib/idlc/ast.rb#5478
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#5483
+    # source://idlc//lib/idlc/ast.rb#5514
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5816,9 +5857,9 @@ class Idl::ReplicationExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5414
+# source://idlc//lib/idlc/ast.rb#5441
 class Idl::ReplicationExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5415
+  # source://idlc//lib/idlc/ast.rb#5442
   def to_ast; end
 end
 
@@ -5849,18 +5890,18 @@ module Idl::ReturnExpression3
   def vals; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6613
+# source://idlc//lib/idlc/ast.rb#6674
 class Idl::ReturnExpressionAst < ::Idl::AstNode
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#6621
+  # source://idlc//lib/idlc/ast.rb#6682
   def initialize(input, interval, return_nodes); end
 
-  # source://idlc//lib/idlc/ast.rb#6617
+  # source://idlc//lib/idlc/ast.rb#6678
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6665
+  # source://idlc//lib/idlc/ast.rb#6726
   def enclosing_function; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#30
@@ -5869,34 +5910,34 @@ class Idl::ReturnExpressionAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#115
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#6638
+  # source://idlc//lib/idlc/ast.rb#6699
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6627
+  # source://idlc//lib/idlc/ast.rb#6688
   def return_types(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6670
+  # source://idlc//lib/idlc/ast.rb#6731
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6619
+  # source://idlc//lib/idlc/ast.rb#6680
   def return_value_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#6681
+  # source://idlc//lib/idlc/ast.rb#6742
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6695
+  # source://idlc//lib/idlc/ast.rb#6756
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6692
+  # source://idlc//lib/idlc/ast.rb#6753
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6650
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6711
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6702
+    # source://idlc//lib/idlc/ast.rb#6763
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5907,9 +5948,9 @@ class Idl::ReturnExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6600
+# source://idlc//lib/idlc/ast.rb#6661
 class Idl::ReturnExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6601
+  # source://idlc//lib/idlc/ast.rb#6662
   def to_ast; end
 end
 
@@ -5928,21 +5969,21 @@ module Idl::ReturnStatement1
   def return_expression; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6524
+# source://idlc//lib/idlc/ast.rb#6585
 class Idl::ReturnStatementAst < ::Idl::AstNode
   include ::Idl::Returns
 
-  # source://idlc//lib/idlc/ast.rb#6534
+  # source://idlc//lib/idlc/ast.rb#6595
   def initialize(input, interval, return_expression); end
 
-  # source://idlc//lib/idlc/ast.rb#6528
+  # source://idlc//lib/idlc/ast.rb#6589
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6563
+  # source://idlc//lib/idlc/ast.rb#6624
   def enclosing_function; end
 
-  # source://idlc//lib/idlc/ast.rb#6549
+  # source://idlc//lib/idlc/ast.rb#6610
   def expected_return_type(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#271
@@ -5954,37 +5995,37 @@ class Idl::ReturnStatementAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/find_return_values.rb#19
   def pass_find_return_values(values, current_conditions, symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6530
+  # source://idlc//lib/idlc/ast.rb#6591
   def return_expression; end
 
-  # source://idlc//lib/idlc/ast.rb#6544
+  # source://idlc//lib/idlc/ast.rb#6605
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6539
+  # source://idlc//lib/idlc/ast.rb#6600
   def return_types(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6568
+  # source://idlc//lib/idlc/ast.rb#6629
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6559
+  # source://idlc//lib/idlc/ast.rb#6620
   def return_value_nodes; end
 
-  # source://idlc//lib/idlc/ast.rb#6573
+  # source://idlc//lib/idlc/ast.rb#6634
   def return_values(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6581
+  # source://idlc//lib/idlc/ast.rb#6642
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6578
+  # source://idlc//lib/idlc/ast.rb#6639
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6554
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6615
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6588
+    # source://idlc//lib/idlc/ast.rb#6649
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -5995,25 +6036,25 @@ class Idl::ReturnStatementAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6513
+# source://idlc//lib/idlc/ast.rb#6574
 class Idl::ReturnStatementSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6514
+  # source://idlc//lib/idlc/ast.rb#6575
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#623
+# source://idlc//lib/idlc/ast.rb#621
 module Idl::Returns
   abstract!
 
-  # source://idlc//lib/idlc/ast.rb#664
+  # source://idlc//lib/idlc/ast.rb#662
   sig { params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def expected_return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#641
+  # source://idlc//lib/idlc/ast.rb#639
   sig { abstract.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def return_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#646
+  # source://idlc//lib/idlc/ast.rb#644
   sig do
     abstract
       .params(
@@ -6022,7 +6063,7 @@ module Idl::Returns
   end
   def return_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#660
+  # source://idlc//lib/idlc/ast.rb#658
   sig do
     abstract
       .params(
@@ -6067,27 +6108,27 @@ end
 # source://idlc//lib/idlc/interfaces.rb#20
 Idl::RuntimeParam::ValueType = T.type_alias { T.any(::Integer, ::String, T::Array[::Integer], T::Array[::String], T::Array[T::Boolean], T::Boolean) }
 
-# source://idlc//lib/idlc/ast.rb#715
+# source://idlc//lib/idlc/ast.rb#713
 module Idl::Rvalue
   abstract!
 
-  # source://idlc//lib/idlc/ast.rb#765
+  # source://idlc//lib/idlc/ast.rb#763
   sig { params(symtab: ::Idl::SymbolTable).returns(T.any(::Integer, ::Symbol)) }
   def max_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#775
+  # source://idlc//lib/idlc/ast.rb#773
   sig { params(symtab: ::Idl::SymbolTable).returns(T.any(::Integer, ::Symbol)) }
   def min_value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#800
+  # source://idlc//lib/idlc/ast.rb#798
   sig { params(value: ::Integer, width: ::Integer, signed: T::Boolean).returns(::Integer) }
   def truncate(value, width, signed); end
 
-  # source://idlc//lib/idlc/ast.rb#738
+  # source://idlc//lib/idlc/ast.rb#736
   sig { abstract.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#762
+  # source://idlc//lib/idlc/ast.rb#760
   sig do
     abstract
       .params(
@@ -6096,7 +6137,7 @@ module Idl::Rvalue
   end
   def value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#797
+  # source://idlc//lib/idlc/ast.rb#795
   sig do
     params(
       symtab: ::Idl::SymbolTable
@@ -6105,7 +6146,7 @@ module Idl::Rvalue
   def values(symtab); end
 end
 
-# source://idlc//lib/idlc/ast.rb#817
+# source://idlc//lib/idlc/ast.rb#815
 Idl::RvalueAst = T.type_alias { T.all(::Idl::AstNode, ::Idl::Rvalue) }
 
 # source://idlc//lib/idlc/interfaces.rb#43
@@ -6133,42 +6174,42 @@ module Idl::Schema
   def to_idl_type; end
 end
 
-# source://idlc//lib/idlc/ast.rb#4236
+# source://idlc//lib/idlc/ast.rb#4252
 class Idl::SignCastAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#4244
+  # source://idlc//lib/idlc/ast.rb#4260
   def initialize(input, interval, exp); end
 
-  # source://idlc//lib/idlc/ast.rb#4240
+  # source://idlc//lib/idlc/ast.rb#4256
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4242
+  # source://idlc//lib/idlc/ast.rb#4258
   def expression; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#163
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#4273
+  # source://idlc//lib/idlc/ast.rb#4290
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#4270
+  # source://idlc//lib/idlc/ast.rb#4287
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#4252
+  # source://idlc//lib/idlc/ast.rb#4269
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4247
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#4263
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#4255
+  # source://idlc//lib/idlc/ast.rb#4272
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#4280
+    # source://idlc//lib/idlc/ast.rb#4297
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -6179,9 +6220,9 @@ class Idl::SignCastAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#4230
+# source://idlc//lib/idlc/ast.rb#4246
 class Idl::SignCastSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#4231
+  # source://idlc//lib/idlc/ast.rb#4247
   def to_ast; end
 end
 
@@ -6239,24 +6280,24 @@ module Idl::Statement1
   def a; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6258
+# source://idlc//lib/idlc/ast.rb#6319
 class Idl::StatementAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#6266
+  # source://idlc//lib/idlc/ast.rb#6327
   def initialize(input, interval, action); end
 
-  # source://idlc//lib/idlc/ast.rb#6264
+  # source://idlc//lib/idlc/ast.rb#6325
   def action; end
 
-  # source://idlc//lib/idlc/ast.rb#6262
+  # source://idlc//lib/idlc/ast.rb#6323
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6276
+  # source://idlc//lib/idlc/ast.rb#6337
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6286
+  # source://idlc//lib/idlc/ast.rb#6347
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#259
@@ -6265,8 +6306,8 @@ class Idl::StatementAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#83
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#222
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#252
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
   # source://idlc//lib/idlc/passes/reachable_exceptions.rb#82
   def reachable_exceptions(symtab, cache = T.unsafe(nil)); end
@@ -6274,19 +6315,19 @@ class Idl::StatementAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/reachable_functions.rb#69
   def reachable_functions(symtab, cache = T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#6300
+  # source://idlc//lib/idlc/ast.rb#6361
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6297
+  # source://idlc//lib/idlc/ast.rb#6358
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6271
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6332
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6307
+    # source://idlc//lib/idlc/ast.rb#6368
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -6297,9 +6338,9 @@ class Idl::StatementAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6211
+# source://idlc//lib/idlc/ast.rb#6272
 class Idl::StatementSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6212
+  # source://idlc//lib/idlc/ast.rb#6273
   def to_ast; end
 end
 
@@ -6309,44 +6350,44 @@ module Idl::String0; end
 # source://idlc//lib/idlc/idl_parser.rb#16628
 module Idl::String1; end
 
-# source://idlc//lib/idlc/ast.rb#7010
+# source://idlc//lib/idlc/ast.rb#7071
 class Idl::StringLiteralAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#7017
+  # source://idlc//lib/idlc/ast.rb#7078
   sig { params(input: T.nilable(::String), interval: T.nilable(T::Range[::Integer]), text: ::String).void }
   def initialize(input, interval, text); end
 
-  # source://idlc//lib/idlc/ast.rb#7014
+  # source://idlc//lib/idlc/ast.rb#7075
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#55
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#7024
+  # source://idlc//lib/idlc/ast.rb#7085
   sig { override.returns(::String) }
   def text_value; end
 
-  # source://idlc//lib/idlc/ast.rb#7042
+  # source://idlc//lib/idlc/ast.rb#7103
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#7039
+  # source://idlc//lib/idlc/ast.rb#7100
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#7029
+  # source://idlc//lib/idlc/ast.rb#7090
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7027
-  def type_check(_symtab); end
+  # source://idlc//lib/idlc/ast.rb#7088
+  def type_check(_symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#7034
+  # source://idlc//lib/idlc/ast.rb#7095
   def value(_symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#7049
+    # source://idlc//lib/idlc/ast.rb#7110
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -6357,13 +6398,13 @@ class Idl::StringLiteralAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6998
+# source://idlc//lib/idlc/ast.rb#7059
 module Idl::StringLiteralSyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6999
+  # source://idlc//lib/idlc/ast.rb#7060
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/type.rb#1004
+# source://idlc//lib/idlc/type.rb#1024
 Idl::StringType = T.let(T.unsafe(nil), Idl::Type)
 
 # source://idlc//lib/idlc/idl_parser.rb#1191
@@ -6384,51 +6425,51 @@ module Idl::StructDefinition1
   def user_type_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#2255
+# source://idlc//lib/idlc/ast.rb#2271
 class Idl::StructDefinitionAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#2270
+  # source://idlc//lib/idlc/ast.rb#2286
   def initialize(input, interval, name, member_types, member_names); end
 
-  # source://idlc//lib/idlc/ast.rb#2298
+  # source://idlc//lib/idlc/ast.rb#2314
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2268
+  # source://idlc//lib/idlc/ast.rb#2284
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2265
+  # source://idlc//lib/idlc/ast.rb#2281
   def member_names; end
 
-  # source://idlc//lib/idlc/ast.rb#2309
+  # source://idlc//lib/idlc/ast.rb#2325
   def member_type(name, symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2262
+  # source://idlc//lib/idlc/ast.rb#2278
   def member_types; end
 
-  # source://idlc//lib/idlc/ast.rb#2259
+  # source://idlc//lib/idlc/ast.rb#2275
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#2316
+  # source://idlc//lib/idlc/ast.rb#2332
   def num_members; end
 
-  # source://idlc//lib/idlc/ast.rb#2328
+  # source://idlc//lib/idlc/ast.rb#2344
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2319
+  # source://idlc//lib/idlc/ast.rb#2335
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2287
+  # source://idlc//lib/idlc/ast.rb#2303
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2279
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2295
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2341
+    # source://idlc//lib/idlc/ast.rb#2357
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -6439,38 +6480,38 @@ class Idl::StructDefinitionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2234
+# source://idlc//lib/idlc/ast.rb#2250
 class Idl::StructDefinitionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#2235
+  # source://idlc//lib/idlc/ast.rb#2251
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/type.rb#599
+# source://idlc//lib/idlc/type.rb#618
 class Idl::StructType < ::Idl::Type
-  # source://idlc//lib/idlc/type.rb#604
+  # source://idlc//lib/idlc/type.rb#623
   sig { params(type_name: ::String, member_types: T::Array[::Idl::Type], member_names: T::Array[::String]).void }
   def initialize(type_name, member_types, member_names); end
 
-  # source://idlc//lib/idlc/type.rb#614
+  # source://idlc//lib/idlc/type.rb#633
   def clone; end
 
-  # source://idlc//lib/idlc/type.rb#618
+  # source://idlc//lib/idlc/type.rb#637
   def default; end
 
-  # source://idlc//lib/idlc/type.rb#626
+  # source://idlc//lib/idlc/type.rb#645
   def member?(name); end
 
-  # source://idlc//lib/idlc/type.rb#628
+  # source://idlc//lib/idlc/type.rb#647
   def member_type(member_name); end
 
-  # source://idlc//lib/idlc/type.rb#612
+  # source://idlc//lib/idlc/type.rb#631
   sig { returns(::String) }
   def name; end
 
-  # source://idlc//lib/idlc/type.rb#636
+  # source://idlc//lib/idlc/type.rb#655
   def runtime?; end
 
-  # source://idlc//lib/idlc/type.rb#601
+  # source://idlc//lib/idlc/type.rb#620
   sig { returns(::String) }
   def type_name; end
 end
@@ -6828,21 +6869,30 @@ module Idl::TernaryExpression0
   def t; end
 end
 
-# source://idlc//lib/idlc/ast.rb#6086
+# source://idlc//lib/idlc/ast.rb#6107
 class Idl::TernaryOperatorExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#6096
+  # source://idlc//lib/idlc/ast.rb#6131
+  sig do
+    params(
+      input: T.nilable(::String),
+      interval: T.nilable(T::Range[::Integer]),
+      condition: T.all(::Idl::AstNode, ::Idl::Rvalue),
+      true_expression: T.all(::Idl::AstNode, ::Idl::Rvalue),
+      false_expression: T.all(::Idl::AstNode, ::Idl::Rvalue)
+    ).void
+  end
   def initialize(input, interval, condition, true_expression, false_expression); end
 
-  # source://idlc//lib/idlc/ast.rb#6092
+  # source://idlc//lib/idlc/ast.rb#6117
   def condition; end
 
-  # source://idlc//lib/idlc/ast.rb#6090
+  # source://idlc//lib/idlc/ast.rb#6115
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6094
+  # source://idlc//lib/idlc/ast.rb#6119
   def false_expression; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#186
@@ -6851,34 +6901,34 @@ class Idl::TernaryOperatorExpressionAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#123
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#456
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#559
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#6188
+  # source://idlc//lib/idlc/ast.rb#6249
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6185
+  # source://idlc//lib/idlc/ast.rb#6246
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#6093
+  # source://idlc//lib/idlc/ast.rb#6118
   def true_expression; end
 
-  # source://idlc//lib/idlc/ast.rb#6128
+  # source://idlc//lib/idlc/ast.rb#6176
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6101
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6137
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#6169
+  # source://idlc//lib/idlc/ast.rb#6230
   def value(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6174
+  # source://idlc//lib/idlc/ast.rb#6235
   def values(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6197
+    # source://idlc//lib/idlc/ast.rb#6258
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -6889,21 +6939,26 @@ class Idl::TernaryOperatorExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#6075
+# source://idlc//lib/idlc/ast.rb#6110
+class Idl::TernaryOperatorExpressionAst::Memo < ::T::Struct
+  prop :type, T::Hash[::Idl::SymbolTable, ::Idl::Type], default: T.unsafe(nil)
+end
+
+# source://idlc//lib/idlc/ast.rb#6096
 class Idl::TernaryOperatorExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#6076
+  # source://idlc//lib/idlc/ast.rb#6097
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#869
+# source://idlc//lib/idlc/ast.rb#867
 class Idl::TrueExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#873
+  # source://idlc//lib/idlc/ast.rb#871
   sig { params(input: ::String, interval: T::Range[::Integer]).void }
   def initialize(input, interval); end
 
-  # source://idlc//lib/idlc/ast.rb#878
+  # source://idlc//lib/idlc/ast.rb#876
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
@@ -6913,28 +6968,28 @@ class Idl::TrueExpressionAst < ::Idl::AstNode
   # source://idlc//lib/idlc/passes/gen_option_adoc.rb#89
   def gen_option_adoc; end
 
-  # source://idlc//lib/idlc/ast.rb#893
+  # source://idlc//lib/idlc/ast.rb#891
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#890
+  # source://idlc//lib/idlc/ast.rb#888
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#884
+  # source://idlc//lib/idlc/ast.rb#882
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#881
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#879
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#887
+  # source://idlc//lib/idlc/ast.rb#885
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::TrueClass) }
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#899
+    # source://idlc//lib/idlc/ast.rb#897
     sig do
       override
         .params(
@@ -6946,157 +7001,176 @@ class Idl::TrueExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#865
+# source://idlc//lib/idlc/ast.rb#863
 class Idl::TrueExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#866
+  # source://idlc//lib/idlc/ast.rb#864
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/type.rb#15
+# source://idlc//lib/idlc/type.rb#13
 class Idl::Type
-  # source://idlc//lib/idlc/type.rb#132
-  def initialize(kind, qualifiers: T.unsafe(nil), width: T.unsafe(nil), width_ast: T.unsafe(nil), max_width: T.unsafe(nil), sub_type: T.unsafe(nil), name: T.unsafe(nil), tuple_types: T.unsafe(nil), return_type: T.unsafe(nil), arguments: T.unsafe(nil), enum_class: T.unsafe(nil), csr: T.unsafe(nil)); end
+  # source://idlc//lib/idlc/type.rb#152
+  sig do
+    params(
+      kind: ::Symbol,
+      qualifiers: T::Array[::Symbol],
+      width: T.nilable(T.any(::Integer, ::Symbol)),
+      width_ast: T.nilable(::Idl::AstNode),
+      max_width: T.nilable(::Integer),
+      sub_type: T.nilable(::Idl::Type),
+      name: T.nilable(::String),
+      tuple_types: T.nilable(T::Array[::Idl::Type]),
+      return_type: T.nilable(::Idl::Type),
+      enum_class: T.nilable(::Idl::EnumerationType),
+      csr: T.nilable(::Idl::Csr)
+    ).void
+  end
+  def initialize(kind, qualifiers: T.unsafe(nil), width: T.unsafe(nil), width_ast: T.unsafe(nil), max_width: T.unsafe(nil), sub_type: T.unsafe(nil), name: T.unsafe(nil), tuple_types: T.unsafe(nil), return_type: T.unsafe(nil), enum_class: T.unsafe(nil), csr: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/type.rb#48
+  # source://idlc//lib/idlc/type.rb#53
   def ==(other); end
 
-  # source://idlc//lib/idlc/type.rb#397
+  # source://idlc//lib/idlc/type.rb#416
   def ary?; end
 
-  # source://idlc//lib/idlc/type.rb#248
+  # source://idlc//lib/idlc/type.rb#267
   def ary_type(ary); end
 
-  # source://idlc//lib/idlc/type.rb#173
+  # source://idlc//lib/idlc/type.rb#192
   def clone; end
 
-  # source://idlc//lib/idlc/type.rb#188
+  # source://idlc//lib/idlc/type.rb#207
   def comparable_to?(type); end
 
-  # source://idlc//lib/idlc/type.rb#401
+  # source://idlc//lib/idlc/type.rb#420
   def const?; end
 
-  # source://idlc//lib/idlc/type.rb#258
+  # source://idlc//lib/idlc/type.rb#277
   def convertable_to?(type); end
 
-  # source://idlc//lib/idlc/type.rb#69
+  # source://idlc//lib/idlc/type.rb#74
   def default; end
 
-  # source://idlc//lib/idlc/type.rb#111
+  # source://idlc//lib/idlc/type.rb#119
   sig { returns(::Idl::EnumerationType) }
   def enum_class; end
 
-  # source://idlc//lib/idlc/type.rb#220
+  # source://idlc//lib/idlc/type.rb#239
   def equal_to?(type); end
 
-  # source://idlc//lib/idlc/type.rb#377
+  # source://idlc//lib/idlc/type.rb#396
   def fully_qualified_name; end
 
-  # source://idlc//lib/idlc/type.rb#413
+  # source://idlc//lib/idlc/type.rb#432
   def global?; end
 
-  # source://idlc//lib/idlc/type.rb#44
+  # source://idlc//lib/idlc/type.rb#49
   sig { returns(T::Boolean) }
   def integral?; end
 
-  # source://idlc//lib/idlc/type.rb#93
+  # source://idlc//lib/idlc/type.rb#98
   sig { returns(::Symbol) }
   def kind; end
 
-  # source://idlc//lib/idlc/type.rb#421
+  # source://idlc//lib/idlc/type.rb#440
   def known?; end
 
-  # source://idlc//lib/idlc/type.rb#439
+  # source://idlc//lib/idlc/type.rb#458
   sig { returns(::Idl::Type) }
   def make_const; end
 
-  # source://idlc//lib/idlc/type.rb#432
+  # source://idlc//lib/idlc/type.rb#451
   sig { returns(::Idl::Type) }
   def make_const!; end
 
-  # source://idlc//lib/idlc/type.rb#444
+  # source://idlc//lib/idlc/type.rb#463
   def make_global; end
 
-  # source://idlc//lib/idlc/type.rb#449
+  # source://idlc//lib/idlc/type.rb#468
   def make_known; end
 
-  # source://idlc//lib/idlc/type.rb#425
+  # source://idlc//lib/idlc/type.rb#444
   def make_signed; end
 
-  # source://idlc//lib/idlc/type.rb#405
+  # source://idlc//lib/idlc/type.rb#110
+  sig { returns(T.nilable(::Integer)) }
+  def max_width; end
+
+  # source://idlc//lib/idlc/type.rb#424
   def mutable?; end
 
-  # source://idlc//lib/idlc/type.rb#379
+  # source://idlc//lib/idlc/type.rb#398
   def name; end
 
-  # source://idlc//lib/idlc/type.rb#96
+  # source://idlc//lib/idlc/type.rb#101
   sig { returns(T::Array[::Symbol]) }
   def qualifiers; end
 
-  # source://idlc//lib/idlc/type.rb#113
+  # source://idlc//lib/idlc/type.rb#121
   def qualify(qualifier); end
 
-  # source://idlc//lib/idlc/type.rb#61
+  # source://idlc//lib/idlc/type.rb#66
   def runtime?; end
 
-  # source://idlc//lib/idlc/type.rb#409
+  # source://idlc//lib/idlc/type.rb#428
   def signed?; end
 
-  # source://idlc//lib/idlc/type.rb#105
+  # source://idlc//lib/idlc/type.rb#113
   sig { returns(::Idl::Type) }
   def sub_type; end
 
-  # source://idlc//lib/idlc/type.rb#417
+  # source://idlc//lib/idlc/type.rb#436
   def template_var?; end
 
-  # source://idlc//lib/idlc/type.rb#327
+  # source://idlc//lib/idlc/type.rb#346
   sig { returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/type.rb#347
+  # source://idlc//lib/idlc/type.rb#366
   def to_s; end
 
-  # source://idlc//lib/idlc/type.rb#108
+  # source://idlc//lib/idlc/type.rb#116
   sig { returns(T::Array[::Idl::Type]) }
   def tuple_types; end
 
-  # source://idlc//lib/idlc/type.rb#99
+  # source://idlc//lib/idlc/type.rb#104
   sig { returns(T.any(::Integer, ::Symbol)) }
   def width; end
 
-  # source://idlc//lib/idlc/type.rb#102
+  # source://idlc//lib/idlc/type.rb#107
   sig { returns(T.nilable(::Idl::AstNode)) }
   def width_ast; end
 
   class << self
-    # source://idlc//lib/idlc/type.rb#582
+    # source://idlc//lib/idlc/type.rb#601
     sig { params(schema: T::Hash[::String, T.untyped]).returns(T.nilable(::Idl::Type)) }
     def from_json_schema(schema); end
 
-    # source://idlc//lib/idlc/type.rb#119
+    # source://idlc//lib/idlc/type.rb#127
     def from_typename(type_name, cfg_arch); end
 
     private
 
-    # source://idlc//lib/idlc/type.rb#544
+    # source://idlc//lib/idlc/type.rb#563
     sig { params(schema: T::Hash[::String, T.untyped]).returns(::Idl::Type) }
     def from_json_schema_array_type(schema); end
 
-    # source://idlc//lib/idlc/type.rb#457
+    # source://idlc//lib/idlc/type.rb#476
     sig { params(schema: T::Hash[::String, T.untyped]).returns(T.nilable(::Idl::Type)) }
     def from_json_schema_scalar_type(schema); end
   end
 end
 
-# source://idlc//lib/idlc/type.rb#18
+# source://idlc//lib/idlc/type.rb#23
 Idl::Type::KINDS = T.let(T.unsafe(nil), Array)
 
-# source://idlc//lib/idlc/type.rb#34
+# source://idlc//lib/idlc/type.rb#39
 Idl::Type::QUALIFIERS = T.let(T.unsafe(nil), Array)
 
-# source://idlc//lib/idlc/type.rb#171
+# source://idlc//lib/idlc/type.rb#190
 Idl::Type::TYPE_FROM_KIND = T.let(T.unsafe(nil), Hash)
 
-# source://idlc//lib/idlc/ast.rb#7822
+# source://idlc//lib/idlc/ast.rb#7908
 Idl::TypeNameAst = T.type_alias { T.any(::Idl::BuiltinTypeNameAst, ::Idl::UserTypeNameAst) }
 
 # source://idlc//lib/idlc/idl_parser.rb#6782
@@ -7171,51 +7245,51 @@ module Idl::UnaryExpression9
   def o; end
 end
 
-# source://idlc//lib/idlc/ast.rb#5943
+# source://idlc//lib/idlc/ast.rb#5964
 class Idl::UnaryOperatorExpressionAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#5951
+  # source://idlc//lib/idlc/ast.rb#5972
   def initialize(input, interval, op, expression); end
 
-  # source://idlc//lib/idlc/ast.rb#5947
+  # source://idlc//lib/idlc/ast.rb#5968
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6040
+  # source://idlc//lib/idlc/ast.rb#6061
   def exp; end
 
-  # source://idlc//lib/idlc/ast.rb#5949
+  # source://idlc//lib/idlc/ast.rb#5970
   def expression; end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#265
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#5957
+  # source://idlc//lib/idlc/ast.rb#5978
   def invert(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#6045
+  # source://idlc//lib/idlc/ast.rb#6066
   def op; end
 
-  # source://idlc//lib/idlc/ast.rb#6054
+  # source://idlc//lib/idlc/ast.rb#6075
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#6051
+  # source://idlc//lib/idlc/ast.rb#6072
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#5968
+  # source://idlc//lib/idlc/ast.rb#5989
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#5984
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#6005
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#6012
+  # source://idlc//lib/idlc/ast.rb#6033
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#6062
+    # source://idlc//lib/idlc/ast.rb#6083
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -7226,77 +7300,83 @@ class Idl::UnaryOperatorExpressionAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#5931
+# source://idlc//lib/idlc/ast.rb#5952
 class Idl::UnaryOperatorExpressionSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#5932
+  # source://idlc//lib/idlc/ast.rb#5953
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#7067
+# source://idlc//lib/idlc/ast.rb#7128
 class Idl::UnknownLiteral
-  # source://idlc//lib/idlc/ast.rb#7069
+  # source://idlc//lib/idlc/ast.rb#7130
   def initialize(known_value, unknown_mask); end
 
-  # source://idlc//lib/idlc/ast.rb#7077
+  # source://idlc//lib/idlc/ast.rb#7138
   def &(other); end
 
-  # source://idlc//lib/idlc/ast.rb#7098
+  # source://idlc//lib/idlc/ast.rb#7200
+  def <<(shamt); end
+
+  # source://idlc//lib/idlc/ast.rb#7168
+  def <=(other); end
+
+  # source://idlc//lib/idlc/ast.rb#7159
   def ==(other); end
 
-  # source://idlc//lib/idlc/ast.rb#7073
+  # source://idlc//lib/idlc/ast.rb#7134
   def bit_length; end
 
-  # source://idlc//lib/idlc/ast.rb#7068
+  # source://idlc//lib/idlc/ast.rb#7129
   def known_value; end
 
-  # source://idlc//lib/idlc/ast.rb#7128
+  # source://idlc//lib/idlc/ast.rb#7209
   def to_s; end
 
-  # source://idlc//lib/idlc/ast.rb#7068
+  # source://idlc//lib/idlc/ast.rb#7129
   def unknown_mask; end
 
-  # source://idlc//lib/idlc/ast.rb#7076
+  # source://idlc//lib/idlc/ast.rb#7137
   def zero?; end
 
-  # source://idlc//lib/idlc/ast.rb#7107
+  # source://idlc//lib/idlc/ast.rb#7179
   def |(other); end
 end
 
 # source://idlc//lib/idlc/idl_parser.rb#15764
 module Idl::UserTypeName0; end
 
-# source://idlc//lib/idlc/ast.rb#7770
+# source://idlc//lib/idlc/ast.rb#7856
 class Idl::UserTypeNameAst < ::Idl::AstNode
-  # source://idlc//lib/idlc/ast.rb#7774
+  # source://idlc//lib/idlc/ast.rb#7860
   def initialize(input, interval, name); end
 
-  # source://idlc//lib/idlc/ast.rb#7772
+  # source://idlc//lib/idlc/ast.rb#7858
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#66
   def gen_adoc(indent, indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#7780
+  # source://idlc//lib/idlc/ast.rb#7866
   def text_value; end
 
-  # source://idlc//lib/idlc/ast.rb#7803
+  # source://idlc//lib/idlc/ast.rb#7889
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#7800
+  # source://idlc//lib/idlc/ast.rb#7886
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#7791
+  # source://idlc//lib/idlc/ast.rb#7877
   sig { params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#7783
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#7869
+  def type_check(symtab, strict:); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#7810
+    # source://idlc//lib/idlc/ast.rb#7896
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -7307,13 +7387,13 @@ class Idl::UserTypeNameAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#7764
+# source://idlc//lib/idlc/ast.rb#7850
 class Idl::UserTypeNameSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#7765
+  # source://idlc//lib/idlc/ast.rb#7851
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#28
+# source://idlc//lib/idlc/ast.rb#26
 Idl::ValueRbType = T.type_alias { T.any(::Integer, ::String, T::Array[::Integer], T::Array[::String], T::Array[T::Boolean], T::Boolean, T::Hash[::String, T.any(::Integer, ::String, T::Array[::Integer], T::Array[::String], T::Array[T::Boolean], T::Boolean)]) }
 
 # source://idlc//lib/idlc/symbol_table.rb#17
@@ -7385,56 +7465,56 @@ module Idl::VarWrite0
   def csr_name; end
 end
 
-# source://idlc//lib/idlc/ast.rb#2680
+# source://idlc//lib/idlc/ast.rb#2696
 class Idl::VariableAssignmentAst < ::Idl::AstNode
   include ::Idl::Executable
 
-  # source://idlc//lib/idlc/ast.rb#2704
+  # source://idlc//lib/idlc/ast.rb#2720
   def initialize(input, interval, lhs_ast, rhs_ast); end
 
-  # source://idlc//lib/idlc/ast.rb#2684
+  # source://idlc//lib/idlc/ast.rb#2700
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2735
+  # source://idlc//lib/idlc/ast.rb#2751
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#2756
+  # source://idlc//lib/idlc/ast.rb#2772
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#241
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#2699
+  # source://idlc//lib/idlc/ast.rb#2715
   sig { returns(::Idl::IdAst) }
   def lhs; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#74
+  # source://idlc//lib/idlc/passes/prune.rb#81
   def nullify_assignments(symtab); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#69
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#76
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#2702
+  # source://idlc//lib/idlc/ast.rb#2718
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#2773
+  # source://idlc//lib/idlc/ast.rb#2789
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#2770
+  # source://idlc//lib/idlc/ast.rb#2786
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#2710
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#2726
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#2725
+  # source://idlc//lib/idlc/ast.rb#2741
   def var(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#2781
+    # source://idlc//lib/idlc/ast.rb#2797
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -7445,17 +7525,17 @@ class Idl::VariableAssignmentAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#2669
+# source://idlc//lib/idlc/ast.rb#2685
 class Idl::VariableAssignmentSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#2670
+  # source://idlc//lib/idlc/ast.rb#2686
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#3536
+# source://idlc//lib/idlc/ast.rb#3552
 class Idl::VariableDeclarationAst < ::Idl::AstNode
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#3566
+  # source://idlc//lib/idlc/ast.rb#3582
   sig do
     params(
       input: T.nilable(::String),
@@ -7467,57 +7547,57 @@ class Idl::VariableDeclarationAst < ::Idl::AstNode
   end
   def initialize(input, interval, type_name, id, ary_size); end
 
-  # source://idlc//lib/idlc/ast.rb#3636
+  # source://idlc//lib/idlc/ast.rb#3652
   sig { override.params(symtab: ::Idl::SymbolTable).void }
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3552
+  # source://idlc//lib/idlc/ast.rb#3568
   sig { returns(T.nilable(T.all(::Idl::AstNode, ::Idl::Rvalue))) }
   def ary_size; end
 
-  # source://idlc//lib/idlc/ast.rb#3540
+  # source://idlc//lib/idlc/ast.rb#3556
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3582
+  # source://idlc//lib/idlc/ast.rb#3598
   sig { params(symtab: ::Idl::SymbolTable).returns(T.nilable(::Idl::Type)) }
   def decl_type(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#174
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3549
+  # source://idlc//lib/idlc/ast.rb#3565
   sig { returns(::Idl::IdAst) }
   def id; end
 
-  # source://idlc//lib/idlc/ast.rb#3577
+  # source://idlc//lib/idlc/ast.rb#3593
   sig { void }
   def make_global; end
 
-  # source://idlc//lib/idlc/ast.rb#3555
+  # source://idlc//lib/idlc/ast.rb#3571
   sig { returns(::String) }
   def name; end
 
-  # source://idlc//lib/idlc/ast.rb#3657
+  # source://idlc//lib/idlc/ast.rb#3673
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#3648
+  # source://idlc//lib/idlc/ast.rb#3664
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#3607
+  # source://idlc//lib/idlc/ast.rb#3623
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3610
-  def type_check(symtab, add_sym = T.unsafe(nil)); end
+  # source://idlc//lib/idlc/ast.rb#3626
+  def type_check(symtab, strict:, add_sym: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3546
+  # source://idlc//lib/idlc/ast.rb#3562
   sig { returns(T.any(::Idl::BuiltinTypeNameAst, ::Idl::UserTypeNameAst)) }
   def type_name; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#3669
+    # source://idlc//lib/idlc/ast.rb#3685
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -7528,18 +7608,18 @@ class Idl::VariableDeclarationAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#3525
+# source://idlc//lib/idlc/ast.rb#3541
 class Idl::VariableDeclarationSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3526
+  # source://idlc//lib/idlc/ast.rb#3542
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/ast.rb#3719
+# source://idlc//lib/idlc/ast.rb#3735
 class Idl::VariableDeclarationWithInitializationAst < ::Idl::AstNode
   include ::Idl::Executable
   include ::Idl::Declaration
 
-  # source://idlc//lib/idlc/ast.rb#3761
+  # source://idlc//lib/idlc/ast.rb#3777
   sig do
     params(
       input: T.nilable(::String),
@@ -7553,64 +7633,64 @@ class Idl::VariableDeclarationWithInitializationAst < ::Idl::AstNode
   end
   def initialize(input, interval, type_name_ast, var_write_ast, ary_size, rval_ast, is_for_loop_iteration_var); end
 
-  # source://idlc//lib/idlc/ast.rb#3835
+  # source://idlc//lib/idlc/ast.rb#3851
   def add_symbol(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3742
+  # source://idlc//lib/idlc/ast.rb#3758
   sig { returns(T.nilable(T.all(::Idl::AstNode, ::Idl::Rvalue))) }
   def ary_size; end
 
-  # source://idlc//lib/idlc/ast.rb#3724
+  # source://idlc//lib/idlc/ast.rb#3740
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3865
+  # source://idlc//lib/idlc/ast.rb#3881
   def execute(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3881
+  # source://idlc//lib/idlc/ast.rb#3897
   def execute_unknown(symtab); end
 
   # source://idlc//lib/idlc/passes/gen_adoc.rb#219
   def gen_adoc(indent = T.unsafe(nil), indent_spaces: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3748
+  # source://idlc//lib/idlc/ast.rb#3764
   sig { returns(::String) }
   def id; end
 
-  # source://idlc//lib/idlc/ast.rb#3739
+  # source://idlc//lib/idlc/ast.rb#3755
   sig { returns(::Idl::IdAst) }
   def lhs; end
 
-  # source://idlc//lib/idlc/ast.rb#3775
+  # source://idlc//lib/idlc/ast.rb#3791
   def lhs_type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#3771
+  # source://idlc//lib/idlc/ast.rb#3787
   def make_global; end
 
-  # source://idlc//lib/idlc/passes/prune.rb#93
-  def prune(symtab); end
+  # source://idlc//lib/idlc/passes/prune.rb#111
+  def prune(symtab, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/ast.rb#3745
+  # source://idlc//lib/idlc/ast.rb#3761
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def rhs; end
 
-  # source://idlc//lib/idlc/ast.rb#3896
+  # source://idlc//lib/idlc/ast.rb#3912
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#3887
+  # source://idlc//lib/idlc/ast.rb#3903
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#3802
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#3818
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#3736
+  # source://idlc//lib/idlc/ast.rb#3752
   sig { returns(T.any(::Idl::BuiltinTypeNameAst, ::Idl::UserTypeNameAst)) }
   def type_name; end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#3910
+    # source://idlc//lib/idlc/ast.rb#3926
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -7621,56 +7701,56 @@ class Idl::VariableDeclarationWithInitializationAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#3692
+# source://idlc//lib/idlc/ast.rb#3708
 class Idl::VariableDeclarationWithInitializationSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#3693
+  # source://idlc//lib/idlc/ast.rb#3709
   def to_ast; end
 end
 
 # source://idlc//lib/idlc/idl_parser.rb#1394
 module Idl::VersionString0; end
 
-# source://idlc//lib/idlc/type.rb#1003
+# source://idlc//lib/idlc/type.rb#1023
 Idl::VoidType = T.let(T.unsafe(nil), Idl::Type)
 
-# source://idlc//lib/idlc/ast.rb#4169
+# source://idlc//lib/idlc/ast.rb#4185
 class Idl::WidthRevealAst < ::Idl::AstNode
   include ::Idl::Rvalue
 
-  # source://idlc//lib/idlc/ast.rb#4179
+  # source://idlc//lib/idlc/ast.rb#4195
   sig { params(input: T.nilable(::String), interval: T.nilable(T::Range[::Integer]), e: ::Idl::AstNode).void }
   def initialize(input, interval, e); end
 
-  # source://idlc//lib/idlc/ast.rb#4173
+  # source://idlc//lib/idlc/ast.rb#4189
   sig { override.params(symtab: ::Idl::SymbolTable).returns(T::Boolean) }
   def const_eval?(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4176
+  # source://idlc//lib/idlc/ast.rb#4192
   sig { returns(T.all(::Idl::AstNode, ::Idl::Rvalue)) }
   def expression; end
 
-  # source://idlc//lib/idlc/ast.rb#4211
+  # source://idlc//lib/idlc/ast.rb#4227
   sig { override.returns(T::Hash[::String, T.untyped]) }
   def to_h; end
 
-  # source://idlc//lib/idlc/ast.rb#4208
+  # source://idlc//lib/idlc/ast.rb#4224
   sig { override.returns(::String) }
   def to_idl; end
 
-  # source://idlc//lib/idlc/ast.rb#4192
+  # source://idlc//lib/idlc/ast.rb#4208
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Idl::Type) }
   def type(symtab); end
 
-  # source://idlc//lib/idlc/ast.rb#4184
-  sig { override.params(symtab: ::Idl::SymbolTable).void }
-  def type_check(symtab); end
+  # source://idlc//lib/idlc/ast.rb#4200
+  sig { override.params(symtab: ::Idl::SymbolTable, strict: T::Boolean).void }
+  def type_check(symtab, strict:); end
 
-  # source://idlc//lib/idlc/ast.rb#4201
+  # source://idlc//lib/idlc/ast.rb#4217
   sig { override.params(symtab: ::Idl::SymbolTable).returns(::Integer) }
   def value(symtab); end
 
   class << self
-    # source://idlc//lib/idlc/ast.rb#4218
+    # source://idlc//lib/idlc/ast.rb#4234
     sig do
       params(
         yaml: T::Hash[::String, T.untyped],
@@ -7681,21 +7761,21 @@ class Idl::WidthRevealAst < ::Idl::AstNode
   end
 end
 
-# source://idlc//lib/idlc/ast.rb#4163
+# source://idlc//lib/idlc/ast.rb#4179
 class Idl::WidthRevealSyntaxNode < ::Idl::SyntaxNode
-  # source://idlc//lib/idlc/ast.rb#4164
+  # source://idlc//lib/idlc/ast.rb#4180
   def to_ast; end
 end
 
-# source://idlc//lib/idlc/type.rb#981
+# source://idlc//lib/idlc/type.rb#1001
 class Idl::XregType < ::Idl::Type
-  # source://idlc//lib/idlc/type.rb#982
+  # source://idlc//lib/idlc/type.rb#1002
   def initialize(xlen); end
 
-  # source://idlc//lib/idlc/type.rb#990
+  # source://idlc//lib/idlc/type.rb#1010
   def to_cxx; end
 
-  # source://idlc//lib/idlc/type.rb#986
+  # source://idlc//lib/idlc/type.rb#1006
   def to_s; end
 end
 
@@ -7725,14 +7805,14 @@ class Object < ::BasicObject
 
   private
 
-  # source://idlc//lib/idlc/passes/prune.rb#19
+  # source://idlc//lib/idlc/passes/prune.rb#23
   def create_bool_literal(value); end
 
   # source://idlc//lib/idlc/passes/prune.rb#14
-  def create_int_literal(value); end
+  def create_int_literal(value, forced_type: T.unsafe(nil)); end
 
-  # source://idlc//lib/idlc/passes/prune.rb#27
-  def create_literal(symtab, value, type); end
+  # source://idlc//lib/idlc/passes/prune.rb#31
+  def create_literal(symtab, value, type, forced_type: T.unsafe(nil)); end
 end
 
 # source://idlc//lib/idlc/syntax_node.rb#11


### PR DESCRIPTION
Updated version of #1617.

Successfully updating Ruby rbi files. Should be extended to also regenerate the golden files, but those are not currently available from the `./bin/chore` target.