### PR TITLE
fix(csr): add missing LPE field definition for Zicfilp extension

### DIFF
--- a/spec/std/isa/csr/H/henvcfg.yaml
+++ b/spec/std/isa/csr/H/henvcfg.yaml
@@ -289,6 +289,22 @@ fields:
         return 0;
       }
       return csr_value.SSE;
+  LPE:
+    location: 2
+    description: |
+      *Landing Pad Enable*
+
+      When the `LPE` field is set to 1, the Zicfilp extension is enabled in
+      VS-mode. When the `LPE` field is 0, the Zicfilp extension is not enabled
+      in VS-mode and the following rules apply to VS-mode:
+
+      * The hart does not update the `ELP` state; it remains as `NO_LP_EXPECTED`.
+      * The `LPAD` instruction operates as a no-op.
+    definedBy:
+      extension:
+        name: Zicfilp
+    type: RW
+    reset_value: UNDEFINED_LEGAL
   FIOM:
     location: 0
     description: |

--- a/spec/std/isa/csr/menvcfg.yaml
+++ b/spec/std/isa/csr/menvcfg.yaml
@@ -296,6 +296,25 @@ fields:
         name: Zicfiss
     type: RW
     reset_value: UNDEFINED_LEGAL
+  LPE:
+    location: 2
+    description: |
+      *Landing Pad Enable*
+
+      When the `LPE` field is set to 1 and S-mode is implemented, the Zicfilp
+      extension is enabled in S-mode. If the `LPE` field is set to 1 and S-mode
+      is not implemented, the Zicfilp extension is enabled in U-mode. When the
+      `LPE` field is 0, the Zicfilp extension is not enabled in S-mode, and the
+      following rules apply to S-mode. If the `LPE` field is 0 and S-mode is not
+      implemented, then the same rules apply to U-mode.
+
+      * The hart does not update the `ELP` state; it remains as `NO_LP_EXPECTED`.
+      * The `LPAD` instruction operates as a no-op.
+    definedBy:
+      extension:
+        name: Zicfilp
+    type: RW
+    reset_value: UNDEFINED_LEGAL
   FIOM:
     location: 0
     description: |

--- a/spec/std/isa/csr/senvcfg.yaml
+++ b/spec/std/isa/csr/senvcfg.yaml
@@ -11,6 +11,13 @@ writable: true
 long_name: Supervisor Environment Configuration
 description: |
   Contains fields that control certain characteristics of the U-mode execution environment.
+
+  The Zicfilp extension adds the `LPE` field in `senvcfg`. When the `LPE` field is
+  set to 1, the Zicfilp extension is enabled in U-mode. When the `LPE` field is 0,
+  the Zicfilp extension is not enabled in U-mode, and the following rules apply:
+
+  * The hart does not update the `ELP` state; it remains as `NO_LP_EXPECTED`.
+  * The `LPAD` instruction operates as a no-op.
 priv_mode: S
 length: 64
 definedBy:
@@ -165,6 +172,22 @@ fields:
         return 0;
       }
       return csr_value.SSE;
+  LPE:
+    location: 2
+    description: |
+      *Landing Pad Enable*
+
+      When the `LPE` field is set to 1, the Zicfilp extension is enabled in
+      U-mode. When the `LPE` field is 0, the Zicfilp extension is not enabled
+      in U-mode and the following rules apply:
+
+      * The hart does not update the `ELP` state; it remains as `NO_LP_EXPECTED`.
+      * The `LPAD` instruction operates as a no-op.
+    definedBy:
+      extension:
+        name: Zicfilp
+    type: RW
+    reset_value: UNDEFINED_LEGAL
   FIOM:
     location: 0
     description: |

--- a/spec/std/isa/ext/Zicfilp.yaml
+++ b/spec/std/isa/ext/Zicfilp.yaml
@@ -8,7 +8,11 @@ kind: extension
 name: Zicfilp
 long_name: Landing Pad
 description: |
-  TODO
+  The Zicfilp extension adds the Landing Pad extension, which provides
+  forward-edge control-flow integrity. When enabled (via the `LPE` field
+  in `menvcfg`, `henvcfg`, or `senvcfg`), the `LPAD` instruction is used
+  to set a landing pad expectation, and indirect jumps must target a
+  matching `LPAD` instruction or an exception is raised.
 type: unprivileged
 versions:
   - version: "1.0.0"


### PR DESCRIPTION
## Summary

Add the missing LPE (Landing Pad Enable) field at bit 2 to:
- `menvcfg` (enables Zicfilp in S-mode or U-mode)
- `henvcfg` (enables Zicfilp in VS-mode)
- `senvcfg` (enables Zicfilp in U-mode)

Also updates `senvcfg` description and `Zicfilp` extension description (was "TODO").

Fixes #1845