### PR TITLE
feat(Xqccmi): precise trap semantics and resume mechanism (v0.2.0)

### DIFF
--- a/cfgs/qc_iu.yaml
+++ b/cfgs/qc_iu.yaml
@@ -23,7 +23,7 @@ implemented_extensions:
   - { name: Zihpm, version: "= 2.0" }
   - { name: Xqccmp, version: "= 0.3" }
   - { name: Xqccmt, version: "= 0.1.0" }
-  - { name: Xqccmi, version: "= 0.1.0" }
+  - { name: Xqccmi, version: "= 0.2.0" }
   - { name: Xqci, version: "= 0.13" }
   - { name: Xqcia, version: "= 0.7.0" }
   - { name: Xqciac, version: "= 0.3.0" }

--- a/spec/custom/isa/qc_iu/ext/Xqccmi.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqccmi.yaml
@@ -24,9 +24,8 @@ description: |
 
   `qc.cm.ilut` is a 16-bit instruction that takes an 11-bit immediate index
   (range 0..2047) into the ILUT. The ILUT base address is held in the `qc.itba`
-  CSR (address 0x800). The hardware computes the byte offset of the addressed
-  entry from the base address, fetches the entry, parses the packed instructions
-  within it, and executes them in order.
+  CSR (address 0x800). The instruction architecturally behaves as the
+  sub-instruction(s) stored at the addressed ILUT entry, executed in order.
 
   ILUT memory is treated as instruction memory. It requires execute (X)
   permission and does NOT require read (R) permission. A `fence.i` instruction
@@ -80,9 +79,9 @@ description: |
 
   === Dual-Instruction Packing
 
-  Each ILUT entry may contain one or two instructions packed together. The
-  hardware determines instruction sizes by parsing bits[1:0] of each
-  sub-instruction after fetching the full entry.
+  Each ILUT entry may contain one or two instructions packed together.
+  Instruction sizes are determined by the standard RISC-V instruction-length
+  encoding (bits[1:0] of each sub-instruction).
 
   ==== 32-bit Entry Valid Combinations
 
@@ -110,14 +109,15 @@ description: |
 
   Unused bits in any entry MUST be padded with `c.nop` (16'h0001). Instruction
   combinations that do not fit within the entry size cause an illegal instruction
-  exception. Hardware determines instruction sizes by parsing bits[1:0] of each
-  sub-instruction after fetching the full entry.
+  exception. Instruction sizes are determined by the standard RISC-V
+  instruction-length encoding (bits[1:0] of each sub-instruction).
 
   === Instruction Restrictions
 
   Any instruction that references PC as an input or output is NOT permitted
-  in the ILUT. Hardware detects such instructions during decode and raises an
-  illegal instruction exception before any instruction in the entry executes.
+  in the ILUT. If any such instruction is present in the entry, an
+  IllegalInstruction exception is raised before any sub-instruction in the
+  entry takes architectural effect.
 
   Forbidden instructions fall into three categories:
 
@@ -147,36 +147,44 @@ description: |
 
   === Execution Model
 
-  Logically, the PC points to the `qc.cm.ilut` instruction throughout the
-  execution of all instructions contained within the fetched entry. The
-  instructions within an entry execute as if they were a single atomic unit from
-  the perspective of interrupt handling:
+  The PC points to the `qc.cm.ilut` instruction throughout the execution of all
+  sub-instructions contained within the fetched ILUT entry. Sub-instructions
+  execute sequentially and independently:
 
-  * Interrupts cannot be taken between two instructions of the same entry once
-    the first instruction has committed.
-  * If the first instruction has not yet committed when an interrupt arrives, the
-    interrupt is taken with mepc set to the PC of `qc.cm.ilut`.
-  * If the first instruction has already committed when an interrupt arrives, the
-    interrupt is serviced after the second instruction commits, with mepc pointing
-    to the next instruction after `qc.cm.ilut`.
+  * The architectural state changes produced by the first sub-instruction are
+    visible to the second sub-instruction and to any subsequent trap handler.
+  * Each sub-instruction can trap independently; traps are taken precisely at the
+    sub-instruction that caused them, not deferred.
+  * After the final sub-instruction completes, the PC advances past `qc.cm.ilut`
+    normally.
 
   === Exception Handling
 
-  On any exception caused by an instruction fetched from the ILUT:
+  On any trap (exception, interrupt, NMI, or double-trap) occurring during the
+  execution of a sub-instruction fetched from the ILUT:
 
   * mepc (or mnepc for a double-trap) is set to the PC of `qc.cm.ilut`.
-  * Bit 0 of mepc/mnepc is set to 0 if the first instruction in the entry caused
-    the exception.
-  * Bit 0 of mepc/mnepc is set to 1 if the second instruction in the entry caused
-    the exception.
+  * Bit 0 of mepc/mnepc encodes which sub-instruction was executing when the trap
+    occurred:
+  ** Bit 0 = 0: the trap occurred during the first (or only) sub-instruction.
+  ** Bit 0 = 1: the trap occurred during the second sub-instruction (the
+     architectural effects of the first sub-instruction are already visible).
 
-  Bit 0 of mepc/mnepc is writable to 0 only; software cannot set it to 1.
-  Return-from-trap instructions (`mret`, `mnret`, `qc.c.mret`, `qc.c.mnret`,
-  `qc.c.mileaveret`) leave bit 0 of mepc/mnepc unchanged when returning.
+  On trap return (`mret`, `qc.c.mret`, `qc.c.mnret`, `qc.c.mileaveret`), $pc is
+  restored directly from mepc/mnepc including bit 0:
+
+  * If bit 0 = 0: `qc.cm.ilut` re-executes from the beginning, running both
+    sub-instructions.
+  * If bit 0 = 1: `qc.cm.ilut` skips the first sub-instruction and executes only
+    the second.
+
+  Bit 0 of mepc/mnepc is readable and writable in this architecture.
+  Software may explicitly set bit 0 to 1 to force resumption from the second
+  sub-instruction.
 
   NOTE: This is an architectural exception to the standard RISC-V requirement
-  that *epc bit 0 is always zero. The non-zero bit 0 encodes which instruction
-  within the ILUT entry caused the exception, enabling precise exception restart.
+  that *epc bit 0 is always zero. The non-zero bit 0 encodes which sub-instruction
+  within the ILUT entry was interrupted, enabling precise trap restart.
 
   === Encoding
 
@@ -226,6 +234,49 @@ versions:
     - Initial version. Custom instruction lookup table extension with dual-instruction
       packing and 64-bit double entries. Supports 16-bit, 32-bit, and 48-bit instructions
       in the ILUT. Introduces qc.itba and qc.itdec CSRs.
+  requirements:
+    allOf:
+      - extension:
+          name: Zca
+          version: ">= 1.0.0"
+      - extension:
+          name: Zicsr
+          version: ">= 2.0.0"
+      - not:
+          extension:
+            name: Zcd
+- version: "0.2.0"
+  state: development
+  contributors:
+  - name: Albert Yosher
+    company: Qualcomm Technologies, Inc.
+    email: ayosher@qti.qualcomm.com
+  - name: Derek Hower
+    company: Qualcomm Technologies, Inc.
+    email: dhower@qti.qualcomm.com
+  - name: Gil Zukerman
+    company: Qualcomm Technologies, Inc.
+    email: gzukerma@qti.qualcomm.com
+  changes:
+    - >-
+      Precise trap semantics: each sub-instruction in an ILUT entry can now trap
+      independently. Traps are taken immediately at the faulting sub-instruction
+      rather than being deferred.
+    - >-
+      Resume mechanism: bit 0 of mepc/mnepc encodes which sub-instruction caused
+      the trap. On trap return, qc.cm.ilut re-enters with PC bit 0 reflecting this
+      value; if set, the first sub-instruction is skipped and only the second is
+      re-executed.
+    - >-
+      mepc/mnepc bit 0 is readable and writable in this architecture.
+      Software may set bit 0 to 1 to force resumption from the second sub-instruction.
+    - >-
+      Expanded ILUT instruction restrictions to all PC-referencing instructions:
+      added register-indirect jumps (jalr, c.jr, c.jalr) and return instructions
+      (cm.popret, cm.popretz, qc.cm.popret, qc.cm.popretz) to the forbidden list.
+    - >-
+      Spec language audit: removed all implementation-implying language; descriptions
+      now define architectural behavior only.
   requirements:
     allOf:
       - extension:

--- a/spec/custom/isa/qc_iu/ext/Xqccmi.yaml
+++ b/spec/custom/isa/qc_iu/ext/Xqccmi.yaml
@@ -115,15 +115,35 @@ description: |
 
   === Instruction Restrictions
 
-  PC-relative instructions are NOT permitted in the ILUT. This includes:
+  Any instruction that references PC as an input or output is NOT permitted
+  in the ILUT. Hardware detects such instructions during decode and raises an
+  illegal instruction exception before any instruction in the entry executes.
 
-  * `auipc`
-  * All branch instructions (beq, bne, blt, bge, bltu, bgeu, c.beqz, c.bnez, etc.)
-  * All jump instructions (jal, jalr, c.j, c.jal, c.jr, c.jalr, etc.)
+  Forbidden instructions fall into three categories:
 
-  If a PC-relative instruction is fetched from the ILUT, an illegal instruction
-  exception is raised. 16-bit compressed instructions (bits[1:0] != 2'b11) are
-  otherwise valid in ILUT entries.
+  * *PC-relative instructions* (read PC as input):
+  ** `auipc`
+  ** All branch instructions (`beq`, `bne`, `blt`, `bge`, `bltu`, `bgeu`,
+     `c.beqz`, `c.bnez`, etc.)
+  ** PC-relative jump instructions (`jal`, `c.j`, `c.jal`)
+
+  * *Register-indirect jumps* (write PC as output):
+  ** `jalr`
+  ** `c.jr`
+  ** `c.jalr`
+
+  * *Return instructions* (write PC as output):
+  ** `cm.popret`
+  ** `cm.popretz`
+  ** `qc.cm.popret`
+  ** `qc.cm.popretz`
+
+  The following push/pop instructions are explicitly *allowed* in ILUT entries
+  because they do not reference PC:
+  `cm.push`, `cm.pop`, `qc.cm.push`, `qc.cm.pushfp`, `qc.cm.pop`.
+
+  16-bit compressed instructions (bits[1:0] != 2'b11) are otherwise valid
+  in ILUT entries.
 
   === Execution Model
 

--- a/spec/custom/isa/qc_iu/inst/Xqccmi/qc.cm.ilut.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmi/qc.cm.ilut.yaml
@@ -127,4 +127,10 @@ operation(): |
       CSR[mepc].PC = real_pc | 32'b1;
     }
     execute_instruction(second_inst);
+    # Restore mepc/mnepc bit 0 to 0 after successful completion
+    if (implemented?(ExtensionName::Smrnmi) && CSR[mnstatus].NMIE == 1'b0) {
+      CSR[mnepc].PC = real_pc;
+    } else {
+      CSR[mepc].PC = real_pc;
+    }
   }

--- a/spec/custom/isa/qc_iu/inst/Xqccmi/qc.cm.ilut.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmi/qc.cm.ilut.yaml
@@ -24,9 +24,13 @@ description: |
   If bits remain after the first instruction and the next 16 bits are not
   `c.nop` (16'h0001), a second instruction is present and is also executed.
 
-  PC-relative instructions (`auipc`, branches, and jumps) are not permitted
-  inside ILUT entries. Hardware detects such instructions during decode and
-  raises an IllegalInstruction exception.
+  Any instruction that references PC as an input or output is not permitted
+  inside ILUT entries. This includes: PC-relative instructions (`auipc`,
+  branches, `jal`, `c.j`, `c.jal`, `c.beqz`, `c.bnez`); register-indirect
+  jumps that write PC (`jalr`, `c.jr`, `c.jalr`); and return instructions
+  that write PC (`cm.popret`, `cm.popretz`, `qc.cm.popret`, `qc.cm.popretz`).
+  Hardware detects such instructions during decode and raises an
+  IllegalInstruction exception before any instruction in the entry executes.
 
   On an exception caused by the second instruction, hardware sets bit 0 of
   `mepc` to indicate that the fault originated from the second instruction
@@ -117,11 +121,13 @@ operation(): |
     # No room for a second instruction after a 48-bit first in a 64-bit entry
   }
 
-  # PC-relative instruction check:
-  # Hardware detects auipc, branches, and jump instructions during decode
-  # and raises an IllegalInstruction exception before any instruction executes.
+  # PC-referencing instruction check:
+  # Hardware detects any instruction that references PC as input or output
+  # (auipc, branches, jal/c.j/c.jal, jalr/c.jr/c.jalr, cm.popret,
+  # cm.popretz, qc.cm.popret, qc.cm.popretz) during decode and raises an
+  # IllegalInstruction exception before any instruction executes.
   # mepc bit 0 reflects which slot contained the forbidden instruction.
-  if (is_pc_relative_inst?(entry_lo)) {
+  if (is_pc_referencing_inst?(entry_lo)) {
     executing_second_inst = false;
     raise_ilut(ExceptionCode::IllegalInstruction, $encoding);
   }
@@ -132,7 +138,7 @@ operation(): |
     } else {
       second_inst = {16'b0, entry_hi[15:0]};
     }
-    if (is_pc_relative_inst?(second_inst)) {
+    if (is_pc_referencing_inst?(second_inst)) {
       executing_second_inst = true;
       raise_ilut(ExceptionCode::IllegalInstruction, $encoding);
     }

--- a/spec/custom/isa/qc_iu/inst/Xqccmi/qc.cm.ilut.yaml
+++ b/spec/custom/isa/qc_iu/inst/Xqccmi/qc.cm.ilut.yaml
@@ -29,12 +29,19 @@ description: |
   branches, `jal`, `c.j`, `c.jal`, `c.beqz`, `c.bnez`); register-indirect
   jumps that write PC (`jalr`, `c.jr`, `c.jalr`); and return instructions
   that write PC (`cm.popret`, `cm.popretz`, `qc.cm.popret`, `qc.cm.popretz`).
-  Hardware detects such instructions during decode and raises an
-  IllegalInstruction exception before any instruction in the entry executes.
+  If any such instruction is present in the entry, an IllegalInstruction
+  exception is raised before any sub-instruction in the entry takes
+  architectural effect.
 
-  On an exception caused by the second instruction, hardware sets bit 0 of
-  `mepc` to indicate that the fault originated from the second instruction
-  within the entry.
+  When a trap (exception, interrupt, NMI, or double-trap) occurs during
+  execution of a `qc.cm.ilut` entry, `mepc`/`mnepc` is set to the PC of
+  `qc.cm.ilut` with bit 0 encoding which sub-instruction caused the trap:
+  bit 0 = 0 means the trap came from the first (or only) instruction;
+  bit 0 = 1 means the trap came from the second instruction (the architectural
+  effects of the first sub-instruction are already visible). When `qc.cm.ilut` is re-entered with PC bit 0 = 1,
+  it skips the first instruction and executes only the second. This applies
+  uniformly to all trap types including exceptions, interrupts, NMIs, and
+  double-traps.
 
   See the Xqccmi extension description for full details on entry layout,
   dual-instruction packing, exception handling, and restrictions.
@@ -53,10 +60,10 @@ access:
   vs: always
   vu: always
 operation(): |
-  # Read the double-entry count (N = number of 64-bit double entries)
-  XReg N = {21'b0, CSR[qc.itdec].dec};
+  XReg real_pc = $pc & ~32'b1;
+  Boolean resuming_second = ($pc[0:0] == 1'b1);
 
-  # Compute the byte address of the ILUT entry
+  XReg N = {21'b0, CSR[qc.itdec].dec};
   XReg base_addr = CSR[qc.itba].base << 6;
   XReg entry_addr;
   Boolean is_double;
@@ -69,91 +76,55 @@ operation(): |
     is_double = false;
   }
 
-  # Translate the entry address (instruction fetch)
   TranslationResult result;
   if (CSR[misa].S == 1) {
     result = translate(entry_addr, MemoryOperation::Fetch, mode(), $encoding);
   } else {
     result.paddr = entry_addr;
   }
-
-  # Access check for instruction fetch
   access_check(result.paddr, is_double ? 8 : 4, $pc, MemoryOperation::Fetch, ExceptionCode::InstructionAccessFault, mode());
 
-  # Read the entry from physical memory.
-  # For a 32-bit entry, read 32 bits. For a 64-bit double entry, read two
-  # consecutive 32-bit words (entry_lo = bits[31:0], entry_hi = bits[63:32]).
   XReg entry_lo = read_physical_memory(32, result.paddr);
-  XReg entry_hi = 32'b0;
-  if (is_double) {
-    entry_hi = read_physical_memory(32, result.paddr + 4);
-  }
+  XReg entry_hi = is_double ? read_physical_memory(32, result.paddr + 4) : 32'b0;
 
-  # Determine the size of the first instruction using RISC-V length encoding:
-  #   bits[1:0] != 2'b11 -> 16-bit instruction
-  #   bits[1:0] == 2'b11 and bits[4:2] != 3'b111 -> 32-bit instruction
-  #   bits[1:0] == 2'b11 and bits[4:2] == 3'b111 -> 48-bit instruction
-  Boolean has_second_inst = false; # true if this entry contains a second packed instruction
-
+  Boolean has_second_inst = false; # true if entry contains a second packed instruction
   if (entry_lo[1:0] != 2'b11) {
-    # 16-bit first instruction; second instruction is in entry_lo[31:16]
-    Bits<16> second_lo = entry_lo[31:16];
-    if (second_lo != 16'h0001) {
-      has_second_inst = true;
-    }
+    if (entry_lo[31:16] != 16'h0001) { has_second_inst = true; }
   } else if (entry_lo[4:2] != 3'b111) {
-    # 32-bit first instruction
-    if (is_double) {
-      # Second instruction starts at entry_hi[15:0]
-      Bits<16> second_lo = entry_hi[15:0];
-      if (second_lo != 16'h0001) {
-        has_second_inst = true;
-      }
-    }
-    # No room for a second instruction in a 32-bit entry after a 32-bit first
+    if (is_double && entry_hi[15:0] != 16'h0001) { has_second_inst = true; }
   } else {
-    # 48-bit first instruction
-    if (!is_double) {
-      # 48-bit instruction does not fit in a 32-bit entry
-      executing_second_inst = false;
-      raise_ilut(ExceptionCode::IllegalInstruction, $encoding);
-    }
-    # No room for a second instruction after a 48-bit first in a 64-bit entry
+    if (!is_double) { raise_ilut(ExceptionCode::IllegalInstruction, $encoding); }
   }
 
-  # PC-referencing instruction check:
-  # Hardware detects any instruction that references PC as input or output
-  # (auipc, branches, jal/c.j/c.jal, jalr/c.jr/c.jalr, cm.popret,
-  # cm.popretz, qc.cm.popret, qc.cm.popretz) during decode and raises an
-  # IllegalInstruction exception before any instruction executes.
-  # mepc bit 0 reflects which slot contained the forbidden instruction.
   if (is_pc_referencing_inst?(entry_lo)) {
     executing_second_inst = false;
     raise_ilut(ExceptionCode::IllegalInstruction, $encoding);
   }
   if (has_second_inst) {
-    Bits<32> second_inst;
-    if (entry_lo[1:0] != 2'b11) {
-      second_inst = {16'b0, entry_lo[31:16]};
-    } else {
-      second_inst = {16'b0, entry_hi[15:0]};
-    }
+    Bits<32> second_inst = (entry_lo[1:0] != 2'b11) ? {16'b0, entry_lo[31:16]} : {16'b0, entry_hi[15:0]};
     if (is_pc_referencing_inst?(second_inst)) {
       executing_second_inst = true;
       raise_ilut(ExceptionCode::IllegalInstruction, $encoding);
     }
   }
 
-  # Execute the first instruction from the ILUT entry.
-  # IDL cannot express dynamic instruction dispatch; actual execution is implementation-defined.
-  # Any exception raised must call raise_ilut() with executing_second_inst = false (mepc bit 0 = 0).
-  executing_second_inst = false;
-  unpredictable("TO-DO: execute first ILUT instruction");
+  # Execute first instruction (skip if resuming after second-slot trap)
+  if (!resuming_second) {
+    if (implemented?(ExtensionName::Smrnmi) && CSR[mnstatus].NMIE == 1'b0) {
+      CSR[mnepc].PC = real_pc;
+    } else {
+      CSR[mepc].PC = real_pc;
+    }
+    execute_instruction(entry_lo);
+  }
 
-  # Execute the second instruction from the ILUT entry, if present.
-  # Any exception raised must call raise_ilut() with executing_second_inst = true (mepc bit 0 = 1).
+  # Execute second instruction if present
   if (has_second_inst) {
-    executing_second_inst = true;
-    unpredictable("TO-DO: execute second ILUT instruction");
-    executing_second_inst = false;
+    Bits<32> second_inst = (entry_lo[1:0] != 2'b11) ? {16'b0, entry_lo[31:16]} : {16'b0, entry_hi[15:0]};
+    if (implemented?(ExtensionName::Smrnmi) && CSR[mnstatus].NMIE == 1'b0) {
+      CSR[mnepc].PC = real_pc | 32'b1;
+    } else {
+      CSR[mepc].PC = real_pc | 32'b1;
+    }
+    execute_instruction(second_inst);
   }

--- a/spec/custom/isa/qc_iu/isa/globals.isa
+++ b/spec/custom/isa/qc_iu/isa/globals.isa
@@ -103,14 +103,15 @@ function raise_ilut {
   }
 }
 
-function is_pc_relative_inst? {
+function is_pc_referencing_inst? {
   returns Boolean
   arguments Bits<32> inst
   description {
-    Returns true if +inst+ is a PC-relative instruction (auipc, branch, jump, or
-    compressed PC-relative jump (jal/c.j/c.jal), or compressed branch) that is
-    forbidden inside an ILUT entry. Register-indirect jumps (jalr, c.jr, c.jalr)
-    are NOT PC-relative and are permitted inside ILUT entries.
+    Returns true if +inst+ references PC as an input or output, making it
+    forbidden inside an ILUT entry. This covers three categories:
+    (1) PC-relative instructions: auipc, branches, jal, c.j, c.jal, c.beqz, c.bnez;
+    (2) register-indirect jumps that write PC: jalr, c.jr, c.jalr;
+    (3) return instructions that write PC: cm.popret, cm.popretz, qc.cm.popret, qc.cm.popretz.
     For 16-bit compressed instructions, only the lower 16 bits of +inst+ are examined.
     For 48-bit Xqci instructions, only the lower 32 bits are passed here (the upper
     16 bits are in a separate word and are not needed for this check).
@@ -135,6 +136,22 @@ function is_pc_relative_inst? {
       if (cinst[15:13] == 3'b111 && cinst[1:0] == 2'b01) {
         return true;
       }
+      # c.jr:   bits[15:12]=1000, bits[6:2]!=00000, bits[1:0]=10 (register jump, writes PC)
+      if (cinst[15:12] == 4'b1000 && cinst[6:2] != 5'b00000 && cinst[1:0] == 2'b10) {
+        return true;
+      }
+      # c.jalr: bits[15:12]=1001, bits[6:2]!=00000, bits[1:0]=10 (register jump-and-link, writes PC)
+      if (cinst[15:12] == 4'b1001 && cinst[6:2] != 5'b00000 && cinst[1:0] == 2'b10) {
+        return true;
+      }
+      # cm.popret / qc.cm.popret: bits[15:8]=10111110, bits[1:0]=10 (pops stack and returns, writes PC)
+      if (cinst[15:8] == 8'b10111110 && cinst[1:0] == 2'b10) {
+        return true;
+      }
+      # cm.popretz / qc.cm.popretz: bits[15:8]=10111100, bits[1:0]=10 (pops stack, zeroes a0, returns, writes PC)
+      if (cinst[15:8] == 8'b10111100 && cinst[1:0] == 2'b10) {
+        return true;
+      }
       return false;
     } else {
       # 32-bit (or 48-bit) instruction: check opcode field bits[6:0]
@@ -145,6 +162,11 @@ function is_pc_relative_inst? {
       }
       # jal
       if (opcode == 7'b1101111) {
+        return true;
+      }
+      # jalr: register-indirect jump, writes PC
+      # (grouped with PC-referencing instructions, not PC-relative)
+      if (opcode == 7'b1100111) {
         return true;
       }
       # branches


### PR DESCRIPTION
feat(Xqccmi): precise trap semantics and resume mechanism (v0.2.0)
Introduce precise per-sub-instruction trap handling for qc.cm.ilut,
replacing the v0.1.0 deferred/atomic-unit model.

Trap semantics:
- Each sub-instruction in an ILUT entry can trap independently.
  Traps are taken immediately at the faulting sub-instruction, not
  deferred until the entry completes.
- Before executing the first sub-instruction, mepc/mnepc.PC is set
  to the PC of qc.cm.ilut with bit 0 = 0.
- Before executing the second sub-instruction, mepc/mnepc.PC is set
  to the PC of qc.cm.ilut with bit 0 = 1.
- The Smrnmi double-trap condition is checked before each sub-
  instruction to select mepc vs mnepc correctly.

Resume mechanism:
- Bit 0 of mepc/mnepc encodes which sub-instruction caused the trap:
  0 = first (or only), 1 = second (first already took effect).
- On trap return, $pc is restored from mepc/mnepc including bit 0.
- When qc.cm.ilut is re-entered with $pc[0] = 1, it skips the first
  sub-instruction and executes only the second.
- Bit 0 of mepc/mnepc is readable and writable in this architecture.
  Software may set bit 0 to 1 to force resumption from the second
  sub-instruction.
- Applies uniformly to all trap types: exceptions, interrupts, NMIs,
  and double-traps.

Additional changes:
- Expanded ILUT instruction restrictions to all PC-referencing
  instructions: register-indirect jumps (jalr, c.jr, c.jalr) and
  return instructions (cm.popret, cm.popretz, qc.cm.popret,
  qc.cm.popretz) added to the forbidden list.
- Spec language audit: removed all implementation-implying language
  (e.g., "fetches", "parses", "commits", "during decode"); all
  descriptions now define architectural behavior only.
- Bumped Xqccmi to version 0.2.0 in Xqccmi.yaml and cfgs/qc_iu.yaml.

Files modified:
- spec/custom/isa/qc_iu/ext/Xqccmi.yaml
- spec/custom/isa/qc_iu/inst/Xqccmi/qc.cm.ilut.yaml
- cfgs/qc_iu.yaml


fix(Xqccmi): expand ILUT instruction restrictions to all PC-referencing instructions
The ILUT forbidden instruction rule is clarified: any instruction that
references PC as an input or output is forbidden, not just PC-relative
instructions. This adds three new categories to the restriction:

- Register-indirect jumps that write PC: jalr, c.jr, c.jalr
- Return instructions that write PC: cm.popret, cm.popretz,
  qc.cm.popret, qc.cm.popretz

Push/pop instructions (cm.push, cm.pop, qc.cm.push, qc.cm.pushfp,
qc.cm.pop) are explicitly allowed as they do not reference PC.

Changes:
- globals.isa: rename is_pc_relative_inst?() to is_pc_referencing_inst?();
  add detection for c.jr, c.jalr, jalr, cm.popret/popretz,
  qc.cm.popret/popretz; update description
- qc.cm.ilut.yaml: update call sites and description to reflect new rule
- Xqccmi.yaml: rewrite Instruction Restrictions section with three
  explicit forbidden categories and an explicit allowlist
