### PR TITLE
fix: correct andn operand order

### DIFF
--- a/spec/std/isa/inst/B/andn.yaml
+++ b/spec/std/isa/inst/B/andn.yaml
@@ -38,4 +38,4 @@ operation(): |
     raise (ExceptionCode::IllegalInstruction, mode(), $encoding);
   }
 
-  X[xd] = X[xs2] & ~X[xs1];
+  X[xd] = X[xs1] & ~X[xs2];


### PR DESCRIPTION
Fix the `andn` operation definition so it computes `X[xs1] & ~X[xs2]`, matching the Bit-Manipulation Extension specification.

Fixes #1870