### PR TITLE
fix(vscode): do not highlight sail() keys as IDL

### DIFF
--- a/tools/vscode/yamlidl/syntaxes/yaml-idl-injection.json
+++ b/tools/vscode/yamlidl/syntaxes/yaml-idl-injection.json
@@ -76,7 +76,7 @@
     },
     {
       "comment": "Match quoted string values after keys ending with ()",
-      "begin": "^(\\s*)([\\w-]+)(\\([^)]*\\))\\s*:\\s*(['\"])",
+      "begin": "^(\\s*)(?!sail\\()([\\w-]+)(\\([^)]*\\))\\s*:\\s*(['\"])",
       "beginCaptures": {
         "2": {
           "name": "entity.name.function.yaml"
@@ -107,7 +107,7 @@
     },
     {
       "comment": "Match unquoted single-line scalar values after keys ending with ()",
-      "begin": "^(\\s*)([\\w-]+)(\\([^)]*\\))\\s*:\\s*(?=[^\\s#])(?![\\|>\\[\\{'\"])",
+      "begin": "^(\\s*)(?!sail\\()([\\w-]+)(\\([^)]*\\))\\s*:\\s*(?=[^\\s#])(?![\\|>\\[\\{'\"])",
       "beginCaptures": {
         "2": {
           "name": "entity.name.function.yaml"
@@ -130,7 +130,7 @@
     },
     {
       "comment": "Match block scalar (literal |) values after keys ending with ()",
-      "begin": "^(\\s*)([\\w-]+)(\\([^)]*\\))\\s*:\\s*\\|[-+]?\\s*$",
+      "begin": "^(\\s*)(?!sail\\()([\\w-]+)(\\([^)]*\\))\\s*:\\s*\\|[-+]?\\s*$",
       "beginCaptures": {
         "2": {
           "name": "entity.name.function.yaml"
@@ -153,7 +153,7 @@
     },
     {
       "comment": "Match block scalar (folded >) values after keys ending with ()",
-      "begin": "^(\\s*)([\\w-]+)(\\([^)]*\\))\\s*:\\s*>[-+]?\\s*$",
+      "begin": "^(\\s*)(?!sail\\()([\\w-]+)(\\([^)]*\\))\\s*:\\s*>[-+]?\\s*$",
       "beginCaptures": {
         "2": {
           "name": "entity.name.function.yaml"

--- a/tools/vscode/yamlidl/test-example.yaml
+++ b/tools/vscode/yamlidl/test-example.yaml
@@ -29,7 +29,6 @@ encoding(): "0000000 rs2 rs1 000 rd 0110011"
 # Keys starting with sail() should NOT get IDL highlighting (Issue #1715)
 sail(): "wfi_execution_environment_behavior"
 
-
 # Keys with arguments - IDL highlighting should be applied
 execute(Bits<5> rd, Bits<5> rs1, Bits<5> rs2): "X[rd] = X[rs1] & X[rs2]"
 

--- a/tools/vscode/yamlidl/test-example.yaml
+++ b/tools/vscode/yamlidl/test-example.yaml
@@ -26,6 +26,10 @@ long_description: |
 operation(): "X[rd] = X[rs1] + X[rs2]"
 encoding(): "0000000 rs2 rs1 000 rd 0110011"
 
+# Keys starting with sail() should NOT get IDL highlighting (Issue #1715)
+sail(): "wfi_execution_environment_behavior"
+
+
 # Keys with arguments - IDL highlighting should be applied
 execute(Bits<5> rd, Bits<5> rs1, Bits<5> rs2): "X[rd] = X[rs1] & X[rs2]"
 


### PR DESCRIPTION
## Problem

The UDB VSCode extension's TextMate injection matches any key ending with `()` or arguments (i.e. matching `([\w-]+)(\([^)]*\))`) and highlights the value as IDL. 

However, UDB schemas support a `sail()` key to describe instruction semantics in the Sail language. Since this key ends in `()`, the extension incorrectly highlights Sail code as IDL syntax.

## Solution

Prefix the key matching pattern in all 4 IDL grammar injection points in `syntaxes/yaml-idl-injection.json` with a negative lookahead:
```regex
(?!sail\()
```
This excludes any key starting with `sail(` (e.g. `sail()`) from the IDL injection matching logic.

## Testing

Added a test case for `sail()` in `tools/vscode/yamlidl/test-example.yaml` to verify the exclusion:
```yaml
# Keys starting with sail() should NOT get IDL highlighting (Issue #1715)
sail(): "wfi_execution_environment_behavior"
```

Closes #1715