### PR TITLE
fix(ci): migrate release_gems workflow to mise + root Gemfile

### DIFF
--- a/.github/workflows/release_gems.yml
+++ b/.github/workflows/release_gems.yml
@@ -130,19 +130,14 @@ jobs:
             echo "TAG_EXISTS=false" >> "$GITHUB_ENV"
           fi
 
-      - name: Set up Ruby
+      - name: Set up mise environment
         if: env.TAG_EXISTS == 'false'
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2'
-          bundler-cache: true
-          working-directory: tools/ruby-gems/${{ matrix.gem_dir }}
+        uses: ./.github/actions/mise-setup
 
       - name: Prepare gem staging directory
         if: env.TAG_EXISTS == 'false'
         run: |
-          cd tools/ruby-gems/${{ matrix.gem_dir }}
-          bundle exec rake release:${{ matrix.rake_task }}:prepare
+          BUNDLE_GEMFILE=$PWD/Gemfile bundle exec rake release:${{ matrix.rake_task }}:prepare
 
       - name: Build gem
         if: env.TAG_EXISTS == 'false'


### PR DESCRIPTION
## Problem

Releasing new gem versions fails on `main`. Example: [run 26062529157](https://github.com/riscv/riscv-unified-db/actions/runs/26062529157/job/76643929175) — every `release-gem` matrix job (idlc, udb, udb-gen) fails in *Prepare gem staging directory* with:

```
bundler: failed to load command: rake
Could not find tty-spinner-0.9.3, rdbg-0.1.0, rouge-4.7.0, ... in locally installed gems (Bundler::GemNotFound)
```

(`udb_helpers` only "passed" because its release tag already existed, so `TAG_EXISTS=true` skipped the bundle steps.)

## Root cause

`#1797` consolidated the per-gem `Gemfile`/`Gemfile.lock`/`Rakefile` into a single root-level `Gemfile`, and the mise migration (`#1798`/`#1799`) switched CI to `./.github/actions/mise-setup` + `./bin/setup`. **`release_gems.yml` was never updated** — it was last touched by `#1735`, before the consolidation.

It still ran `ruby/setup-ruby@v1` with `working-directory: tools/ruby-gems/<gem>` + `bundler-cache: true`, then `cd tools/ruby-gems/<gem> && bundle exec rake …`. Those per-gem Gemfiles no longer exist, so bundler walked up to the root `Gemfile.lock` whose gems were never installed → `Bundler::GemNotFound` for the entire root dependency set.

The `release:<gem>:prepare` tasks now live in `tools/ruby-gems/tasks.rake`, loaded by the **root** Rakefile and resolved against the **root** Gemfile, so they must run from the repo root.

## Fix

Aligned `release_gems.yml` with the working `gem_bump.yml` pattern:

- Replaced the `ruby/setup-ruby` step with `uses: ./.github/actions/mise-setup`.
- *Prepare gem staging directory* now runs from the repo root with `BUNDLE_GEMFILE=$PWD/Gemfile bundle exec rake release:<task>:prepare` (dropped the `cd tools/ruby-gems/<gem>`).

The later *Build gem*/*Push gem* steps were already repo-root-relative (`gen/<gen_dir>/…`) and are unchanged.

## Verification

`BUNDLE_GEMFILE=$PWD/Gemfile bundle exec rake release:idlc:prepare` run locally from repo root succeeds — `idlc gem release copy ready at gen/idlc_gem`, gemspec staged, Gemfile correctly stripped (the build step uses `BUNDLE_GEMFILE= gem build`, which needs no Gemfile).

## Note (not addressed here)

`schema-release.yml` still uses the old `ruby/setup-ruby`, and `regress.yml` mixes both patterns — worth a separate look if they reference the deleted per-gem Gemfiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)