### PR TITLE
docs: improve installation verification instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -91,18 +91,16 @@ When it finishes, it will tell you how to activate mise in your shell profile so
 mise-managed tools are available in future terminal sessions, and remind you to use the
 wrappers in `bin/` when invoking any tool.
 
-==== Verify the installation
+=== Verify the installation
 
-After `bin/setup` completes, verify that the development environment has been configured successfully by running the available wrapper scripts from the `bin/` directory:
+After `bin/setup` completes, verify that the development environment has been configured successfully by running:
 
 [source,bash]
 ----
-./bin/regress -h
-./bin/generate -h
-./bin/chore -h
+./bin/doctor
 ----
 
-Each command should display its help message without errors. If any command fails, re-run `bin/setup` and ensure that `mise` has been activated in your shell as instructed by the setup script.
+The doctor script checks that the required tools, dependencies, and development environment are configured correctly. If it reports any issues, follow the suggested fixes or re-run `bin/setup` and ensure that `mise` has been activated in your shell as instructed by the setup script.
 === Tasks
 
 [source,bash]

--- a/README.adoc
+++ b/README.adoc
@@ -91,6 +91,18 @@ When it finishes, it will tell you how to activate mise in your shell profile so
 mise-managed tools are available in future terminal sessions, and remind you to use the
 wrappers in `bin/` when invoking any tool.
 
+==== Verify the installation
+
+After `bin/setup` completes, verify that the development environment has been configured successfully by running the available wrapper scripts from the `bin/` directory:
+
+[source,bash]
+----
+./bin/regress -h
+./bin/generate -h
+./bin/chore -h
+----
+
+Each command should display its help message without errors. If any command fails, re-run `bin/setup` and ensure that `mise` has been activated in your shell as instructed by the setup script.
 === Tasks
 
 [source,bash]


### PR DESCRIPTION
## Summary

Improve the installation verification section in `README.adoc` by adding guidance on verifying the development environment after running `bin/setup`.

## Changes

- Add a dedicated "Verify the installation" section.
- Document how contributors can verify that the setup completed successfully by running the wrapper scripts in `bin/`.
- Clarify what contributors should do if the verification commands fail.

## Why

While setting up the project, I noticed that the README explains how to install the development environment using `bin/setup`, but it does not explicitly describe how contributors can verify that the setup completed successfully. This change adds a simple verification step to improve the onboarding experience for new contributors.