### PR TITLE
fix: check for gnupg before mise install with clear error

### DIFF
--- a/bin/doctor
+++ b/bin/doctor
@@ -67,6 +67,16 @@ _record_warn() { ((_WARN_COUNT++)) || true; }
 _check_core_prerequisites() {
   _section "Core Prerequisites"
 
+  # gpg
+  if command -v gpg > /dev/null 2>&1 || command -v gpg2 > /dev/null 2>&1; then
+    _pass "gpg  ${_C_DIM}found${_C_RESET}"
+    _record_pass
+  else
+    _fail "gpg not found"
+    _info "Fix: install gnupg via your package manager (e.g. \`brew install gnupg\`)"
+    _record_fail
+  fi
+
   # git
   if command -v git > /dev/null 2>&1; then
     local git_ver

--- a/bin/setup
+++ b/bin/setup
@@ -88,6 +88,16 @@ _ok "mise ready ($("$MISE_BIN" --version 2>/dev/null | head -1))"
 
 _section "Tool versions (Ruby, Node.js, uv, CMake, …)"
 
+# gpg is required by some asdf plugins (make, node, ruby) during
+# mise install. Check for it early to surface a clear error.
+if ! command -v gpg > /dev/null 2>&1 && ! command -v gpg2 > /dev/null 2>&1; then
+  printf "\nERROR: GnuPG (gpg) is required but not found.\n" >&2
+  printf "       Install it via your package manager (e.g. \`brew install gnupg\` on macOS,\n" >&2
+  printf "       \`apt install gnupg\` on Debian/Ubuntu).\n\n" >&2
+  exit 1
+fi
+_note "gpg found"
+
 # Pre-initialize ~/.gnupg before mise install so parallel gpg invocations
 # (e.g. for node, make, ruby) don't race to create the directory.
 mkdir -p "${GNUPGHOME:-$HOME/.gnupg}" && chmod 700 "${GNUPGHOME:-$HOME/.gnupg}"


### PR DESCRIPTION
`bin/setup` fails with a cryptic error `asdf-make: gpg or gpg2 command not found. You must install GnuPG` when gnupg is not installed on macOS. This adds an early check for `gpg`/`gpg2` in both `bin/setup` and `bin/doctor` with a clear error message and install instructions.
## Changes
- **`bin/setup`**: Checks for `gpg`/`gpg2` before running `mise install`. If missing, prints an ERROR with platform-specific install instructions (`brew install gnupg` on macOS, `apt install gnupg` on Debian/Ubuntu) and exits.
- **`bin/doctor`**: Adds a `gpg` check to the Core Prerequisites section 
Hopefully Closes #1857
