### PR TITLE
feat: optimize C extensions

### DIFF
--- a/spec/schemas/inst_schema.json
+++ b/spec/schemas/inst_schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "v0.2",
+  "$id": "v0.3",
   "$defs": {
     "fully_resolved_opcodes": {
       "type": "object",
@@ -267,6 +267,15 @@
               "default": 0,
               "description": "Amount the field should be left shifted before use (e.g., for opcode[5:3], left_shift is 3)"
             },
+            "add": {
+              "type": "integer",
+              "default": 0,
+              "description": "Amount the field should be added before use, e.g., source register is ranged between 8 to 15, add is 8"
+            },
+            "implicit": {
+              "type": "integer",
+              "description": "Implicitly use an operand with the value"
+            },
             "alias": {
               "type": "string",
               "description": "Alias of the field. Used when a field can represent multiple things, e.g., when a source register is also the destination register"
@@ -286,7 +295,14 @@
               "description": "Specific value(s) that are not permitted for this field."
             }
           },
-          "required": ["name", "location"],
+          "oneOf": [
+            {
+              "required": ["name", "location"]
+            },
+            {
+              "required": ["name", "implicit"]
+            }
+          ],
           "additionalProperties": false
         }
       ]

--- a/spec/std/isa/inst/C/c.add.yaml
+++ b/spec/std/isa/inst/C/c.add.yaml
@@ -23,6 +23,7 @@ encoding:
     - name: xd
       location: 11-7
       not: 0
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.addi.yaml
+++ b/spec/std/isa/inst/C/c.addi.yaml
@@ -22,9 +22,11 @@ encoding:
     - name: imm
       location: 12|6-2
       not: 0
+      sign_extend: true
     - name: xd
       location: 11-7
       not: 0
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.addi16sp.yaml
+++ b/spec/std/isa/inst/C/c.addi16sp.yaml
@@ -23,6 +23,44 @@ encoding:
       location: 12|4-3|5|2|6
       left_shift: 4
       not: 0
+      sign_extend: true
+    - name: xd
+      location: 11-7
+      not:
+        [
+          0,
+          1,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          28,
+          29,
+          30,
+          31,
+        ]
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.addi4spn.yaml
+++ b/spec/std/isa/inst/C/c.addi4spn.yaml
@@ -25,6 +25,9 @@ encoding:
       not: 0
     - name: xd
       location: 4-2
+      add: 8
+    - name: xs1
+      implicit: 2
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.addiw.yaml
+++ b/spec/std/isa/inst/C/c.addiw.yaml
@@ -23,9 +23,11 @@ encoding:
   variables:
     - name: imm
       location: 12|6-2
+      sign_extend: true
     - name: xd
       location: 11-7
       not: 0
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.addw.yaml
+++ b/spec/std/isa/inst/C/c.addw.yaml
@@ -22,8 +22,11 @@ encoding:
   variables:
     - name: xs2
       location: 4-2
+      add: 8
     - name: xd
       location: 9-7
+      add: 8
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.and.yaml
+++ b/spec/std/isa/inst/C/c.and.yaml
@@ -20,8 +20,11 @@ encoding:
   variables:
     - name: xs2
       location: 4-2
+      add: 8
     - name: xd
       location: 9-7
+      add: 8
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.andi.yaml
+++ b/spec/std/isa/inst/C/c.andi.yaml
@@ -20,8 +20,11 @@ encoding:
   variables:
     - name: imm
       location: 12|6-2
+      sign_extend: true
     - name: xd
       location: 9-7
+      add: 8
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.beqz.yaml
+++ b/spec/std/isa/inst/C/c.beqz.yaml
@@ -23,6 +23,9 @@ encoding:
       sign_extend: true
     - name: xs1
       location: 9-7
+      add: 8
+    - name: xs2
+      implicit: 0
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.bnez.yaml
+++ b/spec/std/isa/inst/C/c.bnez.yaml
@@ -23,6 +23,9 @@ encoding:
       sign_extend: true
     - name: xs1
       location: 9-7
+      add: 8
+    - name: xs2
+      implicit: 0
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.j.yaml
+++ b/spec/std/isa/inst/C/c.j.yaml
@@ -21,6 +21,8 @@ encoding:
       location: 12|8|10-9|6|7|2|11|5-3
       left_shift: 1
       sign_extend: true
+    - name: xd
+      implicit: 0
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.jal.yaml
+++ b/spec/std/isa/inst/C/c.jal.yaml
@@ -23,6 +23,8 @@ encoding:
       location: 12|8|10-9|6|7|2|11|5-3
       left_shift: 1
       sign_extend: true
+    - name: xd
+      implicit: 1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.jalr.yaml
+++ b/spec/std/isa/inst/C/c.jalr.yaml
@@ -20,6 +20,8 @@ encoding:
     - name: xs1
       location: 11-7
       not: 0
+    - name: xd
+      implicit: 1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.jr.yaml
+++ b/spec/std/isa/inst/C/c.jr.yaml
@@ -20,6 +20,8 @@ encoding:
     - name: xs1
       location: 11-7
       not: 0
+    - name: xd
+      implicit: 0
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.ld.yaml
+++ b/spec/std/isa/inst/C/c.ld.yaml
@@ -32,8 +32,10 @@ encoding:
       - name: xd
         location: 4-2
         not: [1, 3, 5, 7]
+        add: 8
       - name: xs1
         location: 9-7
+        add: 8
   RV64:
     match: 011-----------00
     variables:
@@ -42,8 +44,10 @@ encoding:
         left_shift: 3
       - name: xd
         location: 4-2
+        add: 8
       - name: xs1
         location: 9-7
+        add: 8
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.ldsp.yaml
+++ b/spec/std/isa/inst/C/c.ldsp.yaml
@@ -34,7 +34,9 @@ encoding:
         left_shift: 3
       - name: xd
         location: 11-7
-        not: [0, 1, 3, 5, 7]
+        not: [0, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31]
+      - name: xs1
+        implicit: 2
   RV64:
     match: 011-----------10
     variables:
@@ -43,6 +45,8 @@ encoding:
         left_shift: 3
       - name: xd
         location: 11-7
+      - name: xs1
+        implicit: 2
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.li.yaml
+++ b/spec/std/isa/inst/C/c.li.yaml
@@ -20,9 +20,12 @@ encoding:
   variables:
     - name: imm
       location: 12|6-2
+      sign_extend: true
     - name: xd
       location: 11-7
       not: 0
+    - name: xs1
+      implicit: 0
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.lui.yaml
+++ b/spec/std/isa/inst/C/c.lui.yaml
@@ -22,6 +22,7 @@ encoding:
     - name: imm
       location: 12|6-2
       left_shift: 12
+      sign_extend: true
     - name: xd
       location: 11-7
       not: [0, 2]

--- a/spec/std/isa/inst/C/c.lw.yaml
+++ b/spec/std/isa/inst/C/c.lw.yaml
@@ -24,8 +24,10 @@ encoding:
       left_shift: 2
     - name: xd
       location: 4-2
+      add: 8
     - name: xs1
       location: 9-7
+      add: 8
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.lwsp.yaml
+++ b/spec/std/isa/inst/C/c.lwsp.yaml
@@ -26,6 +26,8 @@ encoding:
     - name: xd
       location: 11-7
       not: 0
+    - name: xs1
+      implicit: 2
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.mv.yaml
+++ b/spec/std/isa/inst/C/c.mv.yaml
@@ -9,7 +9,7 @@ name: c.mv
 long_name: Move Register
 description: |
   C.MV (move register) performs copy of the data in register xs2 to register xd
-  C.MV expands to addi xd, x0, xs2.
+  C.MV expands to add xd, x0, xs2.
 definedBy:
   extension:
     name: Zca
@@ -20,6 +20,8 @@ encoding:
     - name: xd
       location: 11-7
       not: 0
+    - name: xs1
+      implicit: 0
     - name: xs2
       location: 6-2
       not: 0

--- a/spec/std/isa/inst/C/c.or.yaml
+++ b/spec/std/isa/inst/C/c.or.yaml
@@ -20,8 +20,11 @@ encoding:
   variables:
     - name: xs2
       location: 4-2
+      add: 8
     - name: xd
       location: 9-7
+      add: 8
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.sd.yaml
+++ b/spec/std/isa/inst/C/c.sd.yaml
@@ -30,9 +30,11 @@ encoding:
         left_shift: 3
       - name: xs2
         location: 4-2
+        add: 8
         not: [1, 3, 5, 7]
       - name: xs1
         location: 9-7
+        add: 8
   RV64:
     match: 111-----------00
     variables:
@@ -41,8 +43,10 @@ encoding:
         left_shift: 3
       - name: xs2
         location: 4-2
+        add: 8
       - name: xs1
         location: 9-7
+        add: 8
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.sdsp.yaml
+++ b/spec/std/isa/inst/C/c.sdsp.yaml
@@ -27,10 +27,12 @@ encoding:
     variables:
       - name: xs2
         location: 6-2
-        not: [1, 3, 5, 7]
+        not: [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31]
       - name: imm
         location: 9-7|12-10
         left_shift: 3
+      - name: xs1
+        implicit: 2
   RV64:
     match: 111-----------10
     variables:
@@ -39,6 +41,8 @@ encoding:
       - name: imm
         location: 9-7|12-10
         left_shift: 3
+      - name: xs1
+        implicit: 2
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.slli.yaml
+++ b/spec/std/isa/inst/C/c.slli.yaml
@@ -23,6 +23,7 @@ encoding:
         not: 0
       - name: xd
         location: 11-7
+        alias: xs1
   RV64:
     match: 000-----------10
     variables:
@@ -31,6 +32,7 @@ encoding:
         not: 0
       - name: xd
         location: 11-7
+        alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.srai.yaml
+++ b/spec/std/isa/inst/C/c.srai.yaml
@@ -24,6 +24,8 @@ encoding:
         not: 0
       - name: xd
         location: 9-7
+        add: 8
+        alias: xs1
   RV64:
     match: 100-01--------01
     variables:
@@ -32,6 +34,8 @@ encoding:
         not: 0
       - name: xd
         location: 9-7
+        add: 8
+        alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.srli.yaml
+++ b/spec/std/isa/inst/C/c.srli.yaml
@@ -24,6 +24,8 @@ encoding:
         not: 0
       - name: xd
         location: 9-7
+        add: 8
+        alias: xs1
   RV64:
     match: 100-00--------01
     variables:
@@ -32,6 +34,8 @@ encoding:
         not: 0
       - name: xd
         location: 9-7
+        add: 8
+        alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.sub.yaml
+++ b/spec/std/isa/inst/C/c.sub.yaml
@@ -20,8 +20,11 @@ encoding:
   variables:
     - name: xs2
       location: 4-2
+      add: 8
     - name: xd
       location: 9-7
+      add: 8
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.subw.yaml
+++ b/spec/std/isa/inst/C/c.subw.yaml
@@ -22,8 +22,11 @@ encoding:
   variables:
     - name: xs2
       location: 4-2
+      add: 8
     - name: xd
       location: 9-7
+      add: 8
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.sw.yaml
+++ b/spec/std/isa/inst/C/c.sw.yaml
@@ -24,8 +24,10 @@ encoding:
       left_shift: 2
     - name: xs2
       location: 4-2
+      add: 8
     - name: xs1
       location: 9-7
+      add: 8
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.swsp.yaml
+++ b/spec/std/isa/inst/C/c.swsp.yaml
@@ -24,6 +24,8 @@ encoding:
       left_shift: 2
     - name: xs2
       location: 6-2
+    - name: xs1
+      implicit: 2
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/C/c.xor.yaml
+++ b/spec/std/isa/inst/C/c.xor.yaml
@@ -20,8 +20,11 @@ encoding:
   variables:
     - name: xs2
       location: 4-2
+      add: 8
     - name: xd
       location: 9-7
+      add: 8
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcb/c.lbu.yaml
+++ b/spec/std/isa/inst/Zcb/c.lbu.yaml
@@ -22,8 +22,10 @@ encoding:
       location: 5|6
     - name: xd
       location: 4-2
+      add: 8
     - name: xs1
       location: 9-7
+      add: 8
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcb/c.lh.yaml
+++ b/spec/std/isa/inst/Zcb/c.lh.yaml
@@ -23,8 +23,10 @@ encoding:
       left_shift: 1
     - name: xd
       location: 4-2
+      add: 8
     - name: xs1
       location: 9-7
+      add: 8
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcb/c.lhu.yaml
+++ b/spec/std/isa/inst/Zcb/c.lhu.yaml
@@ -23,8 +23,10 @@ encoding:
       left_shift: 1
     - name: xd
       location: 4-2
+      add: 8
     - name: xs1
       location: 9-7
+      add: 8
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcb/c.mul.yaml
+++ b/spec/std/isa/inst/Zcb/c.mul.yaml
@@ -21,8 +21,11 @@ encoding:
   variables:
     - name: xd
       location: 9-7
+      add: 8
     - name: xs2
       location: 4-2
+      add: 8
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcb/c.not.yaml
+++ b/spec/std/isa/inst/Zcb/c.not.yaml
@@ -20,6 +20,8 @@ encoding:
   variables:
     - name: xd
       location: 9-7
+      add: 8
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcb/c.sb.yaml
+++ b/spec/std/isa/inst/Zcb/c.sb.yaml
@@ -22,8 +22,10 @@ encoding:
       location: 5|6
     - name: xs2
       location: 4-2
+      add: 8
     - name: xs1
       location: 9-7
+      add: 8
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcb/c.sext.b.yaml
+++ b/spec/std/isa/inst/Zcb/c.sext.b.yaml
@@ -23,6 +23,8 @@ encoding:
   variables:
     - name: xd
       location: 9-7
+      add: 8
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcb/c.sext.h.yaml
+++ b/spec/std/isa/inst/Zcb/c.sext.h.yaml
@@ -23,6 +23,8 @@ encoding:
   variables:
     - name: xd
       location: 9-7
+      add: 8
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcb/c.sh.yaml
+++ b/spec/std/isa/inst/Zcb/c.sh.yaml
@@ -23,8 +23,10 @@ encoding:
       left_shift: 1
     - name: xs2
       location: 4-2
+      add: 8
     - name: xs1
       location: 9-7
+      add: 8
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcb/c.zext.b.yaml
+++ b/spec/std/isa/inst/Zcb/c.zext.b.yaml
@@ -23,6 +23,8 @@ encoding:
   variables:
     - name: xd
       location: 9-7
+      add: 8
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcb/c.zext.h.yaml
+++ b/spec/std/isa/inst/Zcb/c.zext.h.yaml
@@ -23,6 +23,8 @@ encoding:
   variables:
     - name: xd
       location: 9-7
+      add: 8
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcb/c.zext.w.yaml
+++ b/spec/std/isa/inst/Zcb/c.zext.w.yaml
@@ -24,6 +24,8 @@ encoding:
   variables:
     - name: xd
       location: 9-7
+      add: 8
+      alias: xs1
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcd/c.fld.yaml
+++ b/spec/std/isa/inst/Zcd/c.fld.yaml
@@ -24,8 +24,10 @@ encoding:
       left_shift: 3
     - name: fd
       location: 4-2
+      add: 8
     - name: xs1
       location: 9-7
+      add: 8
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcd/c.fldsp.yaml
+++ b/spec/std/isa/inst/Zcd/c.fldsp.yaml
@@ -24,6 +24,8 @@ encoding:
       left_shift: 3
     - name: fd
       location: 11-7
+    - name: xs1
+      implicit: 2
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcd/c.fsd.yaml
+++ b/spec/std/isa/inst/Zcd/c.fsd.yaml
@@ -24,8 +24,10 @@ encoding:
       left_shift: 3
     - name: fs2
       location: 4-2
+      add: 8
     - name: xs1
       location: 9-7
+      add: 8
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcd/c.fsdsp.yaml
+++ b/spec/std/isa/inst/Zcd/c.fsdsp.yaml
@@ -24,6 +24,8 @@ encoding:
       left_shift: 3
     - name: fs2
       location: 6-2
+    - name: xs1
+      implicit: 2
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcf/c.flw.yaml
+++ b/spec/std/isa/inst/Zcf/c.flw.yaml
@@ -24,8 +24,10 @@ encoding:
       left_shift: 2
     - name: fd
       location: 4-2
+      add: 8
     - name: xs1
       location: 9-7
+      add: 8
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcf/c.flwsp.yaml
+++ b/spec/std/isa/inst/Zcf/c.flwsp.yaml
@@ -24,6 +24,8 @@ encoding:
       left_shift: 2
     - name: fd
       location: 11-7
+    - name: xs1
+      implicit: 2
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcf/c.fsw.yaml
+++ b/spec/std/isa/inst/Zcf/c.fsw.yaml
@@ -24,8 +24,10 @@ encoding:
       left_shift: 2
     - name: fs2
       location: 4-2
+      add: 8
     - name: xs1
       location: 9-7
+      add: 8
 access:
   s: always
   u: always

--- a/spec/std/isa/inst/Zcf/c.fswsp.yaml
+++ b/spec/std/isa/inst/Zcf/c.fswsp.yaml
@@ -24,6 +24,8 @@ encoding:
       left_shift: 2
     - name: fs2
       location: 6-2
+    - name: xs1
+      implicit: 2
 access:
   s: always
   u: always

--- a/tools/ruby-gems/udb/lib/udb/obj/instruction.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/instruction.rb
@@ -422,6 +422,8 @@ module Udb
       if effective_xlen.nil?
         if defined_in_base?(32)
           encoding(32).decode_variables.each do |d|
+            next if d.size.zero?
+
             qualifiers = [:const]
             qualifiers << :signed if d.sext?
             width = d.size
@@ -432,6 +434,8 @@ module Udb
         end
         if defined_in_base?(64)
           encoding(64).decode_variables.each do |d|
+            next if d.size.zero?
+
             qualifiers = [:const]
             qualifiers << :signed if d.sext?
             width = d.size
@@ -457,6 +461,8 @@ module Udb
           Idl::Var.new("__effective_xlen", Idl::Type.new(:bits, width: 7), effective_xlen)
         )
         encoding(effective_xlen).decode_variables.each do |d|
+          next if d.size.zero?
+
           qualifiers = [:const]
           qualifiers << :signed if d.sext?
           width = d.size
@@ -661,8 +667,13 @@ module Udb
 
       attr_reader :encoding_fields
 
-      sig { returns(String) }
+      sig { returns(T.nilable(String)) }
       attr_reader :location
+
+      # implicitly use an operand with the value
+      attr_reader :implicit
+
+      def implicit? = @implicit != 0
 
       # @return [Array<Integer>] Any array containing every encoding index covered by this variable
       sig { returns(T::Array[Integer]) }
@@ -674,9 +685,21 @@ module Udb
       # @example
       #   pretty_name #=> "rd != 0"
       #   pretty_name #=> "rd != {0,2}"
+      #   pretty_name #=> "rs1 = 2"
       def pretty_name
-        if excludes.empty?
-          name
+        return name if excludes.empty?
+
+        excludes_set = excludes.to_set
+        bit_width = size
+        all_values = (0...(1 << bit_width)).to_set
+
+        if all_values.size - excludes_set.size < excludes_set.size
+          includes = (all_values - excludes_set).to_a.sort
+          if includes.size == 1
+            "#{name} = #{includes[0]}"
+          else
+            "#{name} = {#{includes.join(',')}}"
+          end
         elsif excludes.size == 1
           "#{name} != #{excludes[0]}"
         else
@@ -763,6 +786,8 @@ module Udb
 
       # array of constituent encoding fields
       def grouped_encoding_fields
+        return [] if @encoding_fields.empty?
+
         sorted_encoding_fields = @encoding_fields.sort { |a, b| b.range.last <=> a.range.last }
         # need to group encoding_fields if they are consecutive
         grouped_fields = [sorted_encoding_fields[0].range]
@@ -789,10 +814,15 @@ module Udb
       def initialize(name, field_data)
         @name = name
         @left_shift = field_data["left_shift"].nil? ? 0 : field_data["left_shift"]
+        @add = field_data["add"].nil? ? 0 : field_data["add"]
         @sext = field_data["sign_extend"].nil? ? false : field_data["sign_extend"]
         @alias = field_data["alias"].nil? ? nil : field_data["alias"]
+        @implicit = field_data["implicit"].nil? ? 0 : field_data["implicit"]
         @location = field_data["location"]
-        extract_location(field_data["location"])
+        @encoding_fields = []
+        if !field_data["location"].nil?
+          extract_location(field_data["location"])
+        end
         @excludes =
           if field_data.key?("not")
             if field_data["not"].is_a?(Array)
@@ -882,6 +912,7 @@ module Udb
           else
             ops[0]
           end
+        ops = "(#{ops} + #{@add})" unless @add.zero?
         ops = "sext(#{ops}, #{size})" if sext?
         ops
       end


### PR DESCRIPTION
Add 2 new attributes to instruction schema:
1. `add`: Used to adjust operand value by adding an integer to binary value. Useful for describing x8-x15 registers in C extensions.
2. `implicit`: Used to hint that the instruction is using an operand without explicitly allocating a field in the encoding. Useful for describing sp-/ra-relative instructions in C extensions.

Though `implicit` is not used by current riscv-unified-db, it may be useful for the library relied on it.

Other notable changes:

1. `inst_schema.json` version is bumped to v0.3
2. Because `sign_extend` default to false, I have added it to C instructions required signed-extend.
3. Fix several C instructions missing `alias` for `rd'/rs1'` operands.
4. Update pretty_print that if `not` array size is more than its reversion, use it instead.