### PR TITLE
fix(ci): use correct gem name in gem bump PR body

### DIFF
--- a/.github/workflows/gem_bump.yml
+++ b/.github/workflows/gem_bump.yml
@@ -84,7 +84,9 @@ jobs:
           BODY="Automated gem version bump."$'\n\n'
           BODY+="**Bumped gems:**"$'\n'
           while IFS= read -r version_file; do
-            GEM_DIR=$(dirname "$(dirname "$version_file")")
+            # Path is tools/ruby-gems/<gem-name>/lib/<gem-name>/version.rb,
+            # so three dirname levels yield the gem directory.
+            GEM_DIR=$(dirname "$(dirname "$(dirname "$version_file")")")
             GEM_NAME=$(basename "$GEM_DIR")
             NEW_VERSION=$(ruby -e "content = File.read('$version_file'); puts content[/[\"'](\d+\.\d+\.\d+)[\"']/, 1]")
             BODY+="- \`${GEM_NAME}\` → ${NEW_VERSION}"$'\n'


### PR DESCRIPTION
The gem-bump workflow's PR body listed every bumped gem as "lib" because dirname was only applied twice to the version file path, stopping at tools/ruby-gems/<gem>/lib instead of <gem>. Add the missing third dirname level so basename returns the gem name.