### PR TITLE
migrate from mergedeep to deepmerge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
     "check-jsonschema>=0.36.1",
+    "deepmerge>=2.1.0",
     "jsonschema>=4.26.0",
-    "mergedeep>=1.3.4",
     "pycobertura>=4.1.0",
     "pytest>=9.0.2",
     "pyyaml>=6.0.3",

--- a/tools/ruby-gems/udb/python/yaml_resolver.py
+++ b/tools/ruby-gems/udb/python/yaml_resolver.py
@@ -12,15 +12,22 @@ import tempfile
 from copy import deepcopy
 from pathlib import Path
 
+from deepmerge import Merger
 from jsonschema import Draft7Validator, validators
 from jsonschema.exceptions import ValidationError, best_match
-from mergedeep import Strategy, merge
 from referencing import Registry, Resource
 from ruamel.yaml import YAML
 from tqdm.auto import tqdm
 
 # cache of Schema validators
 schemas = {}
+
+
+_REPLACE_MERGER = Merger(
+    [(dict, ["merge"])],
+    ["override"],
+    ["override"],
+)
 
 
 def udb_root(d):
@@ -389,8 +396,8 @@ def _resolve(obj, obj_path, obj_file_path, doc_obj, arch_root, do_checks, compil
             for key in ref_obj:
                 if key == "$parent_of" or key == "$child_of":
                     continue  # we don't propagate $parent_of / $child_of
-                if isinstance(parent_obj.get(key), dict):
-                    merge(parent_obj[key], ref_obj[key], strategy=Strategy.REPLACE)
+                if isinstance(parent_obj.get(key), dict) and isinstance(ref_obj[key], dict):
+                    _REPLACE_MERGER.merge(parent_obj[key], deepcopy(ref_obj[key]))
                 else:
                     parent_obj[key] = deepcopy(ref_obj[key])
 
@@ -429,31 +436,20 @@ def _resolve(obj, obj_path, obj_file_path, doc_obj, arch_root, do_checks, compil
                     compile_idl,
                 )
             else:
-                if isinstance(parent_obj[key], dict):
-                    final_obj[key] = merge(
-                        yaml.load("{}"),
-                        parent_obj[key],
-                        _resolve(
-                            obj[key],
-                            obj_path + [key],
-                            obj_file_path,
-                            doc_obj,
-                            arch_root,
-                            do_checks,
-                            compile_idl,
-                        ),
-                        strategy=Strategy.REPLACE,
-                    )
+                resolved_child_value = _resolve(
+                    obj[key],
+                    obj_path + [key],
+                    obj_file_path,
+                    doc_obj,
+                    arch_root,
+                    do_checks,
+                    compile_idl,
+                )
+                if isinstance(parent_obj[key], dict) and isinstance(resolved_child_value, dict):
+                    final_obj[key] = deepcopy(parent_obj[key])
+                    _REPLACE_MERGER.merge(final_obj[key], deepcopy(resolved_child_value))
                 else:
-                    final_obj[key] = _resolve(
-                        obj[key],
-                        obj_path + [key],
-                        obj_file_path,
-                        doc_obj,
-                        arch_root,
-                        do_checks,
-                        compile_idl,
-                    )
+                    final_obj[key] = resolved_child_value
 
         if "$remove" in final_obj:
             if isinstance(final_obj["$remove"], list):

--- a/uv.lock
+++ b/uv.lock
@@ -124,6 +124,15 @@ wheels = [
 ]
 
 [[package]]
+name = "deepmerge"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/78/6e9e20106224083cfb817d2d3c26e80e72258d617b616721a169b87081e0/deepmerge-2.1.0.tar.gz", hash = "sha256:07ca7a7b8935df596c512fa8161877c0487ac61f691c07766e7d71d2b23bdd2f", size = 21449, upload-time = "2026-06-22T05:46:07.669Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/25/2a75b47cb057b1e164c604fb81ab690a6cdb5e2260ce651194eae90f64a3/deepmerge-2.1.0-py3-none-any.whl", hash = "sha256:8f148339a91d680a75ecb74ade235d9e759a93df373a0b04e9d31c8666cfeb75", size = 14345, upload-time = "2026-06-22T05:46:06.742Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -333,15 +342,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
-]
-
-[[package]]
-name = "mergedeep"
-version = "1.3.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
 ]
 
 [[package]]
@@ -596,8 +596,8 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "check-jsonschema" },
+    { name = "deepmerge" },
     { name = "jsonschema" },
-    { name = "mergedeep" },
     { name = "pycobertura" },
     { name = "pytest" },
     { name = "pyyaml" },
@@ -609,8 +609,8 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "check-jsonschema", specifier = ">=0.36.1" },
+    { name = "deepmerge", specifier = ">=2.1.0" },
     { name = "jsonschema", specifier = ">=4.26.0" },
-    { name = "mergedeep", specifier = ">=1.3.4" },
     { name = "pycobertura", specifier = ">=4.1.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },


### PR DESCRIPTION
mergedeep seems to be abandoned and has not seen an update since 2021. Renovate is flagging it as abandoned.