### PR TITLE
fix(cpp_hart_gen): stabilize GDB handshake and single-step debug flow

### DIFF
--- a/backends/cpp_hart_gen/cpp/src/GDBServer.cpp
+++ b/backends/cpp_hart_gen/cpp/src/GDBServer.cpp
@@ -645,11 +645,12 @@ std::string GDBServer::GetSupportedString()
 {
   std::string supported;
   PGDBFEATURE pGdbFeature;
+  const size_t featureCount = sizeof(gFeatureTable) / sizeof(gFeatureTable[0]);
 
   for(uint64_t id = 1; id != 0 && id <= m_uiSupport; id <<= 1)
   {
     for(pGdbFeature = (PGDBFEATURE)&gFeatureTable[0];
-      pGdbFeature < gFeatureTable + sizeof(gFeatureTable);
+      pGdbFeature < gFeatureTable + featureCount;
       pGdbFeature++)
     {
       if(pGdbFeature->uiId == id)
@@ -884,6 +885,9 @@ char GDBPacket::HexCharToValue(unsigned char hexChar)
 int GDBPacket::Write(const std::string& str)
 {
   int len = str.length();
+  if((size_t)(m_pNextPos - m_pPacket + len) > m_size)
+    return -1;
+
   for(int i = 0 ; i < len ; i++)
   {
     *m_pNextPos++ = str[i];

--- a/backends/cpp_hart_gen/cpp/src/iss.cpp
+++ b/backends/cpp_hart_gen/cpp/src/iss.cpp
@@ -362,16 +362,7 @@ int InstructionSetSimulator::OnReadGPR(REGISTERFILE& registerFile)
   registerFile.nXRegs = MIN(registerFile.nXRegs, 32);
   for(int i = 0 ; i < registerFile.nXRegs ; i++)
   {
-    try
-    {
-      registerFile.xReg[i] = m_pHart->xreg(i);
-    }
-    catch(...)
-    {
-      // Unknown values are legal in model state before first execution.
-      // Return a deterministic placeholder so GDB register fetch does not abort ISS.
-      registerFile.xReg[i] = 0;
-    }
+    registerFile.xReg[i] = m_pHart->xreg(i);
   }
   return 0;
 }
@@ -395,18 +386,14 @@ int InstructionSetSimulator::OnReadMemory(uint64_t uiAddress, uint64_t& uiLen, v
 
     if(m_pSoC->memcpy_to_host((uint8_t*)pBuffer, translationResult.pAddr, uiLen) >= 0)
       return 0;
+    else
+      return -1;
   }
-  catch(...)
+  catch(const udb::AbortInstruction& e)
   {
-    // Fall through to physical-address fallback below.
+    //memory not mapped for reading
+    return -1;
   }
-
-  // Debugger memory inspection may happen before translation state is fully usable.
-  // Try direct physical access to keep disassembly/memory view functional.
-  if(m_pSoC->memcpy_to_host((uint8_t*)pBuffer, uiAddress, uiLen) >= 0)
-    return 0;
-
-  return -1;
 }
 
 int InstructionSetSimulator::OnWriteMemory(uint64_t uiAddress, uint64_t& uiLen, void* pMemBuffer)
@@ -418,32 +405,20 @@ int InstructionSetSimulator::OnWriteMemory(uint64_t uiAddress, uint64_t& uiLen, 
 
     if(m_pSoC->memcpy_from_host(translationResult.pAddr, (const uint8_t*)pMemBuffer, uiLen) >= 0)
       return 0;
+    else
+      return -1;
   }
-  catch(...)
+  catch(const udb::AbortInstruction& e)
   {
-    // Fall through to physical-address fallback below.
+    //memory not mapped for writing
+    return -1;
   }
-
-  // Keep debugger memory writes usable when VA translation path is unavailable.
-  if(m_pSoC->memcpy_from_host(uiAddress, (const uint8_t*)pMemBuffer, uiLen) >= 0)
-    return 0;
-
-  return -1;
 }
 
 int InstructionSetSimulator::OnReadSingleRegister(int reg, uint64_t& value)
 {
   if(reg >= RISCV_REG_GPR_FIRST && reg <= RISCV_REG_GPR_LAST)
-  {
-    try
-    {
-      value = m_pHart->xreg(reg);
-    }
-    catch(...)
-    {
-      value = 0;
-    }
-  }
+    value = m_pHart->xreg(reg);
   else if (reg == RISCV_REG_PC)
     value = m_pHart->pc();
   else if (reg >= RISCV_REG_FPR_FIRST && reg <= RISCV_REG_FPR_LAST)

--- a/backends/cpp_hart_gen/cpp/src/iss.cpp
+++ b/backends/cpp_hart_gen/cpp/src/iss.cpp
@@ -316,6 +316,11 @@ int InstructionSetSimulator::Run()
     case STATE_SINGLE_STEP:
       stopReason = m_pHart->run_one();
       m_state = STATE_HALT;
+      if(m_opts.gdbMode)
+      {
+        // Notify debugger that single-step completed and target is halted again.
+        Halt(HALT_STEP, m_pHart->hartid().get(), m_pHart->pc());
+      }
       break;
     case STATE_RUN:
       stopReason = m_pHart->run_one();
@@ -357,7 +362,16 @@ int InstructionSetSimulator::OnReadGPR(REGISTERFILE& registerFile)
   registerFile.nXRegs = MIN(registerFile.nXRegs, 32);
   for(int i = 0 ; i < registerFile.nXRegs ; i++)
   {
-    registerFile.xReg[i] = m_pHart->xreg(i);
+    try
+    {
+      registerFile.xReg[i] = m_pHart->xreg(i);
+    }
+    catch(...)
+    {
+      // Unknown values are legal in model state before first execution.
+      // Return a deterministic placeholder so GDB register fetch does not abort ISS.
+      registerFile.xReg[i] = 0;
+    }
   }
   return 0;
 }
@@ -379,16 +393,20 @@ int InstructionSetSimulator::OnReadMemory(uint64_t uiAddress, uint64_t& uiLen, v
     auto translationResult = m_pHart->translate_native(uiAddress, udb::MemoryOperation{udb::MemoryOperation::Read},
       m_pHart->_get_mode(), uiAddress);
 
-    if(m_pSoC->memcpy_to_host((uint8_t*)pBuffer, translationResult.pAddr, uiLen) == 0)
+    if(m_pSoC->memcpy_to_host((uint8_t*)pBuffer, translationResult.pAddr, uiLen) >= 0)
       return 0;
-    else
-      return -1;
   }
-  catch(const udb::AbortInstruction& e)
+  catch(...)
   {
-    //memory not mapped for reading
-    return -1;
+    // Fall through to physical-address fallback below.
   }
+
+  // Debugger memory inspection may happen before translation state is fully usable.
+  // Try direct physical access to keep disassembly/memory view functional.
+  if(m_pSoC->memcpy_to_host((uint8_t*)pBuffer, uiAddress, uiLen) >= 0)
+    return 0;
+
+  return -1;
 }
 
 int InstructionSetSimulator::OnWriteMemory(uint64_t uiAddress, uint64_t& uiLen, void* pMemBuffer)
@@ -398,22 +416,34 @@ int InstructionSetSimulator::OnWriteMemory(uint64_t uiAddress, uint64_t& uiLen, 
     auto translationResult = m_pHart->translate_native(uiAddress, udb::MemoryOperation{udb::MemoryOperation::Write},
       m_pHart->_get_mode(), uiAddress);
 
-    if(m_pSoC->memcpy_from_host(translationResult.pAddr, (const uint8_t*)pMemBuffer, uiLen) == 0)
+    if(m_pSoC->memcpy_from_host(translationResult.pAddr, (const uint8_t*)pMemBuffer, uiLen) >= 0)
       return 0;
-    else
-      return -1;
   }
-  catch(const udb::AbortInstruction& e)
+  catch(...)
   {
-    //memory not mapped for writing
-    return -1;
+    // Fall through to physical-address fallback below.
   }
+
+  // Keep debugger memory writes usable when VA translation path is unavailable.
+  if(m_pSoC->memcpy_from_host(uiAddress, (const uint8_t*)pMemBuffer, uiLen) >= 0)
+    return 0;
+
+  return -1;
 }
 
 int InstructionSetSimulator::OnReadSingleRegister(int reg, uint64_t& value)
 {
   if(reg >= RISCV_REG_GPR_FIRST && reg <= RISCV_REG_GPR_LAST)
-    value = m_pHart->xreg(reg);
+  {
+    try
+    {
+      value = m_pHart->xreg(reg);
+    }
+    catch(...)
+    {
+      value = 0;
+    }
+  }
   else if (reg == RISCV_REG_PC)
     value = m_pHart->pc();
   else if (reg >= RISCV_REG_FPR_FIRST && reg <= RISCV_REG_FPR_LAST)


### PR DESCRIPTION
Fixes #1885

## Summary

- Added `Halt(HALT_STEP, ...)` notification after single-step completes in GDB mode so
  GDB receives the stop reply and doesn't hang waiting
- Fixed `memcpy_to_host`/`memcpy_from_host` return check from `== 0` to `>= 0` —
  these return bytes copied on success, not 0
- Fixed `GetSupportedString` loop bound using `sizeof(gFeatureTable)/sizeof(gFeatureTable[0])`
  instead of raw byte size to avoid out-of-bounds iteration
- Added bounds check in `GDBPacket::Write` to prevent buffer overwrite on large packets
- Removed physical-address fallback from `OnReadMemory`/`OnWriteMemory` and restored
  typed `catch(const udb::AbortInstruction&)` in memory callbacks

## Test plan

- [x] `./bin/regress -n regress-cpp-unit` passes
- [x] `./bin/regress -n regress-riscv-tests-64` passes
- [x] `./bin/regress -n regress-smoke-perf` passes
- [x] GDB attach and single-step verified manually under `IGNOREUNDEFINED=YES` build