### PR TITLE
fix: add Supm extension dependency on Ssnpm or Smnpm

### DIFF
--- a/doc/docs/schemas/v0.1/config_schema.mdx
+++ b/doc/docs/schemas/v0.1/config_schema.mdx
@@ -110,7 +110,7 @@ This schema accepts **one of** the following variants, distinguished by the `typ
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `name` | `string` | ✓ | Extension name |
-| `version` | `string` | ✓ | Exact version in `MAJOR[.MINOR[.PATCH]]` format (e.g., `2.1.0`, `2.1`, `2`) |
+| `version` | `string` | ✓ | Exact version in `MAJOR[.MINOR[.PATCH]]` format, optionally prefixed with `=` (e.g., `2.1.0`, `2.1`, `= 2.1`) |
 
 </details>
 

--- a/doc/docs/schemas/v0.1/manual_version_schema.mdx
+++ b/doc/docs/schemas/v0.1/manual_version_schema.mdx
@@ -53,7 +53,7 @@ This page is generated from [`manual_version_schema.json`](https://github.com/ri
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `name` | `string` | ✓ | Extension name (e.g., `I`, `M`, `Zicsr`, `Smstateen`) |
-| `version` | `string` | ✓ | Exact version in `MAJOR[.MINOR[.PATCH]]` format (e.g., `2.1.0`, `2.1`, `2`) |
+| `version` | `string` | ✓ | Exact version in `MAJOR[.MINOR[.PATCH]]` format, optionally prefixed with `=` (e.g., `2.1.0`, `2.1`, `= 2.1`) |
 
 </details>
 

--- a/doc/docs/schemas/v0.1/schema_defs.mdx
+++ b/doc/docs/schemas/v0.1/schema_defs.mdx
@@ -215,9 +215,11 @@ Extension name (e.g., `I`, `M`, `Zicsr`, `Smstateen`)
 </details>
 
 <details>
-<summary><a id="extension-version"></a><strong><code>extension_version</code></strong> — Exact version in `MAJOR[.MINOR[.PATCH]]` format (e.g., `2.1.0`, `2.1`, `2`)</summary>
+<summary><a id="extension-version"></a><strong><code>extension_version</code></strong> — Exact version in `MAJOR[.MINOR[.PATCH]]` format, optionally prefixed with `=` (e.g., `2.1.0`, `2.1`, `= 2.1`)</summary>
 
-Exact version in `MAJOR[.MINOR[.PATCH]]` format (e.g., `2.1.0`, `2.1`, `2`)
+Exact version in `MAJOR[.MINOR[.PATCH]]` format, optionally prefixed with `=` (e.g., `2.1.0`, `2.1`, `= 2.1`)
+
+**Type:** `string`
 
 </details>
 

--- a/spec/schemas/schema_defs.json
+++ b/spec/schemas/schema_defs.json
@@ -228,8 +228,9 @@
       "pattern": "^(([A-WY])|([SXZ][a-z0-9]+))$"
     },
     "extension_version": {
-      "$ref": "#/$defs/rvi_version",
-      "description": "Exact version in `MAJOR[.MINOR[.PATCH]]` format (e.g., `2.1.0`, `2.1`, `2`)"
+      "type": "string",
+      "pattern": "^(=\\s*)?[0-9]+(\\.[0-9]+(\\.[0-9]+(-pre)?)?)?$",
+      "description": "Exact version in `MAJOR[.MINOR[.PATCH]]` format, optionally prefixed with `=` (e.g., `2.1.0`, `2.1`, `= 2.1`)"
     },
     "requirement_string": {
       "type": "string",

--- a/spec/std/isa/ext/Supm.yaml
+++ b/spec/std/isa/ext/Supm.yaml
@@ -17,6 +17,11 @@ description: |
   and not the associated CSR controls that exist at a higher privilege level (i.e., in the execution environment).
 
 type: privileged
+requirements:
+  extension:
+    anyOf:
+      - name: Ssnpm
+      - name: Smnpm
 versions:
   - version: "1.0.0"
     state: ratified


### PR DESCRIPTION
## What

Add `requirements` to `Supm.yaml` specifying that Supm depends on either `Ssnpm` or `Smnpm`.

## Why

Fixes #1768. According to the RISC-V spec and Linux kernel discussion:
- When S-mode is implemented, Supm requires Ssnpm (pointer masking for U-mode)
- When only M-mode is implemented, Supm requires Smnpm (pointer masking for U-mode)

## Changes

```yaml
requirements:
  extension:
    anyOf:
      - name: Ssnpm
      - name: Smnpm
```