### PR TITLE
Fix c.ldsp semantics

### DIFF
--- a/spec/std/isa/inst/C/c.ldsp.yaml
+++ b/spec/std/isa/inst/C/c.ldsp.yaml
@@ -57,8 +57,8 @@ operation(): |
   Bits<64> value = read_memory(64, virtual_address, $encoding);
 
   if (xlen()== 64) {
-    X[creg2reg(xd)] = value;
+    X[xd] = value;
   } else if (xlen() == 32) {
-    X[creg2reg(xd)]     = value[31:0];
-    X[creg2reg(xd) + 1] = value[63:32];
+    X[xd]     = value[31:0];
+    X[xd + 1] = value[63:32];
   }


### PR DESCRIPTION
The opcode for `c.ldsp` has a full 5-bit field for the target register.

The current implementation treats that field as a "compressed register" value, which is not correct.

Remove the conversion of the value from compressed register to register.