### PR TITLE
feat: add chore to regenerate udb-gen fixtures

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -338,6 +338,15 @@ jobs:
       uses: "./.github/actions/mise-setup"
     - name: Check udb-gen integration tests
       run: "./do test:udb_gen:integration"
+  regress-udb-gen-chore:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone Github Repo Action
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - name: Set up mise environment
+      uses: "./.github/actions/mise-setup"
+    - name: Generate udb-gen golden files
+      run: "./bin/chore gen -f udb-gen"
   regress-sorbet:
     runs-on: ubuntu-latest
     steps:
@@ -882,6 +891,7 @@ jobs:
     - regress-udb-helpers-unit
     - regress-udb-gen-unit
     - regress-udb-gen-integration
+    - regress-udb-gen-chore
     - regress-sorbet
     - regress-ext-explorer
     - regress-idl-typecheck-smoke

--- a/bin/chore
+++ b/bin/chore
@@ -114,6 +114,7 @@ gen_subcmd_usage() {
   echo "  schema-docs:   Generate schema documentation from JSON Schema files"
   echo "  cfg-headers:   Generate golden cfg header files for regression testing"
   echo "  xqci           Generate Xqci spec used for Golden regressions"
+  echo "  udb-gen:       Generate test case fixtures for udb-gen"
   echo ""
 }
 
@@ -355,6 +356,13 @@ do_update_gem_versions() {
 }
 
 #
+# Generate test cases for udb_gen
+#
+do_gen_udb_gen_fixtures() {
+  "$UDB_ROOT/do" chore:udb_gen:update_fixtures
+}
+
+#
 # Generate all development artifacts
 #
 do_gen_all() {
@@ -366,6 +374,7 @@ do_gen_all() {
   do_gen_xqci_golden
   do_gen_schema_docs
   do_gen_cfg_headers_golden
+  do_gen_udb_gen_fixtures
 }
 
 #
@@ -665,6 +674,10 @@ case "$subcommand" in
         ;;
       xqci )
         do_gen_xqci_golden
+        exit 0
+        ;;
+      udb-gen )
+        do_gen_udb_gen_fixtures
         exit 0
         ;;
       cfg-headers )

--- a/tools/test/regress-tests.yaml
+++ b/tools/test/regress-tests.yaml
@@ -58,6 +58,14 @@ tests:
       - name: Check udb-gen integration tests
         run: ./do test:udb_gen:integration
 
+  regress-udb-gen-chore:
+    ci_stage: pr
+    tags:
+      - smoke
+    test:
+      - name: Generate udb-gen golden files
+        run: ./bin/chore gen -f udb-gen
+
   regress-sorbet:
     ci_stage: pr
     tags:


### PR DESCRIPTION
Help auto-update the udb-gen test case fixtures by adding a chore and regression for it. This will autogenerate the test cases when instructions are changed to keep the test cases up-to-date.