### PR TITLE
fix(udb): correct copy-paste errors in InterruptCode#<=> and #hash

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/obj/exception_code.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/exception_code.rb
@@ -82,9 +82,9 @@ module Udb
 
     sig { override.params(other: BasicObject).returns(T.nilable(Integer)) }
     def <=>(other)
-      return nil unless T.cast(other, Object).is_a?(ExceptionCode)
+      return nil unless T.cast(other, Object).is_a?(InterruptCode)
 
-      num <=> T.cast(other, ExceptionCode).num
+      num <=> T.cast(other, InterruptCode).num
     end
 
     sig { override.params(other: BasicObject).returns(T::Boolean) }
@@ -93,6 +93,6 @@ module Udb
     end
 
     sig { override.returns(Integer) }
-    def hash = [ExceptionCode, num].hash
+    def hash = [InterruptCode, num].hash
   end
 end

--- a/tools/ruby-gems/udb/test/test_exception_interrupt_code.rb
+++ b/tools/ruby-gems/udb/test/test_exception_interrupt_code.rb
@@ -1,0 +1,91 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# typed: false
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "tmpdir"
+require "fileutils"
+
+require "udb/resolver"
+
+class TestExceptionInterruptCode < Minitest::Test
+  include Udb
+
+  def setup
+    @gen_dir = Dir.mktmpdir
+    @resolver = Resolver.new(
+      Udb.repo_root,
+      gen_path_override: Pathname.new(@gen_dir)
+    )
+    @arch = @resolver.cfg_arch_for("_")
+  end
+
+  def teardown
+    FileUtils.rm_rf @gen_dir
+  end
+
+  def test_exception_code_comparisons
+    exceptions = @arch.exception_codes.to_a
+    assert_operator exceptions.size, :>, 1
+
+    # Test sorting
+    sorted = exceptions.sort
+    assert_equal exceptions.map(&:num).sort, sorted.map(&:num)
+
+    # Test eql? and hash contract
+    exc1 = exceptions.find { |e| e.num == 1 }
+    exc2 = exceptions.find { |e| e.num == 1 }
+    exc3 = exceptions.find { |e| e.num != 1 }
+
+    assert_equal exc1, exc2
+    assert exc1.eql?(exc2)
+    assert_equal exc1.hash, exc2.hash
+
+    if exc3
+      refute_equal exc1, exc3
+      refute exc1.eql?(exc3)
+      refute_equal exc1.hash, exc3.hash
+    end
+  end
+
+  def test_interrupt_code_comparisons
+    interrupts = @arch.interrupt_codes.to_a
+    assert_operator interrupts.size, :>, 1
+
+    # Test sorting
+    sorted = interrupts.sort
+    assert_equal interrupts.map(&:num).sort, sorted.map(&:num)
+
+    # Test eql? and hash contract
+    int1 = interrupts.find { |i| i.num == 1 }
+    int2 = interrupts.find { |i| i.num == 1 }
+    int3 = interrupts.find { |i| i.num != 1 }
+
+    assert_equal int1, int2
+    assert int1.eql?(int2)
+    assert_equal int1.hash, int2.hash
+
+    if int3
+      refute_equal int1, int3
+      refute int1.eql?(int3)
+      refute_equal int1.hash, int3.hash
+    end
+  end
+
+  def test_cross_type_comparisons
+    exc = @arch.exception_codes.find { |e| e.num == 1 }
+    int = @arch.interrupt_codes.find { |i| i.num == 1 }
+
+    # If both num=1 exist, ensure they do not equal or collide in hash
+    if exc && int
+      assert_nil exc <=> int
+      assert_nil int <=> exc
+
+      refute_equal exc, int
+      refute exc.eql?(int)
+      refute_equal exc.hash, int.hash
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`InterruptCode` in `tools/ruby-gems/udb/lib/udb/obj/exception_code.rb` was copy-pasted from `ExceptionCode` but two class references were not updated, introducing two silent bugs:

**1. `InterruptCode#<=>` always returns `nil`**

```ruby
# Before (wrong)
def <=>(other)
  return nil unless T.cast(other, Object).is_a?(ExceptionCode)  # always false for InterruptCode
  num <=> T.cast(other, ExceptionCode).num
end
```

Comparing two `InterruptCode` objects always returns `nil` because an `InterruptCode` instance is never `is_a?(ExceptionCode)`. Any `sort`, `min`, `max`, or `Enumerable` operation using the base-class comparator raises `ArgumentError: comparison failed`.

**2. `InterruptCode#hash` collides with `ExceptionCode`**

```ruby
# Before (wrong)  
def hash = [ExceptionCode, num].hash
```

An `InterruptCode` with `num = 1` and an `ExceptionCode` with `num = 1` produce the same hash, violating the `a.eql?(b) => a.hash == b.hash` contract and breaking `Set`/`Hash` correctness.

## Fix

Change both occurrences of `ExceptionCode` in `InterruptCode`'s methods to `InterruptCode`:

```ruby
# After (correct)
def <=>(other)
  return nil unless T.cast(other, Object).is_a?(InterruptCode)
  num <=> T.cast(other, InterruptCode).num
end

def hash = [InterruptCode, num].hash
```

## Tests

Add `test_exception_interrupt_code.rb` covering:
- Sorting `ExceptionCode` and `InterruptCode` collections by `num`
- `eql?` and `hash` consistency (objects with same `num` are equal and share a hash)
- Cross-type isolation: an `ExceptionCode` and `InterruptCode` with the same `num` are not equal and do not share a hash

All 3 tests pass. Sorbet type-checking (`./do test:sorbet`) passes with no errors.

Fixes #1979