### PR TITLE
fix(sorbet): align CsrField interface with implementation

### DIFF
--- a/tools/ruby-gems/idlc/lib/idlc/interfaces.rb
+++ b/tools/ruby-gems/idlc/lib/idlc/interfaces.rb
@@ -79,6 +79,10 @@ module Idl
     sig { abstract.returns(T::Boolean) }
     def defined_in_base64?; end
 
+    # whether or not this field is defined in the given base
+    sig { abstract.params(xlen: Integer).returns(T::Boolean) }
+    def defined_in_base?(xlen); end
+
     # whether or not this field is defined only in RV64
     sig { abstract.returns(T::Boolean) }
     def base64_only?; end
@@ -90,7 +94,7 @@ module Idl
     # returns the location of the field in the CSR.
     # base is required when the field moves locations between RV32 and RV64
     sig { abstract.params(base: T.nilable(Integer)).returns(T::Range[Integer]) }
-    def location(base); end
+    def location(base = nil); end
 
     sig { abstract.params(base: T.nilable(Integer)).returns(Integer) }
     def width(base); end

--- a/tools/ruby-gems/udb/lib/udb/obj/csr_field.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/csr_field.rb
@@ -715,7 +715,7 @@ module Udb
     sig { override.returns(T::Boolean) }
     def defined_in_base64? = base != 32
 
-    sig { params(xlen: Integer).returns(T::Boolean) }
+    sig { override.params(xlen: Integer).returns(T::Boolean) }
     def defined_in_base?(xlen) = xlen == 32 ? defined_in_base32? : defined_in_base64?
 
     # @return [Boolean] Whether or not this field exists for any XLEN


### PR DESCRIPTION
Adds the missing `defined_in_base?` abstract method to the `Idl::CsrField` interface and makes `location`'s abstract signature match the implementation's optional argument. Fixes #1048.