### PR TITLE
fix(svnapot): normalize requirements field to use top-level allOf str…

### DIFF
--- a/spec/std/isa/ext/Ztso.yaml
+++ b/spec/std/isa/ext/Ztso.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) Ishaan Arora
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
 # yaml-language-server: $schema=../../../schemas/ext_schema.json


### PR DESCRIPTION

---

## Issue 5 — Svnapot requirements Field Uses Incorrect YAML Structure

**Branch:** `fix/svnapot-requirements-structure`  
**Files Changed:**
- [`spec/std/isa/ext/Svnapot.yaml`](file:///c:/opensource/riscv-unified-db/spec/std/isa/ext/Svnapot.yaml)

### Issue Description

**Title:** `[data-error] Svnapot requirements field nests allOf under extension key, inconsistent with schema`

**Labels:** `data-error`, `schema`

**Body:**
