### PR TITLE
Fix Zcmp issues

### DIFF
--- a/backends/cpp_hart_gen/lib/template_helpers.rb
+++ b/backends/cpp_hart_gen/lib/template_helpers.rb
@@ -16,6 +16,10 @@ module Udb
   class Instruction
     def assembly_fmt(xlen)
       fmt = assembly.dup
+      # fmt::format treats braces as replacement fields, so any literal braces in
+      # the assembly syntax must be escaped before we inject positional "{}".
+      fmt.gsub!("{", "{{")
+      fmt.gsub!("}", "}}")
       dvs = encoding(xlen).decode_variables
       dvs.each do |dv|
         fmt.gsub!(dv.name, "{}")

--- a/spec/std/isa/inst/Zcmp/cm.pop.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.pop.yaml
@@ -20,7 +20,7 @@ description: |
 definedBy:
   extension:
     name: Zcmp
-assembly: reg_list, stack_adj
+assembly: "{reg_list}, stack_adj"
 encoding:
   match: 10111010------10
   variables:

--- a/spec/std/isa/inst/Zcmp/cm.popret.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.popret.yaml
@@ -20,7 +20,7 @@ description: |
 definedBy:
   extension:
     name: Zcmp
-assembly: reg_list, stack_adj
+assembly: "{reg_list}, stack_adj"
 encoding:
   match: 10111110------10
   variables:

--- a/spec/std/isa/inst/Zcmp/cm.popretz.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.popretz.yaml
@@ -20,7 +20,7 @@ description: |
 definedBy:
   extension:
     name: Zcmp
-assembly: reg_list, stack_adj
+assembly: "{reg_list}, stack_adj"
 encoding:
   match: 10111100------10
   variables:

--- a/spec/std/isa/inst/Zcmp/cm.push.yaml
+++ b/spec/std/isa/inst/Zcmp/cm.push.yaml
@@ -21,7 +21,7 @@ description: |
 definedBy:
   extension:
     name: Zcmp
-assembly: reg_list, -stack_adj
+assembly: "{reg_list}, -stack_adj"
 encoding:
   match: 10111000------10
   variables:
@@ -30,7 +30,6 @@ encoding:
       not: [0, 1, 2, 3]
     - name: spimm
       location: 3-2
-      left_shift: 4
 access:
   s: always
   u: always
@@ -45,7 +44,7 @@ operation(): |
   XReg nreg = (rlist == 15) ? 13 : (rlist - 3);
   XReg stack_aligned_adj = (nreg * 4 + 15) & ~0xF;
   XReg virtual_address_sp = X[2];
-  XReg virtual_address_new_sp = virtual_address_sp - stack_aligned_adj - spimm;
+  XReg virtual_address_new_sp = virtual_address_sp - stack_aligned_adj - spimm * 16;
   XReg virtual_address_base = virtual_address_sp - (nreg * size);
 
   write_memory_xlen_aligned(virtual_address_base +  0*size, X[ 1], $encoding);

--- a/tests/golden/all_instructions.golden.adoc
+++ b/tests/golden/all_instructions.golden.adoc
@@ -10415,7 +10415,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |sext($encoding[31:20], 12)
+|imm |$encoding[31:20]
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -15908,7 +15908,7 @@ Base::
 |===
 
 Assembly::
-cm.pop reg_list, stack_adj
+cm.pop {reg_list}, stack_adj
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -15967,7 +15967,7 @@ Base::
 |===
 
 Assembly::
-cm.popret reg_list, stack_adj
+cm.popret {reg_list}, stack_adj
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -16026,7 +16026,7 @@ Base::
 |===
 
 Assembly::
-cm.popretz reg_list, stack_adj
+cm.popretz {reg_list}, stack_adj
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
@@ -17417,8 +17417,8 @@ Decode Variables::
 |Variable Name |Location
 |fs2 |$encoding[24:20]
 |fs1 |$encoding[19:15]
-|fd |$encoding[11:7]
 |rm |$encoding[14:12]
+|fd |$encoding[11:7]
 |===
 
 Included in::
@@ -38426,7 +38426,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |sext({$encoding[31:25], $encoding[11:7]}, 12)
+|imm |{$encoding[31:25], $encoding[11:7]}
 |xs2 |$encoding[24:20]
 |xs1 |$encoding[19:15]
 |===

--- a/tests/golden/all_instructions.golden.adoc
+++ b/tests/golden/all_instructions.golden.adoc
@@ -1,6 +1,6 @@
 = Instruction Appendix
 :doctype: book
-:wavedrom: /home/henry/projects/riscv-unified-db/node_modules/.bin/wavedrom-cli
+:wavedrom: /home/paulclar/projects/riscv-unified-db/riscv-unified-db/node_modules/.bin/wavedrom-cli
 // Now the document header is complete and the wavedrom attribute is active.
 
 
@@ -10415,7 +10415,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -16085,12 +16085,12 @@ Base::
 |===
 
 Assembly::
-cm.push reg_list, -stack_adj
+cm.push {reg_list}, -stack_adj
 
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":2,"name": "spimm[5:4]","type":4},{"bits":4,"name": "rlist != {0,1,2,3}","type":4},{"bits":8,"name": 0xb8,"type":2}]}
+{"reg":[{"bits":2,"name": 0x2,"type":2},{"bits":2,"name": "spimm","type":4},{"bits":4,"name": "rlist != {0,1,2,3}","type":4},{"bits":8,"name": 0xb8,"type":2}]}
 ....
 
 Description::
@@ -16111,7 +16111,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |rlist |$encoding[7:4]
-|spimm |{$encoding[3:2], 4'd0}
+|spimm |$encoding[3:2]
 |===
 
 Included in::
@@ -17417,8 +17417,8 @@ Decode Variables::
 |Variable Name |Location
 |fs2 |$encoding[24:20]
 |fs1 |$encoding[19:15]
-|rm |$encoding[14:12]
 |fd |$encoding[11:7]
+|rm |$encoding[14:12]
 |===
 
 Included in::
@@ -38426,7 +38426,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |{$encoding[31:25], $encoding[11:7]}
+|imm |sext({$encoding[31:25], $encoding[11:7]}, 12)
 |xs2 |$encoding[24:20]
 |xs1 |$encoding[19:15]
 |===


### PR DESCRIPTION
Zcmp PUSH/POP instructions use braces around reg_list operands, but these are missing. Add them.

Also, the encoded "spimm" is the scale to apply to the 16-byte increments for stack adjustment, so multiply "spimm" by 16.

`./bin/regress --name regress-riscv-tests-32` failed when braces were added to the "assembly" fields
(for example `{reg_list}, -stack_adj`).

The C++ hart generator injects instruction assembly text into `fmt::format`. Unescaped `{...}` from assembly text is parsed by fmt as a named format field, so generated code failed to compile.

Escape literal `{` and `}` in `Instruction#assembly_fmt` before decode-variable substitution.

This is needed so assembly templates can safely use brace syntax without breaking generated disassembly format strings.