### PR TITLE
Add "--fix" to ruff-check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,7 @@ repos:
         priority: 20
       - id: ruff-check
         priority: 30
+        args: ["--fix"]
 
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.11.0-1


### PR DESCRIPTION
The pre-commit check "ruff-check" often identifies simple issues like Python "import" statements not being in a certain order. In this case, it could fix them, but it doesn't, and getting it to do so is not trivial. There may be a better way, but I end up:
1. edit `.pre-commit-config.yaml`, adding ``` args: ["--fix"] ``` to the "ruff-check" stanza.
2. `git add .pre-commit-config.yaml`
3. `./bin/prek run ruff-check`
4. `git diff` to check changes.
5. `git add [changed files]`
6. `git restore --staged .pre-commit-config.yaml`
7. `git restore .pre-commit-config.yaml`
8. `git commit [...]` again.

Other pre-commit checks make changes, so allow "ruff-check" to also implement the fixes it requires by adding "--fix" to its command line.