### PR TITLE
Add more pseudoinstructions

### DIFF
--- a/backends/instructions_appendix/all_instructions.golden.adoc
+++ b/backends/instructions_appendix/all_instructions.golden.adoc
@@ -73552,7 +73552,7 @@ Decode Variables::
 |Variable Name |Location
 |vm |$encoding[25]
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 

--- a/spec/std/isa/inst/D/fsgnj.d.yaml
+++ b/spec/std/isa/inst/D/fsgnj.d.yaml
@@ -27,6 +27,9 @@ encoding:
       location: 19-15
     - name: fd
       location: 11-7
+pseudoinstructions:
+  - when: fs1 == fs2
+    to: fmv.d fd, fs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/D/fsgnjn.d.yaml
+++ b/spec/std/isa/inst/D/fsgnjn.d.yaml
@@ -32,5 +32,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: fs1 == fs2
+    to: fneg.d fd, fs1
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/D/fsgnjx.d.yaml
+++ b/spec/std/isa/inst/D/fsgnjx.d.yaml
@@ -32,5 +32,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: fs1 == fs2
+    to: fabs.d fd, fs1
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/F/fsgnj.s.yaml
+++ b/spec/std/isa/inst/F/fsgnj.s.yaml
@@ -34,7 +34,7 @@ access:
 data_independent_timing: true
 pseudoinstructions:
   - when: (fs2 == fs1)
-    to: fmv.s fd,fs1
+    to: fmv.s fd, fs1
 
 operation(): |
   check_f_ok($encoding);

--- a/spec/std/isa/inst/F/fsgnjx.s.yaml
+++ b/spec/std/isa/inst/F/fsgnjx.s.yaml
@@ -33,7 +33,7 @@ access:
 data_independent_timing: true
 pseudoinstructions:
   - when: (fs2 == fs1)
-    to: fabs.s fd,fs1
+    to: fabs.s fd, fs1
 operation(): |
   check_f_ok($encoding);
 

--- a/spec/std/isa/inst/I/addi.yaml
+++ b/spec/std/isa/inst/I/addi.yaml
@@ -33,5 +33,5 @@ pseudoinstructions:
   - when: (xd == 0 && xs1 == 0 && imm == 0)
     to: nop
   - when: imm == 0
-    to: mv xd,xs1
+    to: mv xd, xs1
 operation(): X[xd] = X[xs1] + $signed(imm);

--- a/spec/std/isa/inst/I/addiw.yaml
+++ b/spec/std/isa/inst/I/addiw.yaml
@@ -33,6 +33,6 @@ access:
 data_independent_timing: true
 pseudoinstructions:
   - when: imm == 0
-    to: sext.w xd,xs1
+    to: sext.w xd, xs1
 operation(): |
   X[xd] = $signed((X[xs1] + $signed(imm))[31:0]);

--- a/spec/std/isa/inst/I/andi.yaml
+++ b/spec/std/isa/inst/I/andi.yaml
@@ -29,5 +29,5 @@ access:
 data_independent_timing: true
 pseudoinstructions:
   - when: imm == 255
-    to: zext.b xd,xs1
+    to: zext.b xd, xs1
 operation(): X[xd] = X[xs1] & $signed(imm);

--- a/spec/std/isa/inst/I/beq.yaml
+++ b/spec/std/isa/inst/I/beq.yaml
@@ -34,7 +34,7 @@ access:
   vu: always
 pseudoinstructions:
   - when: xs2 == 0
-    to: beqz xs1,imm
+    to: beqz xs1, imm
 operation(): |
   XReg lhs = X[xs1];
   XReg rhs = X[xs2];

--- a/spec/std/isa/inst/I/bge.yaml
+++ b/spec/std/isa/inst/I/bge.yaml
@@ -34,9 +34,9 @@ access:
   vu: always
 pseudoinstructions:
   - when: xs1 == 0
-    to: blez xs2,imm
+    to: blez xs2, imm
   - when: xs2 == 0
-    to: bgez xs1,imm
+    to: bgez xs1, imm
   - when: "true"
     to: ble xs2, xs1, imm
 operation(): |

--- a/spec/std/isa/inst/I/bge.yaml
+++ b/spec/std/isa/inst/I/bge.yaml
@@ -37,6 +37,8 @@ pseudoinstructions:
     to: blez xs2,imm
   - when: xs2 == 0
     to: bgez xs1,imm
+  - when: "true"
+    to: ble xs2, xs1, imm
 operation(): |
   XReg lhs = X[xs1];
   XReg rhs = X[xs2];

--- a/spec/std/isa/inst/I/bgeu.yaml
+++ b/spec/std/isa/inst/I/bgeu.yaml
@@ -32,6 +32,9 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: "true"
+    to: bleu xs2, xs1, imm
 operation(): |
   XReg lhs = X[xs1];
   XReg rhs = X[xs2];

--- a/spec/std/isa/inst/I/blt.yaml
+++ b/spec/std/isa/inst/I/blt.yaml
@@ -37,6 +37,8 @@ pseudoinstructions:
     to: bltz xs1,imm
   - when: xs1 == 0
     to: bgtz xs2,imm
+  - when: "true"
+    to: bgt xs2, xs1, imm
 operation(): |
   XReg lhs = X[xs1];
   XReg rhs = X[xs2];

--- a/spec/std/isa/inst/I/blt.yaml
+++ b/spec/std/isa/inst/I/blt.yaml
@@ -34,9 +34,9 @@ access:
   vu: always
 pseudoinstructions:
   - when: xs2 == 0
-    to: bltz xs1,imm
+    to: bltz xs1, imm
   - when: xs1 == 0
-    to: bgtz xs2,imm
+    to: bgtz xs2, imm
   - when: "true"
     to: bgt xs2, xs1, imm
 operation(): |

--- a/spec/std/isa/inst/I/bltu.yaml
+++ b/spec/std/isa/inst/I/bltu.yaml
@@ -32,6 +32,9 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: "true"
+    to: bgtu xs2, xs1, imm
 operation(): |
   XReg lhs = X[xs1];
   XReg rhs = X[xs2];

--- a/spec/std/isa/inst/I/bne.yaml
+++ b/spec/std/isa/inst/I/bne.yaml
@@ -34,7 +34,7 @@ access:
   vu: always
 pseudoinstructions:
   - when: xs2 == 0
-    to: bnez xs1,imm
+    to: bnez xs1, imm
 operation(): |
   XReg lhs = X[xs1];
   XReg rhs = X[xs2];

--- a/spec/std/isa/inst/I/slt.yaml
+++ b/spec/std/isa/inst/I/slt.yaml
@@ -31,9 +31,9 @@ access:
 data_independent_timing: true
 pseudoinstructions:
   - when: xs2 == 0
-    to: sltz xd,xs1
+    to: sltz xd, xs1
   - when: xs1 == 0
-    to: sgtz xd,xs2
+    to: sgtz xd, xs2
 operation(): |
   XReg src1 = X[xs1];
   XReg src2 = X[xs2];

--- a/spec/std/isa/inst/I/sltiu.yaml
+++ b/spec/std/isa/inst/I/sltiu.yaml
@@ -35,7 +35,7 @@ access:
 data_independent_timing: true
 pseudoinstructions:
   - when: imm == 1
-    to: seqz xd,xs1
+    to: seqz xd, xs1
 operation(): |
   Bits<MXLEN> sign_extend_imm = $signed(imm);
   X[xd] = (X[xs1] < sign_extend_imm) ? 1 : 0;

--- a/spec/std/isa/inst/I/sltu.yaml
+++ b/spec/std/isa/inst/I/sltu.yaml
@@ -31,6 +31,6 @@ access:
 data_independent_timing: true
 pseudoinstructions:
   - when: xs1 == 0
-    to: snez xd,xs2
+    to: snez xd, xs2
 operation(): |
   X[xd] = (X[xs1] < X[xs2]) ? 1 : 0;

--- a/spec/std/isa/inst/I/sub.yaml
+++ b/spec/std/isa/inst/I/sub.yaml
@@ -29,7 +29,7 @@ access:
 data_independent_timing: true
 pseudoinstructions:
   - when: xs1 == 0
-    to: neg xd,xs2
+    to: neg xd, xs2
 operation(): |
   XReg t0 = X[xs1];
   XReg t1 = X[xs2];

--- a/spec/std/isa/inst/I/subw.yaml
+++ b/spec/std/isa/inst/I/subw.yaml
@@ -33,7 +33,7 @@ access:
 data_independent_timing: true
 pseudoinstructions:
   - when: xs1 == 0
-    to: negw xd,xs2
+    to: negw xd, xs2
 operation(): |
   Bits<32> t0 = X[xs1][31:0];
   Bits<32> t1 = X[xs2][31:0];

--- a/spec/std/isa/inst/I/xori.yaml
+++ b/spec/std/isa/inst/I/xori.yaml
@@ -31,5 +31,5 @@ access:
 data_independent_timing: true
 pseudoinstructions:
   - when: $signed(imm) == -1
-    to: not xd,xs1
+    to: not xd, xs1
 operation(): X[xd] = X[xs1] ^ $signed(imm);

--- a/spec/std/isa/inst/Q/fsgnj.q.yaml
+++ b/spec/std/isa/inst/Q/fsgnj.q.yaml
@@ -32,5 +32,5 @@ access:
 data_independent_timing: false
 pseudoinstructions:
   - when: (fs2 == fs1)
-    to: fmv.q fd,fs1
+    to: fmv.q fd, fs1
 operation(): |

--- a/spec/std/isa/inst/V/vfsgnjn.vv.yaml
+++ b/spec/std/isa/inst/V/vfsgnjn.vv.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: vs2 == vs1
-    to: vfneg.v vd,vs2
+    to: vfneg.v vd, vs2
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vfsgnjn.vv.yaml
+++ b/spec/std/isa/inst/V/vfsgnjn.vv.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: vs2 == vs1
+    to: vfneg.v vd,vs2
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vfsgnjx.vv.yaml
+++ b/spec/std/isa/inst/V/vfsgnjx.vv.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: vs2 == vs1
-    to: vfabs.v vd,vs2
+    to: vfabs.v vd, vs2
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vfsgnjx.vv.yaml
+++ b/spec/std/isa/inst/V/vfsgnjx.vv.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: vs2 == vs1
+    to: vfabs.v vd,vs2
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vl1re8.v.yaml
+++ b/spec/std/isa/inst/V/vl1re8.v.yaml
@@ -25,5 +25,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: "true"
+    to: vl1r.v vd,(xs1)
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vl1re8.v.yaml
+++ b/spec/std/isa/inst/V/vl1re8.v.yaml
@@ -27,6 +27,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: "true"
-    to: vl1r.v vd,(xs1)
+    to: vl1r.v vd, (xs1)
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vl2re8.v.yaml
+++ b/spec/std/isa/inst/V/vl2re8.v.yaml
@@ -25,5 +25,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: "true"
+    to: vl2r.v vd,(xs1)
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vl2re8.v.yaml
+++ b/spec/std/isa/inst/V/vl2re8.v.yaml
@@ -27,6 +27,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: "true"
-    to: vl2r.v vd,(xs1)
+    to: vl2r.v vd, (xs1)
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vl4re8.v.yaml
+++ b/spec/std/isa/inst/V/vl4re8.v.yaml
@@ -25,5 +25,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: "true"
+    to: vl4r.v vd,(xs1)
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vl4re8.v.yaml
+++ b/spec/std/isa/inst/V/vl4re8.v.yaml
@@ -27,6 +27,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: "true"
-    to: vl4r.v vd,(xs1)
+    to: vl4r.v vd, (xs1)
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vl8re8.v.yaml
+++ b/spec/std/isa/inst/V/vl8re8.v.yaml
@@ -27,6 +27,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: "true"
-    to: vl8r.v vd,(xs1)
+    to: vl8r.v vd, (xs1)
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vl8re8.v.yaml
+++ b/spec/std/isa/inst/V/vl8re8.v.yaml
@@ -25,5 +25,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: "true"
+    to: vl8r.v vd,(xs1)
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmand.mm.yaml
+++ b/spec/std/isa/inst/V/vmand.mm.yaml
@@ -27,5 +27,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: vs2 == vs1
+    to: vmmv.m vd,vs2
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmand.mm.yaml
+++ b/spec/std/isa/inst/V/vmand.mm.yaml
@@ -29,6 +29,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: vs2 == vs1
-    to: vmmv.m vd,vs2
+    to: vmmv.m vd, vs2
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmfle.vv.yaml
+++ b/spec/std/isa/inst/V/vmfle.vv.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: "true"
+    to: vmfge.vv vd,vs1,vs2,vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmfle.vv.yaml
+++ b/spec/std/isa/inst/V/vmfle.vv.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: "true"
-    to: vmfge.vv vd,vs1,vs2,vm
+    to: vmfge.vv vd, vs1, vs2, vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmflt.vv.yaml
+++ b/spec/std/isa/inst/V/vmflt.vv.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: "true"
-    to: vmfgt.vv vd,vs1,vs2,vm
+    to: vmfgt.vv vd, vs1, vs2, vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmflt.vv.yaml
+++ b/spec/std/isa/inst/V/vmflt.vv.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: "true"
+    to: vmfgt.vv vd,vs1,vs2,vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmnand.mm.yaml
+++ b/spec/std/isa/inst/V/vmnand.mm.yaml
@@ -27,5 +27,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: vs2 == vs1
+    to: vmnot.m vd,vs2
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmnand.mm.yaml
+++ b/spec/std/isa/inst/V/vmnand.mm.yaml
@@ -29,6 +29,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: vs2 == vs1
-    to: vmnot.m vd,vs2
+    to: vmnot.m vd, vs2
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmsgt.vi.yaml
+++ b/spec/std/isa/inst/V/vmsgt.vi.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: imm < 5'b11111
+    to: vmsge.vi vd,vs2,imm+1,vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmsgt.vi.yaml
+++ b/spec/std/isa/inst/V/vmsgt.vi.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: imm < 5'b11111
-    to: vmsge.vi vd,vs2,imm+1,vm
+    to: vmsge.vi vd, vs2, imm+1, vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmsgtu.vi.yaml
+++ b/spec/std/isa/inst/V/vmsgtu.vi.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: imm < 5'b11111
-    to: vmsgeu.vi vd,vs2,imm+1,vm
+    to: vmsgeu.vi vd, vs2, imm+1, vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmsgtu.vi.yaml
+++ b/spec/std/isa/inst/V/vmsgtu.vi.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: imm < 5'b11111
+    to: vmsgeu.vi vd,vs2,imm+1,vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmsle.vi.yaml
+++ b/spec/std/isa/inst/V/vmsle.vi.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: imm < 5'b11111
+    to: vmslt.vi vd,vs2,imm+1,vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmsle.vi.yaml
+++ b/spec/std/isa/inst/V/vmsle.vi.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: imm < 5'b11111
-    to: vmslt.vi vd,vs2,imm+1,vm
+    to: vmslt.vi vd, vs2, imm+1, vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmsle.vv.yaml
+++ b/spec/std/isa/inst/V/vmsle.vv.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: "true"
-    to: vmsge.vv vd,vs1,vs2,vm
+    to: vmsge.vv vd, vs1, vs2, vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmsle.vv.yaml
+++ b/spec/std/isa/inst/V/vmsle.vv.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: "true"
+    to: vmsge.vv vd,vs1,vs2,vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmsleu.vi.yaml
+++ b/spec/std/isa/inst/V/vmsleu.vi.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: imm < 5'b11111
+    to: vmsltu.vi vd,vs2,imm+1,vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmsleu.vi.yaml
+++ b/spec/std/isa/inst/V/vmsleu.vi.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: imm < 5'b11111
-    to: vmsltu.vi vd,vs2,imm+1,vm
+    to: vmsltu.vi vd, vs2, imm+1, vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmsleu.vv.yaml
+++ b/spec/std/isa/inst/V/vmsleu.vv.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: "true"
-    to: vmsgeu.vv vd,vs1,vs2,vm
+    to: vmsgeu.vv vd, vs1, vs2, vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmsleu.vv.yaml
+++ b/spec/std/isa/inst/V/vmsleu.vv.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: "true"
+    to: vmsgeu.vv vd,vs1,vs2,vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmslt.vv.yaml
+++ b/spec/std/isa/inst/V/vmslt.vv.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: "true"
+    to: vmsgt.vv vd,vs1,vs2,vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmslt.vv.yaml
+++ b/spec/std/isa/inst/V/vmslt.vv.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: "true"
-    to: vmsgt.vv vd,vs1,vs2,vm
+    to: vmsgt.vv vd, vs1, vs2, vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmsltu.vv.yaml
+++ b/spec/std/isa/inst/V/vmsltu.vv.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: "true"
-    to: vmsgtu.vv vd,vs1,vs2,vm
+    to: vmsgtu.vv vd, vs1, vs2, vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmsltu.vv.yaml
+++ b/spec/std/isa/inst/V/vmsltu.vv.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: "true"
+    to: vmsgtu.vv vd,vs1,vs2,vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmxnor.mm.yaml
+++ b/spec/std/isa/inst/V/vmxnor.mm.yaml
@@ -27,5 +27,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: (vs2 == vs1) && (vd == vs2)
+    to: vmset.m vd
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vmxor.mm.yaml
+++ b/spec/std/isa/inst/V/vmxor.mm.yaml
@@ -27,5 +27,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: (vs2 == vs1) && (vd == vs2)
+    to: vmclr.m vd
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vnsrl.wx.yaml
+++ b/spec/std/isa/inst/V/vnsrl.wx.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: xs1 == 0
+    to: vncvt.x.x.w vd,vs2,vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vnsrl.wx.yaml
+++ b/spec/std/isa/inst/V/vnsrl.wx.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: xs1 == 0
-    to: vncvt.x.x.w vd,vs2,vm
+    to: vncvt.x.x.w vd, vs2, vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vrsub.vx.yaml
+++ b/spec/std/isa/inst/V/vrsub.vx.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: xs1 == 0
-    to: vneg.v vd,vs2,vm
+    to: vneg.v vd, vs2, vm
 data_independent_timing: true
 operation(): |

--- a/spec/std/isa/inst/V/vrsub.vx.yaml
+++ b/spec/std/isa/inst/V/vrsub.vx.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: xs1 == 0
+    to: vneg.v vd,vs2,vm
 data_independent_timing: true
 operation(): |

--- a/spec/std/isa/inst/V/vwadd.vx.yaml
+++ b/spec/std/isa/inst/V/vwadd.vx.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: xs1 == 0
-    to: vwcvt.x.x.v vd,vs2,vm
+    to: vwcvt.x.x.v vd, vs2, vm
 data_independent_timing: true
 operation(): |

--- a/spec/std/isa/inst/V/vwadd.vx.yaml
+++ b/spec/std/isa/inst/V/vwadd.vx.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: xs1 == 0
+    to: vwcvt.x.x.v vd,vs2,vm
 data_independent_timing: true
 operation(): |

--- a/spec/std/isa/inst/V/vwaddu.vx.yaml
+++ b/spec/std/isa/inst/V/vwaddu.vx.yaml
@@ -31,6 +31,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: xs1 == 0
-    to: vwcvtu.x.x.v vd,vs2,vm
+    to: vwcvtu.x.x.v vd, vs2, vm
 data_independent_timing: true
 operation(): |

--- a/spec/std/isa/inst/V/vwaddu.vx.yaml
+++ b/spec/std/isa/inst/V/vwaddu.vx.yaml
@@ -29,5 +29,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: xs1 == 0
+    to: vwcvtu.x.x.v vd,vs2,vm
 data_independent_timing: true
 operation(): |

--- a/spec/std/isa/inst/V/vxor.vi.yaml
+++ b/spec/std/isa/inst/V/vxor.vi.yaml
@@ -22,6 +22,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:
@@ -29,5 +30,8 @@ access:
   u: always
   vs: always
   vu: always
+pseudoinstructions:
+  - when: imm == -1
+    to: vnot.v vd,vs2,vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/V/vxor.vi.yaml
+++ b/spec/std/isa/inst/V/vxor.vi.yaml
@@ -32,6 +32,6 @@ access:
   vu: always
 pseudoinstructions:
   - when: imm == -1
-    to: vnot.v vd,vs2,vm
+    to: vnot.v vd, vs2, vm
 data_independent_timing: false
 operation(): |

--- a/spec/std/isa/inst/Zbkb/packw.yaml
+++ b/spec/std/isa/inst/Zbkb/packw.yaml
@@ -32,5 +32,5 @@ access:
 data_independent_timing: true
 pseudoinstructions:
   - when: (xs2 == 0x0)
-    to: zext.h xd,xs1
+    to: zext.h xd, xs1
 operation(): |

--- a/spec/std/isa/inst/Zicsr/csrrc.yaml
+++ b/spec/std/isa/inst/Zicsr/csrrc.yaml
@@ -41,7 +41,7 @@ access:
 data_independent_timing: false
 pseudoinstructions:
   - when: xd == 0
-    to: csrc csr,xs1
+    to: csrc csr, xs1
 operation(): |
   Csr csr_handle = direct_csr_lookup(csr);
 

--- a/spec/std/isa/inst/Zicsr/csrrci.yaml
+++ b/spec/std/isa/inst/Zicsr/csrrci.yaml
@@ -35,7 +35,7 @@ access:
 data_independent_timing: false
 pseudoinstructions:
   - when: xd == 0
-    to: csrci csr,imm
+    to: csrci csr, imm
 operation(): |
   Boolean will_write = imm != 0;
 

--- a/spec/std/isa/inst/Zicsr/csrrs.yaml
+++ b/spec/std/isa/inst/Zicsr/csrrs.yaml
@@ -54,9 +54,9 @@ pseudoinstructions:
   - when: xs1 == 0 && csr == 0xC82
     to: rdinstreth xd
   - when: xs1 == 0
-    to: csrr xd,csr
+    to: csrr xd, csr
   - when: xd == 0
-    to: csrs csr,xs1
+    to: csrs csr, xs1
 operation(): |
   Boolean will_write = xs1 != 0;
 

--- a/spec/std/isa/inst/Zicsr/csrrsi.yaml
+++ b/spec/std/isa/inst/Zicsr/csrrsi.yaml
@@ -35,7 +35,7 @@ access:
 data_independent_timing: false
 pseudoinstructions:
   - when: xd == 0
-    to: csrsi csr,imm
+    to: csrsi csr, imm
 operation(): |
   Boolean will_write = imm != 0;
 

--- a/spec/std/isa/inst/Zicsr/csrrw.yaml
+++ b/spec/std/isa/inst/Zicsr/csrrw.yaml
@@ -35,7 +35,7 @@ access:
   vu: always
 pseudoinstructions:
   - when: xd == 0
-    to: csrw csr,xs1
+    to: csrw csr, xs1
 operation(): |
   Csr csr_handle = direct_csr_lookup(csr);
 

--- a/spec/std/isa/inst/Zicsr/csrrwi.yaml
+++ b/spec/std/isa/inst/Zicsr/csrrwi.yaml
@@ -35,7 +35,7 @@ access:
   vu: always
 pseudoinstructions:
   - when: xd == 0
-    to: csrwi csr,imm
+    to: csrwi csr, imm
 operation(): |
   Csr csr_handle = direct_csr_lookup(csr);
 


### PR DESCRIPTION
Two particularly interesting cases:
- Some vector "less than or equal"/"greater than" instructions are mapped to
 "less than"/"greater than or equal" pseudoinstructions with the immediate
  incremented. So, these need to allow for (by ignoring) cases where the
  immediate cannot be incremented without overflowing.
- `vmnot.v` depends on the immediate for `vxor.vi` being "-1", thus
  sign-extended. Add this attribute to the opcode field (and presume the
  attribute is applied before pseudoinstruction mapping).