### PR TITLE
fix(clean): skip riscv-tests cleanup when unavailable (#1718)

### DIFF
--- a/tests/isa/Makefile
+++ b/tests/isa/Makefile
@@ -85,5 +85,13 @@ riscv_tests:
 # Clean up
 
 clean:
-	$(MAKE) -C $(riscv_tests_dir)/isa XLEN=$(XLEN) clean
+	@if [ -d "$(riscv_tests_dir)/isa" ] && [ -f "$(riscv_tests_dir)/isa/Makefile" ]; then \
+		if command -v "$(RISCV_GCC)" > /dev/null 2>&1; then \
+			$(MAKE) -C $(riscv_tests_dir)/isa XLEN=$(XLEN) clean; \
+		else \
+			echo "Skipping $(riscv_tests_dir)/isa clean: $(RISCV_GCC) not found"; \
+		fi; \
+	else \
+		echo "Skipping $(riscv_tests_dir)/isa clean: submodule not initialized"; \
+	fi
 	rm -rf $(junk)

--- a/tests/isa/Makefile
+++ b/tests/isa/Makefile
@@ -85,13 +85,7 @@ riscv_tests:
 # Clean up
 
 clean:
-	@if [ -d "$(riscv_tests_dir)/isa" ] && [ -f "$(riscv_tests_dir)/isa/Makefile" ]; then \
-		if command -v "$(RISCV_GCC)" > /dev/null 2>&1; then \
-			$(MAKE) -C $(riscv_tests_dir)/isa XLEN=$(XLEN) clean; \
-		else \
-			:; \
-		fi; \
-	else \
-		:; \
+	@if [ -f "$(riscv_tests_dir)/isa/Makefile" ] && command -v "$(RISCV_GCC)" > /dev/null 2>&1; then \
+		$(MAKE) -C $(riscv_tests_dir)/isa XLEN=$(XLEN) clean; \
 	fi
 	rm -rf $(junk)

--- a/tests/isa/Makefile
+++ b/tests/isa/Makefile
@@ -89,9 +89,9 @@ clean:
 		if command -v "$(RISCV_GCC)" > /dev/null 2>&1; then \
 			$(MAKE) -C $(riscv_tests_dir)/isa XLEN=$(XLEN) clean; \
 		else \
-			echo "Skipping $(riscv_tests_dir)/isa clean: $(RISCV_GCC) not found"; \
+			:; \
 		fi; \
 	else \
-		echo "Skipping $(riscv_tests_dir)/isa clean: submodule not initialized"; \
+		:; \
 	fi
 	rm -rf $(junk)


### PR DESCRIPTION
Closes #1718

`./do clean` should not fail when `riscv-tests` dependencies are unavailable.

This change updates `tests/isa/Makefile` clean behavior to:
- skip `ext/riscv-tests/isa` cleanup if the submodule is not initialized
- skip `ext/riscv-tests/isa` cleanup if `RISCV_GCC` is not found
- still clean local `tests/isa` artifacts


