### PR TITLE
data: set data_independent_timing: true for scalar crypto instructions

### DIFF
--- a/spec/std/isa/inst/Zbkb/brev8.yaml
+++ b/spec/std/isa/inst/Zbkb/brev8.yaml
@@ -25,7 +25,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: false
+data_independent_timing: true
 operation(): |
   XReg input = X[xs1];
   XReg output = 0;

--- a/spec/std/isa/inst/Zbkb/unzip.yaml
+++ b/spec/std/isa/inst/Zbkb/unzip.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: false
+data_independent_timing: true
 operation(): |
   XReg input = X[xs1];
   XReg output = 0;

--- a/spec/std/isa/inst/Zbkb/zip.yaml
+++ b/spec/std/isa/inst/Zbkb/zip.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: false
+data_independent_timing: true
 operation(): |
   XReg input = X[xs1];
   XReg output = 0;

--- a/spec/std/isa/inst/Zbkx/xperm4.yaml
+++ b/spec/std/isa/inst/Zbkx/xperm4.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: false
+data_independent_timing: true
 operation(): |
   XReg input1 = X[xs1];
   XReg input2 = X[xs2];

--- a/spec/std/isa/inst/Zbkx/xperm8.yaml
+++ b/spec/std/isa/inst/Zbkx/xperm8.yaml
@@ -29,7 +29,7 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: false
+data_independent_timing: true
 operation(): |
   XReg input1 = X[xs1];
   XReg input2 = X[xs2];

--- a/spec/std/isa/inst/Zks/sm3p0.yaml
+++ b/spec/std/isa/inst/Zks/sm3p0.yaml
@@ -25,5 +25,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: false
+data_independent_timing: true
 operation(): |

--- a/spec/std/isa/inst/Zks/sm3p1.yaml
+++ b/spec/std/isa/inst/Zks/sm3p1.yaml
@@ -25,5 +25,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: false
+data_independent_timing: true
 operation(): |

--- a/spec/std/isa/inst/Zks/sm4ed.yaml
+++ b/spec/std/isa/inst/Zks/sm4ed.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: false
+data_independent_timing: true
 operation(): |

--- a/spec/std/isa/inst/Zks/sm4ks.yaml
+++ b/spec/std/isa/inst/Zks/sm4ks.yaml
@@ -29,5 +29,5 @@ access:
   u: always
   vs: always
   vu: always
-data_independent_timing: false
+data_independent_timing: true
 operation(): |


### PR DESCRIPTION
Corrects the data_independent_timing property to true for the remaining scalar cryptographic and supporting bitmanip instructions: unzip, brev8, zip, xperm4, xperm8, sm3p0, sm3p1, sm4ed, and sm4ks. All these instructions belong to extensions included in the Zkt constant-time latency contract.