### PR TITLE
fix(LPE): Add LPE definition to yaml files

### DIFF
--- a/spec/std/isa/csr/H/henvcfg.yaml
+++ b/spec/std/isa/csr/H/henvcfg.yaml
@@ -289,6 +289,27 @@ fields:
         return 0;
       }
       return csr_value.SSE;
+  LPE:
+    location: 2
+    description: |
+      *Landing Pad Enable*
+
+      When the LPE field is set to 1, the Zicfilp extension is enabled in
+      VS-mode. When the LPE field is 0, the Zicfilp extension is not enabled
+      in VS-mode and the following rules apply to VS-mode:
+
+        * The hart does not update the `ELP` state; it remains as `NO_LP_EXPECTED`.
+        * The `LPAD` instruction operates as a no-op.
+    definedBy:
+      extension:
+        name: Zicfilp
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      if (CSR[menvcfg].LPE == 0){
+        return 0;
+      }
+      return csr_value.LPE;
   FIOM:
     location: 0
     description: |
@@ -335,5 +356,9 @@ sw_read(): |
   if (implemented?(ExtensionName::Zicfiss) && CSR[menvcfg].SSE == 0) {
     # henvcfg.SSE must read-as-zero
     value = value & ~(1 `<< 3);
+  }
+  if (implemented?(ExtensionName::Zicfilp) && CSR[menvcfg].LPE == 0) {
+    # henvcfg.LPE must read-as-zero
+    value = value & ~(1 `<< 2);
   }
   return value;

--- a/spec/std/isa/csr/menvcfg.yaml
+++ b/spec/std/isa/csr/menvcfg.yaml
@@ -296,6 +296,26 @@ fields:
         name: Zicfiss
     type: RW
     reset_value: UNDEFINED_LEGAL
+  LPE:
+    location: 2
+    description: |
+      *Landing Pad Enable*
+
+      When the LPE field is set to 1 and S-mode is implemented, the Zicfilp
+      extension is enabled in S-mode. If the LPE field is set to 1 and S-mode
+      is not implemented, the Zicfilp extension is enabled in U-mode. When the
+      LPE field is 0, the Zicfilp extension is not enabled in S-mode (or U-mode
+      if S-mode is not implemented), and the following rules apply:
+
+        * The hart does not update the `ELP` state; it remains as `NO_LP_EXPECTED`.
+        * The `LPAD` instruction operates as a no-op.
+
+      When `menvcfg.LPE` is 0, `henvcfg.LPE` and `senvcfg.LPE` are read-only zero.
+    definedBy:
+      extension:
+        name: Zicfilp
+    type: RW
+    reset_value: UNDEFINED_LEGAL
   FIOM:
     location: 0
     description: |

--- a/spec/std/isa/csr/senvcfg.yaml
+++ b/spec/std/isa/csr/senvcfg.yaml
@@ -165,6 +165,28 @@ fields:
         return 0;
       }
       return csr_value.SSE;
+  LPE:
+    location: 2
+    description: |
+      *Landing Pad Enable*
+
+      When the LPE field is set to 1 and `menvcfg.LPE` is 1, the Zicfilp extension
+      is enabled in U/VU-mode. Read-only zero when `menvcfg.LPE` is 0. When the LPE
+      field is 0, the Zicfilp extension is not enabled in U/VU-mode and the following
+      rules apply:
+
+        * The hart does not update the `ELP` state; it remains as `NO_LP_EXPECTED`.
+        * The `LPAD` instruction operates as a no-op.
+    definedBy:
+      extension:
+        name: Zicfilp
+    type: RW
+    reset_value: UNDEFINED_LEGAL
+    sw_write(csr_value): |
+      if (CSR[menvcfg].LPE == 0) {
+        return 0;
+      }
+      return csr_value.LPE;
   FIOM:
     location: 0
     description: |
@@ -201,5 +223,9 @@ sw_read(): |
   if (implemented?(ExtensionName::Zicfiss) && (CSR[menvcfg].SSE == 0 || CSR[henvcfg].SSE == 0)) {
     # senvcfg.SSE must read-as-zero
     value = value & ~(1 `<< 3);
+  }
+  if (implemented?(ExtensionName::Zicfilp) && CSR[menvcfg].LPE == 0) {
+    # senvcfg.LPE must read-as-zero when menvcfg.LPE is 0
+    value = value & ~(1 `<< 2);
   }
   return value;


### PR DESCRIPTION
Add `LPE` field definitions to `menvcfg`, `senvcfg`, `henvcfg` per "The RISC-V Instruction Set
Manual, Volume II".

Fixes #1845