### PR TITLE
fix: fixing 404 links (part 1)

### DIFF
--- a/backends/cfg_html_doc/adoc_gen.rake
+++ b/backends/cfg_html_doc/adoc_gen.rake
@@ -33,7 +33,7 @@ require "ruby-prof"
       end
     when "inst"
       cfg_arch.transitive_implemented_instructions.each do |inst|
-        path = dir_path / "#{inst.name}.adoc"
+        path = dir_path / "#{inst.name.sanitize}.adoc"
         Udb.logger.info "  Generating #{path}"
         # RubyProf.start
         File.write(path, Udb::Helpers::AntoraUtils.resolve_links(cfg_arch.convert_monospace_to_links(erb.result(binding))))

--- a/tools/ruby-gems/udb-gen/lib/udb-gen/generators/isa_explorer/js_xlsx_writer.rb
+++ b/tools/ruby-gems/udb-gen/lib/udb-gen/generators/isa_explorer/js_xlsx_writer.rb
@@ -74,7 +74,7 @@ module UdbGen
             urlPrefix = formatterParams.fetch(:urlPrefix)
             fp.write ", formatterParams:{\n"
             fp.write "      labelField:\"#{column_name}\",\n"
-            fp.write "      urlPrefix:\"#{urlPrefix}\"\n"
+            fp.write "      url: function(cell) { return \"#{urlPrefix}\" + cell.getValue().replace(/\\./g, \"_\"); }\n"
             fp.write "      }\n"
           end
           fp.write "    },\n"

--- a/tools/ruby-gems/udb-gen/lib/udb-gen/generators/manual/tasks.rake
+++ b/tools/ruby-gems/udb-gen/lib/udb-gen/generators/manual/tasks.rake
@@ -6,6 +6,14 @@
 
 require "digest"
 
+def sanitized_inst_lookup
+  Rake.application.instance_variable_get(:@sanitized_inst_lookup) ||
+    Rake.application.instance_variable_set(
+      :@sanitized_inst_lookup,
+      Rake.application.cfg_arch.instructions.each_with_object({}) { |i, h| h[i.name.sanitize] = i }
+    )
+end
+
 def versions_from_env(versions)
   manual_name = "isa"
   output_hash = nil
@@ -184,11 +192,11 @@ rule %r{#{Rake.application.gen_dir}/.*/.*/antora/modules/insts/pages/.*.adoc} =>
   __FILE__,
   (UdbGen.root / "templates" / "manual" / "instruction.adoc.erb").to_s
 ] do |t|
-  inst_name = File.basename(t.name, ".adoc")
+  inst_sanitized_name = File.basename(t.name, ".adoc")
 
   cfg_arch = Rake.application.cfg_arch
-  inst = cfg_arch.instruction(inst_name)
-  raise "Can't find instruction '#{inst_name}'" if inst.nil?
+  inst = sanitized_inst_lookup[inst_sanitized_name]
+  raise "Can't find instruction with sanitized name '#{inst_sanitized_name}'" if inst.nil?
 
   inst_template_path = UdbGen.root / "templates" / "manual" / "instruction.adoc.erb"
   erb = ERB.new(inst_template_path.read, trim_mode: "-")
@@ -406,7 +414,7 @@ namespace :gen do
 
       Udb.logger.info "Generating Instructions"
       version_obj.instructions.each do |inst|
-        Rake::Task[antora_path / "modules" / "insts" / "pages" / "#{inst.name}.adoc"].invoke
+        Rake::Task[antora_path / "modules" / "insts" / "pages" / "#{inst.name.sanitize}.adoc"].invoke
       end
 
       Udb.logger.info "Generating Extensions"

--- a/tools/ruby-gems/udb_helpers/test/test_backend_helpers.rb
+++ b/tools/ruby-gems/udb_helpers/test/test_backend_helpers.rb
@@ -133,6 +133,7 @@ class TestAntoraUtils < Minitest::Test
   def test_resolve_links_inst
     assert_equal("xref:insts:foo.adoc#udb:doc:inst:foo[bar]", AntoraUtils.resolve_links("%%UDB_DOC_LINK%inst;foo;bar%%"))
     assert_equal("xref:insts:foo.adoc#udb:doc:inst:foo[foo]", AntoraUtils.resolve_links(link_to_udb_doc_inst("foo")))
+    assert_equal("xref:insts:fo_o.adoc#udb:doc:inst:fo_o[fo.o]", AntoraUtils.resolve_links(link_to_udb_doc_inst("fo.o")))
   end
 
   def test_resolve_links_csr


### PR DESCRIPTION
Fixes 404 errors of #1173 

Dotted names (e.g. c.ld) must use the sanitized name (c_ld) in the file path so Antora can resolve the xref and GitHub Pages can serve the resulting HTML page. Memoized per Rake application

Tried locally: 
<img width="1152" height="559" alt="image" src="https://github.com/user-attachments/assets/5c95c6ab-7be6-4f51-9fc1-1f39c5b4ce84" />

