### PR TITLE
fix: add Supm extension dependency on Ssnpm or Smnpm

### DIFF
--- a/spec/std/isa/ext/Supm.yaml
+++ b/spec/std/isa/ext/Supm.yaml
@@ -17,6 +17,11 @@ description: |
   and not the associated CSR controls that exist at a higher privilege level (i.e., in the execution environment).
 
 type: privileged
+requirements:
+  extension:
+    anyOf:
+      - name: Ssnpm
+      - name: Smnpm
 versions:
   - version: "1.0.0"
     state: ratified


### PR DESCRIPTION
## What

Add `requirements` to `Supm.yaml` specifying that Supm depends on either `Ssnpm` or `Smnpm`.

## Why

Fixes #1768. According to the RISC-V spec and Linux kernel discussion:
- When S-mode is implemented, Supm requires Ssnpm (pointer masking for U-mode)
- When only M-mode is implemented, Supm requires Smnpm (pointer masking for U-mode)

## Changes

```yaml
requirements:
  extension:
    anyOf:
      - name: Ssnpm
      - name: Smnpm
```