### PR TITLE
Fix shell quoting for paths with spaces in toolchain container (#1709)

### DIFF
--- a/.toolchain/.build-elfutils.sh
+++ b/.toolchain/.build-elfutils.sh
@@ -25,7 +25,7 @@ if [ "${UDB_TOOLCHAIN_CONTAINER:-0}" = "1" ]; then
   source "${ROOT}/../bin/.toolchain.sh"
   cd "$BINARY_DIR"
   _setup_toolchain_run
-  exec $TOOLCHAIN_RUN bash -c '
+  exec "${TOOLCHAIN_RUN[@]}" bash -c '
     set -e
     cd "$1"
     "$2/configure" \

--- a/bin/.toolchain.sh
+++ b/bin/.toolchain.sh
@@ -48,29 +48,33 @@ _setup_toolchain_run() {
   fi
 
   local selinux_label=""
-  local user_flags=""
   if [[ "$runtime" == *podman* ]]; then
     selinux_label=":z"
-    user_flags="--userns=keep-id"
+  fi
+
+  TOOLCHAIN_RUN=("$runtime" "run" "--rm")
+  if [ -t 1 ] && [ -t 0 ]; then
+    TOOLCHAIN_RUN+=("-it")
+  fi
+  TOOLCHAIN_RUN+=("-v" "${ROOT}:${ROOT}${selinux_label}")
+
+  if [[ "$runtime" == *podman* ]]; then
+    TOOLCHAIN_RUN+=("--userns=keep-id")
   else
     # For docker: copy /etc/passwd and /etc/group for user resolution (same pattern as bin/setup)
     mkdir -p "${ROOT}/.cache"
     getent passwd > "${ROOT}/.cache/passwd"
     getent group > "${ROOT}/.cache/group"
-    user_flags="--user $(id -u):$(id -g) -v ${ROOT}/.cache/passwd:/etc/passwd:ro -v ${ROOT}/.cache/group:/etc/group:ro"
-  fi
-
-  local tty_flags=""
-  if [ -t 1 ] && [ -t 0 ]; then
-    tty_flags="-it"
+    TOOLCHAIN_RUN+=("--user" "$(id -u):$(id -g)"
+                    "-v" "${ROOT}/.cache/passwd:/etc/passwd:ro"
+                    "-v" "${ROOT}/.cache/group:/etc/group:ro")
   fi
 
   # Handle git worktrees: if .git is a file (worktree), also mount the parent git dir
-  local extra_mounts=""
   if [ -f "${ROOT}/.git" ]; then
     local git_common_dir
     git_common_dir=$(git -C "${ROOT}" rev-parse --git-common-dir | xargs dirname)
-    extra_mounts="-v ${git_common_dir}:${git_common_dir}${selinux_label}"
+    TOOLCHAIN_RUN+=("-v" "${git_common_dir}:${git_common_dir}${selinux_label}")
   fi
 
   local host_pwd container_workdir
@@ -82,7 +86,7 @@ _setup_toolchain_run() {
       ;;
   esac
 
-  TOOLCHAIN_RUN="$runtime run --rm $tty_flags -v ${ROOT}:${ROOT}${selinux_label} $extra_mounts -w ${container_workdir} $user_flags ${TOOLCHAIN_IMAGE}"
+  TOOLCHAIN_RUN+=("-w" "${container_workdir}" "${TOOLCHAIN_IMAGE}")
 }
 
 # Prompt the user to pick a toolchain when they previously selected "neither".

--- a/bin/clang-format
+++ b/bin/clang-format
@@ -14,7 +14,7 @@ if [ "${UDB_TOOLCHAIN_CONTAINER:-0}" = "1" ]; then
   # shellcheck source=.toolchain.sh
   source "${ROOT}/.toolchain.sh"
   _setup_toolchain_run
-  exec $TOOLCHAIN_RUN clang-format "$@"
+  exec "${TOOLCHAIN_RUN[@]}" clang-format "$@"
 elif PATH="${PATH//"${ROOT}:"/}" command -v clang-format > /dev/null 2>&1; then
   PATH="${PATH//"${ROOT}:"/}"
   export PATH

--- a/bin/clang-tidy
+++ b/bin/clang-tidy
@@ -14,7 +14,7 @@ if [ "${UDB_TOOLCHAIN_CONTAINER:-0}" = "1" ]; then
   # shellcheck source=.toolchain.sh
   source "${ROOT}/.toolchain.sh"
   _setup_toolchain_run
-  exec $TOOLCHAIN_RUN clang-tidy "$@"
+  exec "${TOOLCHAIN_RUN[@]}" clang-tidy "$@"
 elif PATH="${PATH//"${ROOT}:"/}" command -v clang-tidy > /dev/null 2>&1; then
   PATH="${PATH//"${ROOT}:"/}"
   export PATH

--- a/bin/g++
+++ b/bin/g++
@@ -14,7 +14,7 @@ if [ "${UDB_TOOLCHAIN_CONTAINER:-0}" = "1" ]; then
   # shellcheck source=.toolchain.sh
   source "${ROOT}/.toolchain.sh"
   _setup_toolchain_run
-  exec $TOOLCHAIN_RUN g++ "$@"
+  exec "${TOOLCHAIN_RUN[@]}" g++ "$@"
 elif PATH="${PATH//"${ROOT}:"/}" command -v g++ > /dev/null 2>&1; then
   # Strip bin/ from PATH to avoid infinite recursion (same pattern as bin/rake),
   # then check C++ requirements before delegating to the real g++.

--- a/bin/gdb
+++ b/bin/gdb
@@ -14,7 +14,7 @@ if [ "${UDB_TOOLCHAIN_CONTAINER:-0}" = "1" ]; then
   # shellcheck source=.toolchain.sh
   source "${ROOT}/.toolchain.sh"
   _setup_toolchain_run
-  exec $TOOLCHAIN_RUN gdb "$@"
+  exec "${TOOLCHAIN_RUN[@]}" gdb "$@"
 elif PATH="${PATH//"${ROOT}:"/}" command -v gdb > /dev/null 2>&1; then
   PATH="${PATH//"${ROOT}:"/}"
   export PATH

--- a/bin/riscv32-unknown-elf-gcc
+++ b/bin/riscv32-unknown-elf-gcc
@@ -15,7 +15,7 @@ if [ "${UDB_TOOLCHAIN_CONTAINER:-0}" = "1" ]; then
   source "${ROOT}/.toolchain.sh"
   _setup_toolchain_run
   # The container's riscv64-unknown-elf-gcc supports rv32 targets via -march/-mabi flags
-  exec $TOOLCHAIN_RUN riscv64-unknown-elf-gcc "$@"
+  exec "${TOOLCHAIN_RUN[@]}" riscv64-unknown-elf-gcc "$@"
 elif _native=$(PATH="${PATH//"${ROOT}:"/}" command -v riscv32-unknown-elf-gcc 2>/dev/null) && [ -n "$_native" ]; then
   exec "$_native" "$@"
 elif _native=$(PATH="${PATH//"${ROOT}:"/}" command -v riscv64-unknown-elf-gcc 2>/dev/null) && [ -n "$_native" ]; then

--- a/bin/riscv32-unknown-elf-objdump
+++ b/bin/riscv32-unknown-elf-objdump
@@ -15,7 +15,7 @@ if [ "${UDB_TOOLCHAIN_CONTAINER:-0}" = "1" ]; then
   source "${ROOT}/.toolchain.sh"
   _setup_toolchain_run
   # The container's riscv64-unknown-elf-objdump handles rv32 binaries too
-  exec $TOOLCHAIN_RUN riscv64-unknown-elf-objdump "$@"
+  exec "${TOOLCHAIN_RUN[@]}" riscv64-unknown-elf-objdump "$@"
 elif _native=$(PATH="${PATH//"${ROOT}:"/}" command -v riscv32-unknown-elf-objdump 2>/dev/null) && [ -n "$_native" ]; then
   exec "$_native" "$@"
 elif _native=$(PATH="${PATH//"${ROOT}:"/}" command -v riscv64-unknown-elf-objdump 2>/dev/null) && [ -n "$_native" ]; then

--- a/bin/riscv64-unknown-elf-gcc
+++ b/bin/riscv64-unknown-elf-gcc
@@ -14,7 +14,7 @@ if [ "${UDB_TOOLCHAIN_CONTAINER:-0}" = "1" ]; then
   # shellcheck source=.toolchain.sh
   source "${ROOT}/.toolchain.sh"
   _setup_toolchain_run
-  exec $TOOLCHAIN_RUN riscv64-unknown-elf-gcc "$@"
+  exec "${TOOLCHAIN_RUN[@]}" riscv64-unknown-elf-gcc "$@"
 elif _native=$(PATH="${PATH//"${ROOT}:"/}" command -v riscv64-unknown-elf-gcc 2>/dev/null) && [ -n "$_native" ]; then
   exec "$_native" "$@"
 else

--- a/bin/riscv64-unknown-elf-objdump
+++ b/bin/riscv64-unknown-elf-objdump
@@ -14,7 +14,7 @@ if [ "${UDB_TOOLCHAIN_CONTAINER:-0}" = "1" ]; then
   # shellcheck source=.toolchain.sh
   source "${ROOT}/.toolchain.sh"
   _setup_toolchain_run
-  exec $TOOLCHAIN_RUN riscv64-unknown-elf-objdump "$@"
+  exec "${TOOLCHAIN_RUN[@]}" riscv64-unknown-elf-objdump "$@"
 elif _native=$(PATH="${PATH//"${ROOT}:"/}" command -v riscv64-unknown-elf-objdump 2>/dev/null) && [ -n "$_native" ]; then
   exec "$_native" "$@"
 else

--- a/tools/ruby-gems/udb/lib/udb/yaml/yaml_resolver.rb
+++ b/tools/ruby-gems/udb/lib/udb/yaml/yaml_resolver.rb
@@ -10,6 +10,7 @@ require "fileutils"
 require "json"
 require "json_schemer"
 require "sorbet-runtime"
+require "uri"
 
 require "idlc"
 
@@ -1027,6 +1028,10 @@ module Udb
         if jsonified_obj.key?("$schema")
           bare_schema = File.basename(T.must(jsonified_obj["$schema"].split("#").first)) + "#"
           jsonified_obj["$schema"] = bare_schema
+        end
+
+        if jsonified_obj.key?("$source")
+          jsonified_obj["$source"] = URI::RFC2396_PARSER.escape(jsonified_obj["$source"])
         end
 
         unless schema.valid?(jsonified_obj)

--- a/tools/ruby-gems/udb/test/test_yaml_resolver.rb
+++ b/tools/ruby-gems/udb/test/test_yaml_resolver.rb
@@ -498,6 +498,35 @@ class TestYamlResolver < Minitest::Test
     end
   end
 
+  def test_schema_validation_accepts_source_paths_with_spaces
+    Dir.mktmpdir do |tmpdir|
+      schemas_dir = Pathname.new(tmpdir) / "schemas"
+      input_dir = Pathname.new(tmpdir) / "input with space"
+      output_dir = Pathname.new(tmpdir) / "output"
+      schemas_dir.mkpath
+      input_dir.mkpath
+
+      (schemas_dir / "mock_schema.json").write(JSON.generate({
+        "$schema" => "http://json-schema.org/draft-07/schema#",
+        "type" => "object",
+        "required" => ["$schema", "$source", "name"],
+        "properties" => {
+          "$schema" => { "type" => "string", "enum" => ["mock_schema.json#"] },
+          "$source" => { "type" => "string", "format" => "uri-reference" },
+          "name" => { "type" => "string" }
+        },
+        "additionalProperties" => false
+      }))
+      (input_dir / "item.yaml").write("$schema: mock_schema.json#\nname: item\n")
+
+      resolver = Udb::Yaml::Resolver.new(quiet: true, schemas_path: schemas_dir)
+      resolver.resolve_files(input_dir, output_dir, no_checks: false)
+
+      resolved_content = File.read(output_dir / "item.yaml")
+      assert_includes resolved_content, "input with space/item.yaml"
+    end
+  end
+
   # Test that resolved files record the versioned $schema
   def test_schema_versioning_in_resolved_files
     gem_schemas = Pathname.new(__dir__).parent / "schemas"


### PR DESCRIPTION
## Summary

- Convert `TOOLCHAIN_RUN` from string to array in `_setup_toolchain_run()` to properly handle paths containing spaces
- Update all bin/ wrapper scripts to use `"${TOOLCHAIN_RUN[@]}"` for correct array expansion
- Properly quote all path variables in volume mounts

Closes #1709