### PR TITLE
fix(vscode): highlight single-line IDL in YAML injection

### DIFF
--- a/tools/vscode/yamlidl/README.md
+++ b/tools/vscode/yamlidl/README.md
@@ -15,6 +15,7 @@ This extension provides syntax highlighting for YAML files with intelligent lang
 - Automatically detects YAML keys ending with `()` or `(args)` patterns
 - Applies IDL syntax highlighting to both the arguments and the associated string values
 - Supports all YAML string value types:
+  - Unquoted single-line scalars: `key(): X[rd] = X[rs1] + X[rs2];`
   - Quoted strings: `key(): "IDL code"`
   - Single-quoted strings: `key(): 'IDL code'`
   - Block scalars (literal): `key(): |`

--- a/tools/vscode/yamlidl/syntaxes/yaml-idl-injection.json
+++ b/tools/vscode/yamlidl/syntaxes/yaml-idl-injection.json
@@ -106,6 +106,29 @@
       ]
     },
     {
+      "comment": "Match unquoted single-line scalar values after keys ending with ()",
+      "begin": "^(\\s*)([\\w-]+)(\\([^)]*\\))\\s*:\\s*(?=[^\\s#])(?![\\|>\\[\\{'\"])",
+      "beginCaptures": {
+        "2": {
+          "name": "entity.name.function.yaml"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "source.idl"
+            }
+          ]
+        }
+      },
+      "end": "(?=\\s+#|$)",
+      "contentName": "meta.embedded.block.idl",
+      "patterns": [
+        {
+          "include": "source.idl"
+        }
+      ]
+    },
+    {
       "comment": "Match block scalar (literal |) values after keys ending with ()",
       "begin": "^(\\s*)([\\w-]+)(\\([^)]*\\))\\s*:\\s*\\|[-+]?\\s*$",
       "beginCaptures": {


### PR DESCRIPTION
## Summary

Fix YAML IDL highlighting for unquoted single-line values after keys like `operation()`.

Updated:
- `tools/vscode/yamlidl/syntaxes/yaml-idl-injection.json`
- `tools/vscode/yamlidl/README.md`

Closes #1716
