### PR TITLE
fix(isa): add missing sign_extend for ISA extensions

### DIFF
--- a/spec/std/isa/inst/I/addi.yaml
+++ b/spec/std/isa/inst/I/addi.yaml
@@ -19,6 +19,7 @@ encoding:
   variables:
     - name: imm
       location: 31-20
+      sign_extend: true
     - name: xs1
       location: 19-15
     - name: xd

--- a/spec/std/isa/inst/I/addiw.yaml
+++ b/spec/std/isa/inst/I/addiw.yaml
@@ -21,6 +21,7 @@ encoding:
   variables:
     - name: imm
       location: 31-20
+      sign_extend: true
     - name: xs1
       location: 19-15
     - name: xd

--- a/spec/std/isa/inst/I/andi.yaml
+++ b/spec/std/isa/inst/I/andi.yaml
@@ -17,6 +17,7 @@ encoding:
   variables:
     - name: imm
       location: 31-20
+      sign_extend: true
     - name: xs1
       location: 19-15
     - name: xd

--- a/spec/std/isa/inst/I/auipc.yaml
+++ b/spec/std/isa/inst/I/auipc.yaml
@@ -18,6 +18,7 @@ encoding:
     - name: imm
       location: 31-12
       left_shift: 12
+      sign_extend: true
     - name: xd
       location: 11-7
 hints:

--- a/spec/std/isa/inst/I/lb.yaml
+++ b/spec/std/isa/inst/I/lb.yaml
@@ -20,6 +20,7 @@ encoding:
   variables:
     - name: imm
       location: 31-20
+      sign_extend: true
     - name: xs1
       location: 19-15
     - name: xd

--- a/spec/std/isa/inst/I/lbu.yaml
+++ b/spec/std/isa/inst/I/lbu.yaml
@@ -20,6 +20,7 @@ encoding:
   variables:
     - name: imm
       location: 31-20
+      sign_extend: true
     - name: xs1
       location: 19-15
     - name: xd

--- a/spec/std/isa/inst/I/ld.yaml
+++ b/spec/std/isa/inst/I/ld.yaml
@@ -29,6 +29,7 @@ encoding:
     variables:
       - name: imm
         location: 31-20
+        sign_extend: true
       - name: xs1
         location: 19-15
       - name: xd
@@ -39,6 +40,7 @@ encoding:
     variables:
       - name: imm
         location: 31-20
+        sign_extend: true
       - name: xs1
         location: 19-15
       - name: xd

--- a/spec/std/isa/inst/I/lh.yaml
+++ b/spec/std/isa/inst/I/lh.yaml
@@ -20,6 +20,7 @@ encoding:
   variables:
     - name: imm
       location: 31-20
+      sign_extend: true
     - name: xs1
       location: 19-15
     - name: xd

--- a/spec/std/isa/inst/I/lhu.yaml
+++ b/spec/std/isa/inst/I/lhu.yaml
@@ -20,6 +20,7 @@ encoding:
   variables:
     - name: imm
       location: 31-20
+      sign_extend: true
     - name: xs1
       location: 19-15
     - name: xd

--- a/spec/std/isa/inst/I/lui.yaml
+++ b/spec/std/isa/inst/I/lui.yaml
@@ -18,6 +18,7 @@ encoding:
     - name: imm
       location: 31-12
       left_shift: 12
+      sign_extend: true
     - name: xd
       location: 11-7
 access:

--- a/spec/std/isa/inst/I/lw.yaml
+++ b/spec/std/isa/inst/I/lw.yaml
@@ -20,6 +20,7 @@ encoding:
   variables:
     - name: imm
       location: 31-20
+      sign_extend: true
     - name: xs1
       location: 19-15
     - name: xd

--- a/spec/std/isa/inst/I/lwu.yaml
+++ b/spec/std/isa/inst/I/lwu.yaml
@@ -22,6 +22,7 @@ encoding:
   variables:
     - name: imm
       location: 31-20
+      sign_extend: true
     - name: xs1
       location: 19-15
     - name: xd

--- a/spec/std/isa/inst/I/ori.yaml
+++ b/spec/std/isa/inst/I/ori.yaml
@@ -17,6 +17,7 @@ encoding:
   variables:
     - name: imm
       location: 31-20
+      sign_extend: true
     - name: xs1
       location: 19-15
     - name: xd

--- a/spec/std/isa/inst/I/sb.yaml
+++ b/spec/std/isa/inst/I/sb.yaml
@@ -19,6 +19,7 @@ encoding:
   variables:
     - name: imm
       location: 31-25|11-7
+      sign_extend: true
     - name: xs2
       location: 24-20
     - name: xs1

--- a/spec/std/isa/inst/I/sd.yaml
+++ b/spec/std/isa/inst/I/sd.yaml
@@ -25,6 +25,7 @@ encoding:
     variables:
       - name: imm
         location: 31-25|11-7
+        sign_extend: true
       - name: xs2
         not: [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31]
         location: 24-20

--- a/spec/std/isa/inst/I/sh.yaml
+++ b/spec/std/isa/inst/I/sh.yaml
@@ -19,6 +19,7 @@ encoding:
   variables:
     - name: imm
       location: 31-25|11-7
+      sign_extend: true
     - name: xs2
       location: 24-20
     - name: xs1

--- a/spec/std/isa/inst/I/slti.yaml
+++ b/spec/std/isa/inst/I/slti.yaml
@@ -19,6 +19,7 @@ encoding:
   variables:
     - name: imm
       location: 31-20
+      sign_extend: true
     - name: xs1
       location: 19-15
     - name: xd

--- a/spec/std/isa/inst/I/sltiu.yaml
+++ b/spec/std/isa/inst/I/sltiu.yaml
@@ -23,6 +23,7 @@ encoding:
   variables:
     - name: imm
       location: 31-20
+      sign_extend: true
     - name: xs1
       location: 19-15
     - name: xd

--- a/spec/std/isa/inst/I/sw.yaml
+++ b/spec/std/isa/inst/I/sw.yaml
@@ -19,6 +19,7 @@ encoding:
   variables:
     - name: imm
       location: 31-25|11-7
+      sign_extend: true
     - name: xs2
       location: 24-20
     - name: xs1

--- a/spec/std/isa/inst/I/xori.yaml
+++ b/spec/std/isa/inst/I/xori.yaml
@@ -19,6 +19,7 @@ encoding:
   variables:
     - name: imm
       location: 31-20
+      sign_extend: true
     - name: xs1
       location: 19-15
     - name: xd

--- a/spec/std/isa/inst/V/vadc.vim.yaml
+++ b/spec/std/isa/inst/V/vadc.vim.yaml
@@ -20,6 +20,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/V/vadd.vi.yaml
+++ b/spec/std/isa/inst/V/vadd.vi.yaml
@@ -22,6 +22,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/V/vand.vi.yaml
+++ b/spec/std/isa/inst/V/vand.vi.yaml
@@ -22,6 +22,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/V/vmadc.vi.yaml
+++ b/spec/std/isa/inst/V/vmadc.vi.yaml
@@ -20,6 +20,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/V/vmadc.vim.yaml
+++ b/spec/std/isa/inst/V/vmadc.vim.yaml
@@ -20,6 +20,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/V/vmerge.vim.yaml
+++ b/spec/std/isa/inst/V/vmerge.vim.yaml
@@ -20,6 +20,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/V/vmseq.vi.yaml
+++ b/spec/std/isa/inst/V/vmseq.vi.yaml
@@ -22,6 +22,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/V/vmsgt.vi.yaml
+++ b/spec/std/isa/inst/V/vmsgt.vi.yaml
@@ -22,6 +22,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/V/vmsgtu.vi.yaml
+++ b/spec/std/isa/inst/V/vmsgtu.vi.yaml
@@ -22,6 +22,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/V/vmsle.vi.yaml
+++ b/spec/std/isa/inst/V/vmsle.vi.yaml
@@ -22,6 +22,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/V/vmsleu.vi.yaml
+++ b/spec/std/isa/inst/V/vmsleu.vi.yaml
@@ -22,6 +22,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/V/vmsne.vi.yaml
+++ b/spec/std/isa/inst/V/vmsne.vi.yaml
@@ -22,6 +22,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/V/vor.vi.yaml
+++ b/spec/std/isa/inst/V/vor.vi.yaml
@@ -22,6 +22,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/V/vrsub.vi.yaml
+++ b/spec/std/isa/inst/V/vrsub.vi.yaml
@@ -22,6 +22,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/V/vsadd.vi.yaml
+++ b/spec/std/isa/inst/V/vsadd.vi.yaml
@@ -22,6 +22,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/V/vsaddu.vi.yaml
+++ b/spec/std/isa/inst/V/vsaddu.vi.yaml
@@ -22,6 +22,7 @@ encoding:
       location: 24-20
     - name: imm
       location: 19-15
+      sign_extend: true
     - name: vd
       location: 11-7
 access:

--- a/spec/std/isa/inst/Zicbop/prefetch.i.yaml
+++ b/spec/std/isa/inst/Zicbop/prefetch.i.yaml
@@ -21,6 +21,8 @@ encoding:
   variables:
     - name: imm
       location: 31-25
+      left_shift: 5
+      sign_extend: true
     - name: xs1
       location: 19-15
 access:

--- a/spec/std/isa/inst/Zicbop/prefetch.r.yaml
+++ b/spec/std/isa/inst/Zicbop/prefetch.r.yaml
@@ -21,6 +21,8 @@ encoding:
   variables:
     - name: imm
       location: 31-25
+      left_shift: 5
+      sign_extend: true
     - name: xs1
       location: 19-15
 access:

--- a/spec/std/isa/inst/Zicbop/prefetch.w.yaml
+++ b/spec/std/isa/inst/Zicbop/prefetch.w.yaml
@@ -21,6 +21,8 @@ encoding:
   variables:
     - name: imm
       location: 31-25
+      left_shift: 5
+      sign_extend: true
     - name: xs1
       location: 19-15
 access:

--- a/tests/golden/all_instructions.golden.adoc
+++ b/tests/golden/all_instructions.golden.adoc
@@ -145,7 +145,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -196,7 +196,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -10415,7 +10415,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -10514,7 +10514,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |{$encoding[31:12], 12'd0}
+|imm |sext({$encoding[31:12], 12'd0}, 32)
 |xd |$encoding[11:7]
 |===
 
@@ -27406,7 +27406,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -27580,7 +27580,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -27651,7 +27651,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -27661,7 +27661,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -27830,7 +27830,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -28004,7 +28004,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -28849,7 +28849,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |{$encoding[31:12], 12'd0}
+|imm |sext({$encoding[31:12], 12'd0}, 32)
 |xd |$encoding[11:7]
 |===
 
@@ -28902,7 +28902,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -29076,7 +29076,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -32198,7 +32198,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -32541,7 +32541,7 @@ prefetch.i imm(xs1)
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":15,"name": 0x6013,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":7,"name": "imm","type":4}]}
+{"reg":[{"bits":15,"name": 0x6013,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x0,"type":2},{"bits":7,"name": "imm[11:5]","type":4}]}
 ....
 
 Description::
@@ -32555,7 +32555,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:25]
+|imm |sext({$encoding[31:25], 5'd0}, 12)
 |xs1 |$encoding[19:15]
 |===
 
@@ -32595,7 +32595,7 @@ prefetch.r imm(xs1)
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":15,"name": 0x6013,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x1,"type":2},{"bits":7,"name": "imm","type":4}]}
+{"reg":[{"bits":15,"name": 0x6013,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x1,"type":2},{"bits":7,"name": "imm[11:5]","type":4}]}
 ....
 
 Description::
@@ -32609,7 +32609,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:25]
+|imm |sext({$encoding[31:25], 5'd0}, 12)
 |xs1 |$encoding[19:15]
 |===
 
@@ -32649,7 +32649,7 @@ prefetch.w imm(xs1)
 Encoding::
 [wavedrom, ,svg,subs='attributes',width="100%"]
 ....
-{"reg":[{"bits":15,"name": 0x6013,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x3,"type":2},{"bits":7,"name": "imm","type":4}]}
+{"reg":[{"bits":15,"name": 0x6013,"type":2},{"bits":5,"name": "xs1","type":4},{"bits":5,"name": 0x3,"type":2},{"bits":7,"name": "imm[11:5]","type":4}]}
 ....
 
 Description::
@@ -32663,7 +32663,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:25]
+|imm |sext({$encoding[31:25], 5'd0}, 12)
 |xs1 |$encoding[19:15]
 |===
 
@@ -33326,7 +33326,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |{$encoding[31:25], $encoding[11:7]}
+|imm |sext({$encoding[31:25], $encoding[11:7]}, 12)
 |xs2 |$encoding[24:20]
 |xs1 |$encoding[19:15]
 |===
@@ -34782,7 +34782,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |{$encoding[31:25], $encoding[11:7]}
+|imm |sext({$encoding[31:25], $encoding[11:7]}, 12)
 |xs2 |$encoding[24:20]
 |xs1 |$encoding[19:15]
 |===
@@ -35409,7 +35409,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |{$encoding[31:25], $encoding[11:7]}
+|imm |sext({$encoding[31:25], $encoding[11:7]}, 12)
 |xs2 |$encoding[24:20]
 |xs1 |$encoding[19:15]
 |===
@@ -37053,7 +37053,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -37110,7 +37110,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===
@@ -38426,7 +38426,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |{$encoding[31:25], $encoding[11:7]}
+|imm |sext({$encoding[31:25], $encoding[11:7]}, 12)
 |xs2 |$encoding[24:20]
 |xs1 |$encoding[19:15]
 |===
@@ -38865,7 +38865,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -39022,7 +39022,7 @@ Decode Variables::
 |Variable Name |Location
 |vm |$encoding[25]
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -39744,7 +39744,7 @@ Decode Variables::
 |Variable Name |Location
 |vm |$encoding[25]
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -55656,7 +55656,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -55708,7 +55708,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -56390,7 +56390,7 @@ Decode Variables::
 |===
 |Variable Name |Location
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -57757,7 +57757,7 @@ Decode Variables::
 |Variable Name |Location
 |vm |$encoding[25]
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -57916,7 +57916,7 @@ Decode Variables::
 |Variable Name |Location
 |vm |$encoding[25]
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -58022,7 +58022,7 @@ Decode Variables::
 |Variable Name |Location
 |vm |$encoding[25]
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -58180,7 +58180,7 @@ Decode Variables::
 |Variable Name |Location
 |vm |$encoding[25]
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -58339,7 +58339,7 @@ Decode Variables::
 |Variable Name |Location
 |vm |$encoding[25]
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -58710,7 +58710,7 @@ Decode Variables::
 |Variable Name |Location
 |vm |$encoding[25]
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -60766,7 +60766,7 @@ Decode Variables::
 |Variable Name |Location
 |vm |$encoding[25]
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -62090,7 +62090,7 @@ Decode Variables::
 |Variable Name |Location
 |vm |$encoding[25]
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -62400,7 +62400,7 @@ Decode Variables::
 |Variable Name |Location
 |vm |$encoding[25]
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -62559,7 +62559,7 @@ Decode Variables::
 |Variable Name |Location
 |vm |$encoding[25]
 |vs2 |$encoding[24:20]
-|imm |$encoding[19:15]
+|imm |sext($encoding[19:15], 5)
 |vd |$encoding[11:7]
 |===
 
@@ -74330,7 +74330,7 @@ Decode Variables::
 [width="100%", cols="1,2", options="header"]
 |===
 |Variable Name |Location
-|imm |$encoding[31:20]
+|imm |sext($encoding[31:20], 12)
 |xs1 |$encoding[19:15]
 |xd |$encoding[11:7]
 |===


### PR DESCRIPTION
I reviewed instructions in std and found some of them are lack of sign_extend, including I, Zicbop, and V.