### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,0 @@
-# default for all files
-*  @dhower-qc @ThinkOpenly
-
-# eclipse Xtext project owned by Ajit Dingankar
-tools/eclipse @adingank-qualcomm @dhower-qc
-
-# Renovate owned by Jordan Carlin
-renovate.json5 @jordancarlin


### PR DESCRIPTION
The list of Codeowners was outdated and this file does not do much anyway, so instead of updating it just remove it.
