### PR TITLE
docs(ext): add proper descriptions for Zicfilp and Zicfiss extensions

### DIFF
--- a/spec/std/isa/ext/Zicfilp.yaml
+++ b/spec/std/isa/ext/Zicfilp.yaml
@@ -8,7 +8,25 @@ kind: extension
 name: Zicfilp
 long_name: Landing Pad
 description: |
-  TODO
+  The `Zicfilp` extension provides forward-edge control-flow integrity (CFI) for RISC-V.
+  It introduces a Landing Pad (`LPAD`) instruction that must be the first instruction
+  at each valid indirect-call or indirect-jump target. If an indirect control-flow
+  transfer lands on any instruction other than `LPAD`, a software-check exception is
+  raised, preventing attackers from redirecting control flow to arbitrary code locations
+  (a technique known as jump-oriented programming, or JOP).
+
+  The extension adds a new CPU state, the Landing Pad State (`ELP`), which transitions
+  from `NO_LP_EXPECTED` to `LP_EXPECTED` after an indirect JALR or C.JALR instruction
+  is retired. When `ELP` is `LP_EXPECTED`, the next instruction fetched must be `LPAD`
+  or a software-check exception (`chkfail`) is raised and `ELP` is reset.
+
+  `LPAD` encodes a 20-bit label. When landing-pad label checking is enabled, the label
+  must match a value supplied by the caller (via register `t2`), providing an additional
+  layer of granularity that can distinguish between different classes of call targets
+  (e.g., function pointers vs. virtual-dispatch targets).
+
+  The `Zicfilp` extension is part of the RISC-V Control-Flow Integrity (CFI) specification,
+  which also includes `Zicfiss` for shadow-stack (backward-edge) CFI.
 type: unprivileged
 versions:
   - version: "1.0.0"

--- a/spec/std/isa/ext/Zicfiss.yaml
+++ b/spec/std/isa/ext/Zicfiss.yaml
@@ -8,7 +8,27 @@ kind: extension
 name: Zicfiss
 long_name: Shadow Stack
 description: |
-  TODO
+  The `Zicfiss` extension provides backward-edge control-flow integrity (CFI) for RISC-V
+  using a hardware-managed shadow stack. The shadow stack is a second, protected call stack
+  that stores only return addresses. On function call (`JAL`, `JALR` with link register),
+  the return address is pushed onto both the regular stack and the shadow stack. On function
+  return (e.g., `JALR x0, 0(x1)`), the return address is popped from both stacks and
+  compared; if they differ, a software-check exception (`chkfail`) is raised.
+
+  The extension introduces three new instructions:
+  * `SSPUSH` — pushes `x1` or `x5` onto the shadow stack.
+  * `SSPOPCHK` — pops the top of the shadow stack and compares it against `x1` or `x5`.
+    Raises a software-check exception if the values differ.
+  * `SSRDP` — reads the current shadow-stack pointer into a register.
+
+  Shadow-stack memory is protected by PMP/PMA and virtual-memory mechanisms: pages mapped
+  as shadow-stack pages (using the page-table `X`/`W`/`R` bit combination reserved for this
+  purpose) can only be written by shadow-stack instructions, preventing regular store
+  instructions from corrupting return addresses.
+
+  `Zicfiss` can be independently enabled or disabled per privilege mode via bits in
+  `menvcfg`, `senvcfg`, and `henvcfg`. It is part of the RISC-V CFI specification,
+  complementing `Zicfilp` for forward-edge protection.
 type: unprivileged
 versions:
   - version: "1.0.0"


### PR DESCRIPTION

---

### PR Description

**Title:** `docs(ext): add proper descriptions for Zicfilp (Landing Pad) and Zicfiss (Shadow Stack) extensions`

**Body:**
