### PR TITLE
Remove duplicate version information for UDB dependencies and allow Renovate to manage them

### DIFF
--- a/.github/workflows/release_udb_deps.yml
+++ b/.github/workflows/release_udb_deps.yml
@@ -1,12 +1,23 @@
 name: Build and release UDB gem dependencies to GitHub
 
 # Builds and uploads prebuilt eqntott, espresso, must, and/or z3 binaries as GitHub release assets.
-# Run this workflow manually whenever a tool version needs to be updated.
 #
-# The workflow automatically creates release tags and uploads binaries for the selected tool(s).
-# Each tool uses the chore update command which handles tag creation and release management.
+# Runs automatically whenever a Renovate PR bumps a tool's *_VERSION file and
+# lands on main. Can also be run manually.
+#
+# The *_VERSION files are the source of truth for dependency release tags:
+# z3 uses an upstream release tag, while eqntott/espresso/must use
+# <tool>-<git-commit>. The workflow builds and publishes binaries for the
+# bumped version.
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "tools/ruby-gems/udb/lib/udb/EQNTOTT_VERSION"
+      - "tools/ruby-gems/udb/lib/udb/ESPRESSO_VERSION"
+      - "tools/ruby-gems/udb/lib/udb/MUST_VERSION"
+      - "tools/ruby-gems/udb/lib/udb/Z3_VERSION"
   workflow_dispatch:
     inputs:
       tool:
@@ -29,8 +40,58 @@ env:
   GITHUB_TOKEN: ${{ secrets.TOKEN }}
 
 jobs:
+  detect-tools:
+    runs-on: ubuntu-24.04
+    outputs:
+      tools: ${{ steps.set-tools.outputs.tools }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 2 # Need to check changed files
+
+      - name: Detect which tool(s) to build
+        id: set-tools
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ "${{ inputs.tool }}" == "all" ]]; then
+              TOOLS='["eqntott","espresso","must","z3"]'
+            else
+              TOOLS='["${{ inputs.tool }}"]'
+            fi
+          else
+            CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+            TOOLS="["
+            SEPARATOR=""
+
+            if echo "$CHANGED_FILES" | grep -q "^tools/ruby-gems/udb/lib/udb/EQNTOTT_VERSION$"; then
+              TOOLS="${TOOLS}${SEPARATOR}\"eqntott\""
+              SEPARATOR=","
+            fi
+
+            if echo "$CHANGED_FILES" | grep -q "^tools/ruby-gems/udb/lib/udb/ESPRESSO_VERSION$"; then
+              TOOLS="${TOOLS}${SEPARATOR}\"espresso\""
+              SEPARATOR=","
+            fi
+
+            if echo "$CHANGED_FILES" | grep -q "^tools/ruby-gems/udb/lib/udb/MUST_VERSION$"; then
+              TOOLS="${TOOLS}${SEPARATOR}\"must\""
+              SEPARATOR=","
+            fi
+
+            if echo "$CHANGED_FILES" | grep -q "^tools/ruby-gems/udb/lib/udb/Z3_VERSION$"; then
+              TOOLS="${TOOLS}${SEPARATOR}\"z3\""
+            fi
+
+            TOOLS="${TOOLS}]"
+          fi
+
+          echo "tools=$TOOLS" >> "$GITHUB_OUTPUT"
+          echo "Tools to build: $TOOLS"
+
   build-eqntott:
-    if: inputs.tool == 'eqntott' || inputs.tool == 'all'
+    needs: detect-tools
+    if: contains(fromJson(needs.detect-tools.outputs.tools), 'eqntott')
     name: Build Eqntott (${{ matrix.arch }})
     strategy:
       fail-fast: false
@@ -56,7 +117,8 @@ jobs:
           fi
 
   build-z3:
-    if: inputs.tool == 'z3' || inputs.tool == 'all'
+    needs: detect-tools
+    if: contains(fromJson(needs.detect-tools.outputs.tools), 'z3')
     name: Build Z3 (${{ matrix.arch }})
     strategy:
       fail-fast: false
@@ -82,7 +144,8 @@ jobs:
           fi
 
   build-espresso:
-    if: inputs.tool == 'espresso' || inputs.tool == 'all'
+    needs: detect-tools
+    if: contains(fromJson(needs.detect-tools.outputs.tools), 'espresso')
     name: Build Espresso (${{ matrix.arch }})
     strategy:
       fail-fast: false
@@ -108,7 +171,8 @@ jobs:
           fi
 
   build-must:
-    if: inputs.tool == 'must' || inputs.tool == 'all'
+    needs: detect-tools
+    if: contains(fromJson(needs.detect-tools.outputs.tools), 'must')
     name: Build Must (${{ matrix.arch }})
     strategy:
       fail-fast: false

--- a/bin/.chore/update.sh
+++ b/bin/.chore/update.sh
@@ -27,6 +27,39 @@ do_update_gems() {
   do_ruby_type_def udb-gen
 }
 
+# Read a git-pinned binary dependency version from its *_VERSION file.
+# Args: $1 - tool/release prefix, e.g. "espresso"
+#       $2 - version file path
+#       $3 - output variable for the full version string
+#       $4 - output variable for the git commit portion
+read_git_pinned_tool_version() {
+  local tool=$1
+  local version_file=$2
+  local version_var=$3
+  local commit_var=$4
+  local version
+  local commit
+
+  version=$(<"${version_file}") || {
+    echo "ERROR: Could not read ${version_file}" >&2
+    exit 1
+  }
+
+  if [[ "${version}" != "${tool}-"* ]]; then
+    echo "ERROR: Invalid ${version_file}: expected ${tool}-<git-commit>, got '${version}'" >&2
+    exit 1
+  fi
+
+  commit="${version#${tool}-}"
+  if [[ ! "${commit}" =~ ^[a-f0-9]{7,40}$ ]]; then
+    echo "ERROR: Invalid ${version_file}: expected ${tool}-<7-to-40-char-hex-commit>, got '${version}'" >&2
+    exit 1
+  fi
+
+  printf -v "${version_var}" "%s" "${version}"
+  printf -v "${commit_var}" "%s" "${commit}"
+}
+
 #
 # Update espresso binary
 # Args: $1 - native_only ("yes" to build only for native platform, "no" for both x64 and arm64)
@@ -43,9 +76,12 @@ do_update_espresso() {
     exit 1
   fi
 
-  # For espresso, we use a fixed version since it builds from a fixed git repo
-  local espresso_version="espresso-1.0"
-  echo "==> Building espresso version: ${espresso_version}"
+  # ESPRESSO_VERSION is the source of truth for both the release tag and git commit.
+  local espresso_version_file="${UDB_ROOT}/tools/ruby-gems/udb/lib/udb/ESPRESSO_VERSION"
+  local espresso_version
+  local espresso_commit
+  read_git_pinned_tool_version espresso "${espresso_version_file}" espresso_version espresso_commit
+  echo "==> Building espresso version: ${espresso_version} (commit: ${espresso_commit})"
 
   # Check if the GitHub Release exists
   local release_exists=no
@@ -147,7 +183,7 @@ do_update_espresso() {
       gh release create "${release_tag}" \
         --repo riscv/riscv-unified-db \
         --title "Espresso binaries ${espresso_version}" \
-        --notes "Pre-built espresso binaries for the udb gem (Linux x64 and arm64, built on AlmaLinux 8)." \
+        --notes "Pre-built espresso binaries for the udb gem (Linux x64 and arm64, built on AlmaLinux 8). Commit: ${espresso_commit}" \
         "${work_dir}/espresso-${native_arch}" \
         "${work_dir}/espresso-${native_arch}.checksum"
     fi
@@ -156,7 +192,7 @@ do_update_espresso() {
     gh release create "${release_tag}" \
       --repo riscv/riscv-unified-db \
       --title "Espresso binaries ${espresso_version}" \
-      --notes "Pre-built espresso binaries for the udb gem (Linux x64 and arm64, built on AlmaLinux 8)." \
+      --notes "Pre-built espresso binaries for the udb gem (Linux x64 and arm64, built on AlmaLinux 8). Commit: ${espresso_commit}" \
       "${work_dir}/espresso-x64" \
       "${work_dir}/espresso-arm64" \
       "${work_dir}/espresso-x64.checksum" \
@@ -186,16 +222,11 @@ do_update_must() {
     exit 1
   fi
 
-  # Read the commit hash from the build script
+  # MUST_VERSION is the source of truth for both the release tag and git commit.
+  local must_version_file="${UDB_ROOT}/tools/ruby-gems/udb/lib/udb/MUST_VERSION"
+  local must_version
   local must_commit
-  must_commit=$(grep '^MUST_COMMIT=' "${UDB_ROOT}/tools/scripts/build_must_with_docker.sh" | cut -d'"' -f2)
-  if [ -z "$must_commit" ]; then
-    echo "ERROR: Could not read MUST_COMMIT from build_must_with_docker.sh" >&2
-    exit 1
-  fi
-
-  # Use short commit hash for the version tag
-  local must_version="must-${must_commit:0:7}"
+  read_git_pinned_tool_version must "${must_version_file}" must_version must_commit
   echo "==> Building must version: ${must_version} (commit: ${must_commit})"
 
   # Check if the GitHub Release exists
@@ -337,16 +368,11 @@ do_update_eqntott() {
     exit 1
   fi
 
-  # Read the commit hash from the build script
+  # EQNTOTT_VERSION is the source of truth for both the release tag and git commit.
+  local eqntott_version_file="${UDB_ROOT}/tools/ruby-gems/udb/lib/udb/EQNTOTT_VERSION"
+  local eqntott_version
   local eqntott_commit
-  eqntott_commit=$(grep '^EQNTOTT_COMMIT=' "${UDB_ROOT}/tools/scripts/build_eqntott_with_docker.sh" | cut -d'"' -f2)
-  if [ -z "$eqntott_commit" ]; then
-    echo "ERROR: Could not read EQNTOTT_COMMIT from build_eqntott_with_docker.sh" >&2
-    exit 1
-  fi
-
-  # Use short commit hash for the version tag
-  local eqntott_version="eqntott-${eqntott_commit:0:7}"
+  read_git_pinned_tool_version eqntott "${eqntott_version_file}" eqntott_version eqntott_commit
   echo "==> Building eqntott version: ${eqntott_version} (commit: ${eqntott_commit})"
 
   # Check if the GitHub Release exists
@@ -488,52 +514,30 @@ do_update_z3() {
     exit 1
   fi
 
-  # Read the version currently tracked in dep_versions.rb
-  local z3_version_rb="${UDB_ROOT}/tools/ruby-gems/udb/lib/udb/dep_versions.rb"
-  local current_version
-  current_version=$(ruby -e "load '${z3_version_rb}'; puts Udb::Z3_VERSION" 2>/dev/null) || {
-    echo "ERROR: Could not read current Z3 version from ${z3_version_rb}" >&2
+  # Z3_VERSION is the source of truth for the release tag and upstream version.
+  local z3_version_file="${UDB_ROOT}/tools/ruby-gems/udb/lib/udb/Z3_VERSION"
+  local z3_version
+  z3_version=$(<"${z3_version_file}") || {
+    echo "ERROR: Could not read ${z3_version_file}" >&2
     exit 1
   }
-  echo "==> Current Z3 version in dep_versions.rb: ${current_version}"
 
-  # Query the latest Z3 release tag from upstream (Z3Prover/z3)
-  local latest_version
-  latest_version=$(gh release list --repo Z3Prover/z3 --limit 50 --json tagName \
-    --jq '[.[] | select(.tagName | test("^z3-[0-9]+\\.[0-9]+\\.[0-9]+$"))] | .[0].tagName' 2>/dev/null) || {
-    echo "ERROR: Could not query latest Z3 release from Z3Prover/z3. Check gh authentication." >&2
+  if [[ ! "${z3_version}" =~ ^z3-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "ERROR: Invalid ${z3_version_file}: expected z3-<major>.<minor>.<patch>, got '${z3_version}'" >&2
     exit 1
-  }
-  echo "==> Latest upstream Z3 release: ${latest_version}"
-
-  # Compare versions: strip "z3-" prefix and use sort -V to determine which is newer
-  local current_ver="${current_version#z3-}"
-  local latest_ver="${latest_version#z3-}"
-  local newest
-  newest=$(printf '%s\n%s\n' "${current_ver}" "${latest_ver}" | sort -V | tail -1)
-
-  # Determine the target version to build/release
-  local target_version
-  if [ "${latest_ver}" = "${current_ver}" ]; then
-    echo "==> Z3 is already up to date (${current_version})."
-    target_version="${current_version}"
-  elif [ "${newest}" != "${latest_ver}" ]; then
-    echo "==> Current version (${current_version}) is already newer than upstream (${latest_version})."
-    target_version="${current_version}"
-  else
-    echo "==> New Z3 version available: ${latest_version} (current: ${current_version})."
-    target_version="${latest_version}"
   fi
+
+  echo "==> Building Z3 version: ${z3_version}"
 
   # Check if the GitHub Release exists
   local release_exists=no
-  if gh release view "${target_version}" --repo riscv/riscv-unified-db &>/dev/null; then
+  if gh release view "${z3_version}" --repo riscv/riscv-unified-db &>/dev/null; then
     release_exists=yes
   fi
 
   # Handle based on force flag and release existence
   if [ "${force}" != "yes" ] && [ "${release_exists}" = "yes" ]; then
-    echo "==> GitHub Release ${target_version} already exists. Nothing to do."
+    echo "==> GitHub Release ${z3_version} already exists. Nothing to do."
     echo "    Use -f flag to force rebuild."
     return 0
   fi
@@ -543,103 +547,64 @@ do_update_z3() {
     # Only delete the release if we're building both architectures (not native_only)
     # For native_only builds, we'll use --clobber to replace individual assets
     if [ "${native_only}" != "yes" ]; then
-      echo "==> Deleting existing GitHub Release ${target_version}..."
-      gh release delete "${target_version}" --repo riscv/riscv-unified-db --yes
+      echo "==> Deleting existing GitHub Release ${z3_version}..."
+      gh release delete "${z3_version}" --repo riscv/riscv-unified-db --yes
     else
       echo "==> Will replace existing assets with --clobber"
     fi
   fi
 
-  echo "==> Building Z3 ${target_version}..."
+  echo "==> Building Z3 ${z3_version}..."
 
   local orig_dir="${PWD}"
   local work_dir
   work_dir=$(mktemp -d --tmpdir="$PWD" build-z3.XXXXXX)
 
-  local z3_version
-  if [ "${target_version}" != "${current_version}" ]; then
-    # New upstream version: build from source
-    if [ "${native_only}" = "yes" ]; then
-      # Detect native architecture
-      local native_arch
-      case "$(uname -m)" in
-        x86_64)
-          native_arch="x64"
-          ;;
-        aarch64)
-          native_arch="arm64"
-          ;;
-        *)
-          echo "ERROR: Unsupported architecture: $(uname -m)" >&2
-          exit 1
-          ;;
-      esac
-      echo "==> Building Z3 for native platform (${native_arch})..."
-      "${UDB_ROOT}"/tools/scripts/build_z3_with_docker.sh "${work_dir}/z3-${native_arch}" Release "${native_arch}" || exit 1
+  if [ "${native_only}" = "yes" ]; then
+    # Detect native architecture
+    local native_arch
+    case "$(uname -m)" in
+      x86_64)
+        native_arch="x64"
+        ;;
+      aarch64)
+        native_arch="arm64"
+        ;;
+      *)
+        echo "ERROR: Unsupported architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+    esac
+    echo "==> Building Z3 for native platform (${native_arch})..."
+    "${UDB_ROOT}"/tools/scripts/build_z3_with_docker.sh "${work_dir}/z3-${native_arch}" Release "${native_arch}" || exit 1
 
-      # Read the version produced by the build
-      z3_version=$(cat "${work_dir}/z3-${native_arch}/VERSION")
-      echo "==> Built Z3 version: ${z3_version}"
-
-      # Rename the .so file to the asset name expected by extconf.rb / setup_z3
-      cp "${work_dir}/z3-${native_arch}/lib/libz3.so" "${work_dir}/libz3-${native_arch}.so"
-    else
-      # Build for both architectures
-      echo "==> Building Z3 for x64..."
-      "${UDB_ROOT}"/tools/scripts/build_z3_with_docker.sh "${work_dir}/z3-x64" Release x64 || exit 1
-
-      echo "==> Building Z3 for arm64..."
-      "${UDB_ROOT}"/tools/scripts/build_z3_with_docker.sh "${work_dir}/z3-arm64" Release arm64 || exit 1
-
-      # Read the version produced by the build
-      z3_version=$(cat "${work_dir}/z3-x64/VERSION")
-      echo "==> Built Z3 version: ${z3_version}"
-
-      # Rename the .so files to the asset names expected by extconf.rb / setup_z3
-      cp "${work_dir}/z3-x64/lib/libz3.so"   "${work_dir}/libz3-x64.so"
-      cp "${work_dir}/z3-arm64/lib/libz3.so" "${work_dir}/libz3-arm64.so"
+    local built_version
+    built_version=$(cat "${work_dir}/z3-${native_arch}/VERSION")
+    if [ "${built_version}" != "${z3_version}" ]; then
+      echo "ERROR: Built Z3 version ${built_version} does not match ${z3_version}" >&2
+      exit 1
     fi
+
+    # Rename the .so file to the asset name expected by extconf.rb / setup_z3
+    cp "${work_dir}/z3-${native_arch}/lib/libz3.so" "${work_dir}/libz3-${native_arch}.so"
   else
-    # Version unchanged: use the already-installed libraries from the XDG cache
-    z3_version="${current_version}"
-    local xdg_cache="${XDG_CACHE_HOME:-${HOME}/.cache}"
+    # Build for both architectures
+    echo "==> Building Z3 for x64..."
+    "${UDB_ROOT}"/tools/scripts/build_z3_with_docker.sh "${work_dir}/z3-x64" Release x64 || exit 1
 
-    if [ "${native_only}" = "yes" ]; then
-      # Detect native architecture
-      local native_arch
-      case "$(uname -m)" in
-        x86_64)
-          native_arch="x64"
-          ;;
-        aarch64)
-          native_arch="arm64"
-          ;;
-        *)
-          echo "ERROR: Unsupported architecture: $(uname -m)" >&2
-          exit 1
-          ;;
-      esac
-      local cache_native="${xdg_cache}/udb/z3/${current_version}/${native_arch}/libz3.so"
-      if [ ! -f "${cache_native}" ]; then
-        echo "ERROR: Cached Z3 library not found. Run 'bin/setup' first to download it." >&2
-        echo "  Expected: ${cache_native}" >&2
-        exit 1
-      fi
-      cp "${cache_native}" "${work_dir}/libz3-${native_arch}.so"
-      echo "==> Using cached Z3 library for ${z3_version} (${native_arch})"
-    else
-      local cache_x64="${xdg_cache}/udb/z3/${current_version}/x64/libz3.so"
-      local cache_arm64="${xdg_cache}/udb/z3/${current_version}/arm64/libz3.so"
-      if [ ! -f "${cache_x64}" ] || [ ! -f "${cache_arm64}" ]; then
-        echo "ERROR: Cached Z3 libraries not found. Run 'bin/setup' first to download them." >&2
-        echo "  Expected: ${cache_x64}" >&2
-        echo "  Expected: ${cache_arm64}" >&2
-        exit 1
-      fi
-      cp "${cache_x64}"   "${work_dir}/libz3-x64.so"
-      cp "${cache_arm64}" "${work_dir}/libz3-arm64.so"
-      echo "==> Using cached Z3 libraries for ${z3_version}"
+    echo "==> Building Z3 for arm64..."
+    "${UDB_ROOT}"/tools/scripts/build_z3_with_docker.sh "${work_dir}/z3-arm64" Release arm64 || exit 1
+
+    local built_version
+    built_version=$(cat "${work_dir}/z3-x64/VERSION")
+    if [ "${built_version}" != "${z3_version}" ]; then
+      echo "ERROR: Built Z3 version ${built_version} does not match ${z3_version}" >&2
+      exit 1
     fi
+
+    # Rename the .so files to the asset names expected by extconf.rb / setup_z3
+    cp "${work_dir}/z3-x64/lib/libz3.so"   "${work_dir}/libz3-x64.so"
+    cp "${work_dir}/z3-arm64/lib/libz3.so" "${work_dir}/libz3-arm64.so"
   fi
 
   # Generate checksum files
@@ -704,24 +669,9 @@ do_update_z3() {
       "${work_dir}/libz3-arm64.checksum"
   fi
 
-  if [ "${target_version}" != "${current_version}" ]; then
-    # Update dep_version.rb so the gem knows which release to download
-    # z3_version_rb already declared above
-    echo "${z3_version}" > "${UDB_ROOT}/tools/ruby-gems/udb/lib/udb/Z3_VERSION"
-    echo "==> Updated ${z3_version_rb}"
-  fi
-
   cd "${orig_dir}" || exit 1
   rm -rf "${work_dir}"
 
   echo ""
-  if [ "${target_version}" != "${current_version}" ]; then
-    echo "Done. Next steps:"
-    echo "  1. git add tools/ruby-gems/udb/lib/udb/dep_versions.rb"
-    echo "  2. git add tools/ruby-gems/udb/lib/udb/Z3_VERSION"
-    echo "  2. git commit -m 'chore: update Z3 to ${z3_version}'"
-    echo "  3. Open a PR"
-  else
-    echo "Done. GitHub Release ${z3_version} created on riscv/riscv-unified-db."
-  fi
+  echo "Done. GitHub Release ${z3_version} created on riscv/riscv-unified-db."
 }

--- a/renovate.json
+++ b/renovate.json
@@ -70,6 +70,49 @@
       "datasourceTemplate": "rubygems"
     },
     {
+      "description": "Bundler version installed by default via mise",
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.default-gems$/"],
+      "matchStrings": ["^bundler\\s+(?<currentValue>[\\d.]+)"],
+      "depNameTemplate": "gem:bundler",
+      "packageNameTemplate": "bundler",
+      "datasourceTemplate": "rubygems"
+    },
+    {
+      "description": "must (mustool) commit tracked by the udb gem binary version file",
+      "customType": "regex",
+      "managerFilePatterns": ["/^tools/ruby-gems/udb/lib/udb/MUST_VERSION$/"],
+      "matchStrings": ["^must-(?<currentDigest>[a-f0-9]{7,40})\\s*$"],
+      "currentValueTemplate": "master",
+      "depNameTemplate": "jar-ben/mustool",
+      "packageNameTemplate": "https://github.com/jar-ben/mustool",
+      "datasourceTemplate": "git-refs"
+    },
+    {
+      "description": "eqntott commit tracked by the udb gem binary version file",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^tools/ruby-gems/udb/lib/udb/EQNTOTT_VERSION$/"
+      ],
+      "matchStrings": ["^eqntott-(?<currentDigest>[a-f0-9]{7,40})\\s*$"],
+      "currentValueTemplate": "master",
+      "depNameTemplate": "TheProjecter/eqntott",
+      "packageNameTemplate": "https://github.com/TheProjecter/eqntott",
+      "datasourceTemplate": "git-refs"
+    },
+    {
+      "description": "espresso commit tracked by the udb gem binary version file",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^tools/ruby-gems/udb/lib/udb/ESPRESSO_VERSION$/"
+      ],
+      "matchStrings": ["^espresso-(?<currentDigest>[a-f0-9]{7,40})\\s*$"],
+      "currentValueTemplate": "master",
+      "depNameTemplate": "psksvp/espresso-ab-1.0",
+      "packageNameTemplate": "https://github.com/psksvp/espresso-ab-1.0",
+      "datasourceTemplate": "git-refs"
+    },
+    {
       "description": "Xtext version shared by the Eclipse Maven and Gradle projects",
       "customType": "regex",
       "managerFilePatterns": [
@@ -131,6 +174,13 @@
       "matchManagers": ["git-submodules"],
       "matchDepNames": ["ext/llvm-project"],
       "schedule": ["before 6am on monday"]
+    },
+    {
+      "description": "Keep AlmaLinux on major version 8 (toolchain container requires its older glibc for prebuilt toolchain compatibility)",
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["almalinux"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }

--- a/tools/ruby-gems/udb/lib/udb/ESPRESSO_VERSION
+++ b/tools/ruby-gems/udb/lib/udb/ESPRESSO_VERSION
@@ -1,1 +1,1 @@
-espresso-1.0
+espresso-18f59c7

--- a/tools/scripts/build_eqntott_with_docker.sh
+++ b/tools/scripts/build_eqntott_with_docker.sh
@@ -9,8 +9,8 @@
 #   output_dir   - where to place the binary (default: ./eqntott-build)
 #   architecture - x64 or arm64 (default: x64)
 #
-# The pinned commit matches EQNTOTT_VERSION in the udb gem.
-# To update: change EQNTOTT_COMMIT below and update lib/udb/EQNTOTT_VERSION accordingly.
+# EQNTOTT_VERSION in the udb gem is the single source of truth.
+# To update: change tools/ruby-gems/udb/lib/udb/EQNTOTT_VERSION.
 
 set -euo pipefail
 
@@ -19,8 +19,23 @@ info()  { echo "INFO: $*"  >&2; }
 
 command_exists() { command -v "$1" >/dev/null 2>&1; }
 
-# Pinned commit - must match lib/udb/EQNTOTT_VERSION
-EQNTOTT_COMMIT="392759e6493a46f1d1ed7d9fb1c7c31197b0f6a8"
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+UDB_ROOT=$(cd -- "${SCRIPT_DIR}/../.." && pwd)
+EQNTOTT_VERSION_FILE="${UDB_ROOT}/tools/ruby-gems/udb/lib/udb/EQNTOTT_VERSION"
+EQNTOTT_VERSION=$(<"${EQNTOTT_VERSION_FILE}") || error "Could not read ${EQNTOTT_VERSION_FILE}"
+
+case "${EQNTOTT_VERSION}" in
+    eqntott-*)
+        EQNTOTT_COMMIT="${EQNTOTT_VERSION#eqntott-}"
+        ;;
+    *)
+        error "Invalid EQNTOTT_VERSION '${EQNTOTT_VERSION}'; expected eqntott-<git-commit>"
+        ;;
+esac
+
+if [[ ! "${EQNTOTT_COMMIT}" =~ ^[a-f0-9]{7,40}$ ]]; then
+    error "Invalid EQNTOTT_VERSION '${EQNTOTT_VERSION}'; expected eqntott-<7-to-40-char-hex-commit>"
+fi
 
 build_eqntott_with_docker() {
     local output_dir="${1:-./eqntott-build}"
@@ -40,7 +55,7 @@ build_eqntott_with_docker() {
             ;;
     esac
 
-    info "Building eqntott (commit $EQNTOTT_COMMIT)"
+    info "Building eqntott (${EQNTOTT_VERSION}, commit ${EQNTOTT_COMMIT})"
     info "Output directory: $output_dir"
     info "Architecture: $architecture ($docker_platform)"
 

--- a/tools/scripts/build_espresso_with_docker.sh
+++ b/tools/scripts/build_espresso_with_docker.sh
@@ -8,6 +8,9 @@
 # Usage: build_espresso_with_docker.sh [output_dir] [architecture]
 #   output_dir   - where to place the binary (default: ./espresso-build)
 #   architecture - x64 or arm64 (default: x64)
+#
+# ESPRESSO_VERSION in the udb gem is the single source of truth.
+# To update: change tools/ruby-gems/udb/lib/udb/ESPRESSO_VERSION.
 
 set -euo pipefail
 
@@ -15,6 +18,24 @@ error() { echo "ERROR: $*" >&2; exit 1; }
 info()  { echo "INFO: $*"  >&2; }
 
 command_exists() { command -v "$1" >/dev/null 2>&1; }
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+UDB_ROOT=$(cd -- "${SCRIPT_DIR}/../.." && pwd)
+ESPRESSO_VERSION_FILE="${UDB_ROOT}/tools/ruby-gems/udb/lib/udb/ESPRESSO_VERSION"
+ESPRESSO_VERSION=$(<"${ESPRESSO_VERSION_FILE}") || error "Could not read ${ESPRESSO_VERSION_FILE}"
+
+case "${ESPRESSO_VERSION}" in
+    espresso-*)
+        ESPRESSO_COMMIT="${ESPRESSO_VERSION#espresso-}"
+        ;;
+    *)
+        error "Invalid ESPRESSO_VERSION '${ESPRESSO_VERSION}'; expected espresso-<git-commit>"
+        ;;
+esac
+
+if [[ ! "${ESPRESSO_COMMIT}" =~ ^[a-f0-9]{7,40}$ ]]; then
+    error "Invalid ESPRESSO_VERSION '${ESPRESSO_VERSION}'; expected espresso-<7-to-40-char-hex-commit>"
+fi
 
 build_espresso_with_docker() {
     local output_dir="${1:-./espresso-build}"
@@ -34,7 +55,7 @@ build_espresso_with_docker() {
             ;;
     esac
 
-    info "Building espresso"
+    info "Building espresso (${ESPRESSO_VERSION}, commit ${ESPRESSO_COMMIT})"
     info "Output directory: $output_dir"
     info "Architecture: $architecture ($docker_platform)"
 
@@ -46,7 +67,7 @@ build_espresso_with_docker() {
 
     info "Using temporary directory: $temp_dir"
 
-    # Write Dockerfile
+    # Write Dockerfile - ESPRESSO_COMMIT is baked in at image-build time via ARG
     cat > "$temp_dir/Dockerfile" << 'EOF'
 FROM almalinux:8
 
@@ -60,6 +81,7 @@ RUN dnf install -y \
 ENV PATH=/opt/rh/gcc-toolset-12/root/usr/bin:$PATH \
     LD_LIBRARY_PATH=/opt/rh/gcc-toolset-12/root/usr/lib64
 
+ARG ESPRESSO_COMMIT
 WORKDIR /build
 
 RUN curl -L -o musl-1.2.5.tar.gz https://musl.libc.org/releases/musl-1.2.5.tar.gz \
@@ -68,7 +90,9 @@ RUN curl -L -o musl-1.2.5.tar.gz https://musl.libc.org/releases/musl-1.2.5.tar.g
   && ./configure && make install
 
 # Clone espresso source
-RUN git clone --depth=1 https://github.com/psksvp/espresso-ab-1.0.git espresso
+RUN git clone https://github.com/psksvp/espresso-ab-1.0.git espresso && \
+    cd espresso && \
+    git checkout ${ESPRESSO_COMMIT}
 
 WORKDIR /build/espresso
 
@@ -82,7 +106,12 @@ EOF
 
     local image_name="espresso-builder-$$"
     info "Building Docker image for $docker_platform..."
-    docker build --platform="$docker_platform" -t "$image_name" -f "$temp_dir/Dockerfile" "$temp_dir" \
+    docker build \
+        --platform="$docker_platform" \
+        --build-arg "ESPRESSO_COMMIT=$ESPRESSO_COMMIT" \
+        -t "$image_name" \
+        -f "$temp_dir/Dockerfile" \
+        "$temp_dir" \
         || error "Docker build failed"
 
     local container_name="espresso-extract-$$"

--- a/tools/scripts/build_must_with_docker.sh
+++ b/tools/scripts/build_must_with_docker.sh
@@ -9,8 +9,8 @@
 #   output_dir   - where to place the binary (default: ./must-build)
 #   architecture - x64 or arm64 (default: x64)
 #
-# The pinned commit matches MUST_VERSION in the udb gem.
-# To update: change MUST_COMMIT below and update lib/udb/MUST_VERSION accordingly.
+# MUST_VERSION in the udb gem is the single source of truth.
+# To update: change tools/ruby-gems/udb/lib/udb/MUST_VERSION.
 
 set -euo pipefail
 
@@ -19,8 +19,23 @@ info()  { echo "INFO: $*"  >&2; }
 
 command_exists() { command -v "$1" >/dev/null 2>&1; }
 
-# Pinned commit - must match lib/udb/MUST_VERSION
-MUST_COMMIT="17fa9f9542a9ce05328dfccd1cd410f05f741ab3"
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+UDB_ROOT=$(cd -- "${SCRIPT_DIR}/../.." && pwd)
+MUST_VERSION_FILE="${UDB_ROOT}/tools/ruby-gems/udb/lib/udb/MUST_VERSION"
+MUST_VERSION=$(<"${MUST_VERSION_FILE}") || error "Could not read ${MUST_VERSION_FILE}"
+
+case "${MUST_VERSION}" in
+    must-*)
+        MUST_COMMIT="${MUST_VERSION#must-}"
+        ;;
+    *)
+        error "Invalid MUST_VERSION '${MUST_VERSION}'; expected must-<git-commit>"
+        ;;
+esac
+
+if [[ ! "${MUST_COMMIT}" =~ ^[a-f0-9]{7,40}$ ]]; then
+    error "Invalid MUST_VERSION '${MUST_VERSION}'; expected must-<7-to-40-char-hex-commit>"
+fi
 
 build_must_with_docker() {
     local output_dir="${1:-./must-build}"
@@ -40,7 +55,7 @@ build_must_with_docker() {
             ;;
     esac
 
-    info "Building must (mustool @ $MUST_COMMIT)"
+    info "Building must (${MUST_VERSION}, commit ${MUST_COMMIT})"
     info "Output directory: $output_dir"
     info "Architecture: $architecture ($docker_platform)"
 

--- a/tools/scripts/build_z3_with_docker.sh
+++ b/tools/scripts/build_z3_with_docker.sh
@@ -2,9 +2,10 @@
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-# Build Z3 from source using Docker and AlmaLinux 8
-# This script downloads the latest Z3 release, compiles it in a Docker container,
-# and extracts the installation files to the host.
+# Build Z3 from source using Docker and AlmaLinux 8.
+# Z3_VERSION in the udb gem is the single source of truth; this script downloads
+# that upstream Z3 release, compiles it in a Docker container, and extracts the
+# installation files to the host.
 
 set -euo pipefail
 
@@ -23,6 +24,15 @@ info() {
 command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+UDB_ROOT=$(cd -- "${SCRIPT_DIR}/../.." && pwd)
+Z3_VERSION_FILE="${UDB_ROOT}/tools/ruby-gems/udb/lib/udb/Z3_VERSION"
+Z3_VERSION=$(<"${Z3_VERSION_FILE}") || error "Could not read ${Z3_VERSION_FILE}"
+
+if [[ ! "${Z3_VERSION}" =~ ^z3-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    error "Invalid Z3_VERSION '${Z3_VERSION}'; expected z3-<major>.<minor>.<patch>"
+fi
 
 # Main function to build Z3
 build_z3_with_docker() {
@@ -50,7 +60,7 @@ build_z3_with_docker() {
             ;;
     esac
 
-    info "Starting Z3 build process"
+    info "Starting Z3 build process (${Z3_VERSION})"
     info "Output directory: $output_dir"
     info "Build type: $build_type"
     info "Architecture: $architecture ($docker_platform)"
@@ -72,9 +82,8 @@ build_z3_with_docker() {
 
     info "Using temporary directory: $temp_dir"
 
-    # Get latest Z3 release version from GitHub API
-    info "Fetching latest Z3 release information from GitHub..."
-    local latest_release
+    local version="${Z3_VERSION}"
+    info "Z3 version: ${version}"
 
     # Check for GitHub token for authentication (helps avoid rate limits)
     local auth_header=""
@@ -83,35 +92,8 @@ build_z3_with_docker() {
         info "Using GitHub authentication token"
     fi
 
-    if command_exists curl; then
-        if [[ -n "$auth_header" ]]; then
-            latest_release=$(curl -s -H "$auth_header" https://api.github.com/repos/Z3Prover/z3/releases/latest)
-        else
-            latest_release=$(curl -s https://api.github.com/repos/Z3Prover/z3/releases/latest)
-        fi
-    else
-        if [[ -n "$auth_header" ]]; then
-            latest_release=$(wget -qO- --header="$auth_header" https://api.github.com/repos/Z3Prover/z3/releases/latest)
-        else
-            latest_release=$(wget -qO- https://api.github.com/repos/Z3Prover/z3/releases/latest)
-        fi
-    fi
-
-    local version
-    version=$(echo "$latest_release" | grep -o '"tag_name": *"[^"]*"' | sed 's/"tag_name": *"\(.*\)"/\1/')
-
-    if [[ -z "$version" ]]; then
-        # Check if we hit rate limit
-        if echo "$latest_release" | grep -q "rate limit"; then
-            error "GitHub API rate limit exceeded. Please set GITHUB_TOKEN environment variable or try again later."
-        fi
-        error "Failed to fetch latest Z3 version from GitHub. Response: $(echo "$latest_release" | head -c 200)"
-    fi
-
-    info "Latest Z3 version: $version"
-
     # Download source tarball
-    local tarball_url="http://github.com/Z3Prover/z3/archive/refs/tags/${version}.tar.gz"
+    local tarball_url="https://github.com/Z3Prover/z3/archive/refs/tags/${version}.tar.gz"
     local tarball_path="$temp_dir/z3-${version}.tar.gz"
 
     info "Downloading Z3 source from: $tarball_url"
@@ -133,7 +115,7 @@ build_z3_with_docker() {
     if ! file "$tarball_path" | grep -q "gzip compressed"; then
         info "Downloaded file is not a gzip archive. First 500 bytes:"
         head -c 500 "$tarball_path" >&2
-        error "Downloaded file is not in gzip format. This may indicate a rate limit or download error."
+        error "Downloaded file is not in gzip format. Check that ${version} is a valid Z3 tag."
     fi
 
     # Extract tarball


### PR DESCRIPTION
z3/eqntott/espresso/must had their versions hardcoded in multiple locations. This updates the scripts to use the `*_VERSION` file as the sole source of truth for the version. It also enables Renovate to manage the version going forward for automatic updates.