### PR TITLE
fix: throw clear error for Z3 on macOS instead of downloading Linux .so

### DIFF
--- a/tools/ruby-gems/udb/ext/udb_download/extconf.rb
+++ b/tools/ruby-gems/udb/ext/udb_download/extconf.rb
@@ -193,6 +193,17 @@ z3_version = Udb::Z3_VERSION
 z3_dir  = File.join(xdg_cache, "udb", "z3", z3_version, cpu)
 z3_file = File.join(z3_dir, "libz3.so")
 
+if RbConfig::CONFIG["host_os"] =~ /darwin|mac os/
+  abort <<~ERROR
+    ERROR: Prebuilt Z3 binaries are not yet available for macOS.
+    The published GitHub release assets contain Linux libz3.so binaries, which cannot be loaded on macOS.
+    If you previously ran bin/setup on macOS, remove the cached Z3 directory:
+
+      #{z3_dir}
+    See https://github.com/riscv/riscv-unified-db/issues/1996
+  ERROR
+end
+
 unless File.exist?(z3_file)
   FileUtils.mkdir_p(z3_dir)
   url_str = "https://github.com/#{GITHUB_REPO}/releases/download/#{z3_version}/libz3-#{cpu}.so"


### PR DESCRIPTION
## Summary
On macOS, `extconf.rb` selected the Z3 binary by CPU only (`arm64`/`x64`) and always downloaded `libz3-<cpu>.so` (a Linux ELF), with no OS check. This library fails to load on macOS with `slice is not valid mach-o file`, breaking any Z3-dependent workflow (e.g. `./bin/regress`).

There is currently no macOS Z3 `.dylib` published in the release assets, so this PR makes `extconf.rb` **detect macOS and abort with a clear, actionable error** instead of silently downloading the incompatible Linux library. This matches the maintainer guidance in #1996: *"If we don't have that, we should at least be throwing a clear error."*

## Change
- Added a `host_os` check in the Z3 section of `extconf.rb`.
- On macOS (Darwin), it aborts before any download with a message that explains the issue, points to the cache directory to clean up a stale `libz3.so`, and links to #1996.
- The Linux path is completely unchanged.

## Design note (why an unconditional error, not a `.dylib` check)
I considered checking for a cached `libz3.dylib` to be forward-compatible. However, no code path currently produces a macOS `.dylib` — so that check would be unreachable dead logic today, and could even mask runtime failures if a `.dylib` were placed manually (the loader still resolves `.so` names). An unconditional macOS abort is cleaner and honest about the current state. Forward-compatible `.dylib` support can come alongside the actual macOS build pipeline in a follow-up.

## Testing
Verified on macOS (Apple Silicon, arm64):
- `ruby extconf.rb` aborts with exit code 1 and the clear error message, even with a stale `libz3.so` already in the cache.
- Linux path is untouched (no regression risk for CI/Ubuntu).

Note: macOS CI does not exist yet, so this was verified manually.

Closes #1996