### PR TITLE
Add requirements for Supm and Sspm extensions

### DIFF
--- a/spec/std/isa/ext/Sspm.yaml
+++ b/spec/std/isa/ext/Sspm.yaml
@@ -21,3 +21,8 @@ versions:
   - version: "1.0.0"
     state: ratified
     ratification_date: 2024-10
+requirements:
+  extension:
+    allOf:
+      - name: S
+      - name: Smnpm

--- a/spec/std/isa/ext/Supm.yaml
+++ b/spec/std/isa/ext/Supm.yaml
@@ -21,3 +21,20 @@ versions:
   - version: "1.0.0"
     state: ratified
     ratification_date: 2024-10
+requirements:
+  allOf:
+    - extension:
+        name: U
+    - if:
+        extension:
+          name: S
+      then:
+        extension:
+          name: Ssnpm
+    - if:
+        not:
+          extension:
+            name: S
+      then:
+        extension:
+          name: Smnpm


### PR DESCRIPTION
According to the pointer masking specification and discussions in #1768:
- `Supm` (User-mode pointer masking execution environment extension) requires User-mode (`U`). If Supervisor-mode (`S`) is implemented, it additionally requires the `Ssnpm` hardware extension to control U-mode pointer masking. Otherwise, if `S` is not implemented, it requires the `Smnpm` hardware extension.
- `Sspm` (Supervisor-mode pointer masking execution environment extension) requires Supervisor-mode (`S`) and the `Smnpm` hardware extension to control S-mode pointer masking.

This commit adds these conditional requirements to `Supm.yaml` and `Sspm.yaml`.

Closes #1768.