### PR TITLE
fix(WFI/WRS): fixing raise an exception before waiting issue #1731

### DIFF
--- a/backends/cpp_hart_gen/cpp/include/udb/hart.hpp
+++ b/backends/cpp_hart_gen/cpp/include/udb/hart.hpp
@@ -124,12 +124,18 @@ namespace udb {
       throw AbortInstruction();
     }
 
-    void wfi() {
-      throw WfiException();
+    bool wfi(bool tw_trap, bool vtw_trap) {
+      //No timeout handling yet
+      if(!tw_trap && !vtw_trap)
+        throw WfiException();
+
+      return false;
     }
 
-    void wrs_nto() {
+    bool wrs_nto(bool tw_trap, bool vtw_trap) {
       // no-op: a valid implementation per the Zawrs spec
+      //No timeout handling yet
+      return false;
     }
 
     void wrs_sto() {

--- a/spec/std/isa/inst/I/wfi.yaml
+++ b/spec/std/isa/inst/I/wfi.yaml
@@ -92,26 +92,34 @@ access_detail: |
 
   <%- end -%>
 operation(): |
-  # first, perform all the access checks
+  Boolean tw_trap = false;
+  Boolean vtw_trap = false;
+
+  # U-mode always causes an illegal-instruction trap on timeout
   if (mode() == PrivilegeMode::U) {
-    raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
-  }
-  if ((CSR[misa].S == 1) && (CSR[mstatus].TW == 1'b1)) {
-    if (mode() != PrivilegeMode::M) {
-      raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
-    }
-  }
-  if (CSR[misa].H == 1) {
+    tw_trap = true;
+  } else if ((CSR[misa].S == 1) && (CSR[mstatus].TW == 1'b1) && (mode() != PrivilegeMode::M)) {
+    # TW=1: any non-M mode traps with illegal-instruction on timeout
+    tw_trap = true;
+  } else if (CSR[misa].H == 1) {
+    # TW=0 with H extension: VU always traps virtually; VS traps virtually when VTW=1
     if (CSR[hstatus].VTW == 1'b0) {
       if (mode() == PrivilegeMode::VU) {
-        raise (ExceptionCode::VirtualInstruction, mode(), $encoding);
+        vtw_trap = true;
       }
-    } else if (CSR[hstatus].VTW == 1'b1) {
+    } else {
       if ((mode() == PrivilegeMode::VS) || (mode() == PrivilegeMode::VU)) {
-        raise (ExceptionCode::VirtualInstruction, mode(), $encoding);
+        vtw_trap = true;
       }
     }
   }
 
-  # passed, so now do the wait
-  wfi();
+  # Wait, then raise only if the implementation-specific timeout expired
+  Boolean timed_out = wfi(tw_trap, vtw_trap);
+  if (timed_out) {
+    if (tw_trap) {
+      raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    } else {
+      raise (ExceptionCode::VirtualInstruction, mode(), $encoding);
+    }
+  }

--- a/spec/std/isa/inst/Zawrs/wrs.nto.yaml
+++ b/spec/std/isa/inst/Zawrs/wrs.nto.yaml
@@ -53,25 +53,29 @@ access:
   vu: always
 data_independent_timing: false
 operation(): |
-  # wrs.nto follows TW/VTW trap rules similar to WFI, but unlike WFI it
-  # does NOT cause an illegal instruction exception in U-mode when TW=0.
+  Boolean tw_trap = false;
+  Boolean vtw_trap = false;
 
-  # When TW=1, any mode other than M traps with IllegalInstruction
-  if ((CSR[misa].S == 1) && (CSR[mstatus].TW == 1'b1)) {
-    if (mode() != PrivilegeMode::M) {
-      raise(ExceptionCode::IllegalInstruction, mode(), $encoding);
-    }
-  }
-
-  # When H extension is present, TW=0, and VTW=1, VS/VU mode traps
-  # with VirtualInstruction. Unlike WFI, VU does NOT trap when VTW=0.
-  if (CSR[misa].H == 1) {
+  # Unlike WFI, U-mode does NOT trap when TW=0
+  if ((CSR[misa].S == 1) && (CSR[mstatus].TW == 1'b1) && (mode() != PrivilegeMode::M)) {
+    # TW=1: any non-M mode traps with illegal-instruction on timeout
+    tw_trap = true;
+  } else if (CSR[misa].H == 1) {
+    # TW=0, VTW=1: VS/VU mode traps with virtual-instruction on timeout
+    # Unlike WFI, VU does NOT trap when VTW=0
     if ((CSR[mstatus].TW == 1'b0) && (CSR[hstatus].VTW == 1'b1)) {
       if ((mode() == PrivilegeMode::VS) || (mode() == PrivilegeMode::VU)) {
-        raise(ExceptionCode::VirtualInstruction, mode(), $encoding);
+        vtw_trap = true;
       }
     }
   }
 
-  # stall while the reservation set is valid and no interrupt is pending
-  wrs_nto();
+  # Wait, then raise only if the implementation-specific timeout expired
+  Boolean timed_out = wrs_nto(tw_trap, vtw_trap);
+  if (timed_out) {
+    if (tw_trap) {
+      raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
+    } else {
+      raise (ExceptionCode::VirtualInstruction, mode(), $encoding);
+    }
+  }

--- a/spec/std/isa/isa/builtin_functions.idl
+++ b/spec/std/isa/isa/builtin_functions.idl
@@ -524,23 +524,42 @@ builtin function write_physical_memory_64 {
 }
 
 builtin function wfi {
+  returns Boolean
+  arguments
+    Boolean tw_trap,   #< true if an illegal-instruction trap applies on timeout
+    Boolean vtw_trap   #< true if a virtual-instruction trap applies on timeout
   description {
-    Wait-for-interrupt: hint that the processor
-    should enter a low power state until the next interrupt.
+    Wait-for-interrupt with bounded-timeout enforcement when trap conditions apply.
 
-    A valid implementation is a no-op.
+    When tw_trap or vtw_trap is true, the implementation must wait for at most an
+    implementation-specific bounded time before returning true (timed out). The time
+    limit may be zero, in which case the function returns true immediately.
+
+    When neither trap condition applies, the implementation waits indefinitely for an
+    interrupt and either does not return (implementation may signal via exception) or
+    returns false.
 
     The model will advance the PC; this function does not need to.
   }
 }
 
 builtin function wrs_nto {
+  returns Boolean
+  arguments
+    Boolean tw_trap,   #< true if an illegal-instruction trap applies on timeout
+    Boolean vtw_trap   #< true if a virtual-instruction trap applies on timeout
   description {
-    Wait-on-reservation-set with no timeout: hint that the processor
-    should enter a low power state until the reservation set is invalidated
-    or an interrupt is pending.
+    Wait-on-reservation-set with no timeout, with bounded-timeout enforcement when
+    trap conditions apply.
 
-    A valid implementation is a no-op.
+    When tw_trap or vtw_trap is true, the implementation must wait for at most an
+    implementation-specific bounded time before returning true (timed out). The time
+    limit may be zero, in which case the function returns true immediately.
+
+    When neither trap condition applies, the implementation waits indefinitely until
+    the reservation set is invalidated or an interrupt is pending, then returns false.
+
+    A valid implementation is a no-op (return false).
 
     The model will advance the PC; this function does not need to.
   }


### PR DESCRIPTION
Addresses https://github.com/riscv/riscv-unified-db/issues/1731 as stated originally in the issue:

> A possible implementation is to pass required architectural state into the builtin(s) as new parameters, so that the builtins can perform a wait for a configuration-specific (parameterized) time and provide a new return value indicating whether the wait was "successful", or an exception should be thrown.

