### PR TITLE
 fix(ci): repair GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -251,7 +251,6 @@ jobs:
               mkdir -p "_site/schemas/${schema_name}/${version}"
               gh release download "${tag}" --dir "_site/schemas/${schema_name}/${version}" --pattern "*.json" 2>/dev/null || true
             done
-          fi
           # Write a JSON index of all available schema versions and files
           ruby tools/scripts/gen_schema_index.rb _site/schemas _site/schemas/index.json
 


### PR DESCRIPTION
Root cause:
- `.github/workflows/pages.yml` had an unmatched `fi` in the "Download and publish schema files" shell block.

Fix:
- Removed the stray `fi` so the step executes correctly.



Closes #1787