### PR TITLE
fix(csr): correct wrong INH alias name in mhpmcounterN description

### DIFF
--- a/spec/std/isa/csr/Zihpm/mhpmcounter10.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter10.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent10.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent10.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent10..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent10.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent10.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent10.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent10.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent10.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent10.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent10.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent10.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent10.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent10.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent10.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent10.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent10.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent10.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter11.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter11.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent11.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent11.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent11..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent11.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent11.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent11.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent11.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent11.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent11.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent11.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent11.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent11.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent11.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent11.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent11.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent11.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent11.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter12.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter12.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent12.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent12.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent12..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent12.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent12.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent12.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent12.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent12.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent12.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent12.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent12.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent12.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent12.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent12.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent12.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent12.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent12.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter13.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter13.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent13.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent13.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent13..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent13.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent13.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent13.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent13.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent13.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent13.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent13.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent13.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent13.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent13.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent13.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent13.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent13.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent13.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter14.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter14.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent14.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent14.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent14..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent14.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent14.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent14.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent14.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent14.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent14.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent14.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent14.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent14.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent14.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent14.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent14.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent14.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent14.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter15.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter15.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent15.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent15.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent15..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent15.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent15.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent15.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent15.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent15.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent15.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent15.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent15.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent15.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent15.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent15.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent15.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent15.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent15.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter16.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter16.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent16.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent16.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent16..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent16.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent16.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent16.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent16.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent16.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent16.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent16.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent16.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent16.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent16.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent16.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent16.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent16.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent16.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter17.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter17.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent17.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent17.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent17..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent17.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent17.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent17.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent17.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent17.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent17.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent17.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent17.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent17.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent17.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent17.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent17.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent17.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent17.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter18.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter18.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent18.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent18.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent18..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent18.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent18.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent18.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent18.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent18.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent18.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent18.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent18.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent18.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent18.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent18.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent18.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent18.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent18.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter19.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter19.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent19.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent19.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent19..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent19.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent19.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent19.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent19.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent19.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent19.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent19.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent19.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent19.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent19.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent19.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent19.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent19.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent19.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter20.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter20.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent20.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent20.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent20..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent20.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent20.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent20.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent20.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent20.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent20.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent20.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent20.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent20.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent20.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent20.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent20.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent20.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent20.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter21.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter21.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent21.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent21.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent21..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent21.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent21.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent21.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent21.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent21.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent21.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent21.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent21.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent21.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent21.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent21.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent21.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent21.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent21.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter22.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter22.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent22.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent22.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent22..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent22.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent22.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent22.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent22.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent22.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent22.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent22.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent22.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent22.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent22.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent22.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent22.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent22.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent22.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter23.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter23.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent23.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent23.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent23..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent23.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent23.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent23.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent23.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent23.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent23.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent23.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent23.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent23.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent23.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent23.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent23.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent23.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent23.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter24.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter24.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent24.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent24.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent24..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent24.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent24.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent24.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent24.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent24.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent24.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent24.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent24.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent24.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent24.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent24.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent24.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent24.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent24.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter25.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter25.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent25.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent25.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent25..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent25.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent25.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent25.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent25.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent25.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent25.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent25.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent25.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent25.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent25.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent25.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent25.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent25.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent25.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter26.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter26.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent26.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent26.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent26..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent26.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent26.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent26.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent26.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent26.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent26.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent26.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent26.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent26.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent26.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent26.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent26.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent26.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent26.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter27.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter27.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent27.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent27.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent27..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent27.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent27.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent27.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent27.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent27.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent27.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent27.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent27.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent27.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent27.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent27.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent27.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent27.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent27.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter28.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter28.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent28.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent28.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent28..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent28.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent28.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent28.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent28.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent28.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent28.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent28.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent28.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent28.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent28.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent28.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent28.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent28.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent28.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter29.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter29.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent29.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent29.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent29..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent29.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent29.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent29.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent29.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent29.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent29.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent29.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent29.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent29.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent29.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent29.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent29.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent29.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent29.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter3.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter3.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent3.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent3.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent3..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent3.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent3.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent3.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent3.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent3.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent3.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent3.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent3.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent3.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent3.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent3.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent3.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent3.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent3.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter30.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter30.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent30.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent30.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent30..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent30.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent30.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent30.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent30.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent30.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent30.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent30.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent30.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent30.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent30.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent30.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent30.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent30.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent30.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter31.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter31.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent31.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent31.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent31..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent31.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent31.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent31.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent31.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent31.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent31.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent31.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent31.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent31.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent31.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent31.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent31.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent31.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent31.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter4.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter4.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent4.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent4.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent4..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent4.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent4.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent4.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent4.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent4.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent4.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent4.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent4.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent4.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent4.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent4.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent4.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent4.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent4.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter5.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter5.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent5.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent5.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent5..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent5.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent5.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent5.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent5.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent5.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent5.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent5.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent5.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent5.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent5.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent5.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent5.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent5.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent5.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter6.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter6.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent6.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent6.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent6..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent6.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent6.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent6.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent6.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent6.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent6.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent6.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent6.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent6.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent6.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent6.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent6.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent6.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent6.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter7.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter7.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent7.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent7.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent7..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent7.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent7.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent7.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent7.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent7.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent7.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent7.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent7.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent7.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent7.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent7.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent7.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent7.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent7.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter8.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter8.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent8.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent8.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent8..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent8.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent8.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent8.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent8.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent8.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent8.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent8.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent8.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent8.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent8.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent8.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent8.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent8.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent8.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounter9.yaml
+++ b/spec/std/isa/csr/Zihpm/mhpmcounter9.yaml
@@ -84,14 +84,14 @@ fields:
         <%- if ext?(:Sscofpmf) -%>
         * `mhpmevent9.MINH` is set and the current privilege level is M
         <%- if ext?(:S) -%>
-        * `mhpmevent9.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent9..SINH`<%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent9.SINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent9.SINH`<%- end -%> is set and the current privilege level is (H)S
         <%- end -%>
         <%- if ext?(:U) -%>
-        * `mhpmevent9.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent9.SINH`<%- end -%> is set and the current privilege level is U
+        * `mhpmevent9.UINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent9.UINH`<%- end -%> is set and the current privilege level is U
         <%- end -%>
         <%- if ext?(:H) -%>
-        * `mhpmevent9.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent9.SINH`<%- end -%> is set and the current privilege level is VS
-        * `mhpmevent9.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent9.SINH`<%- end -%> is set and the current privilege level is VU
+        * `mhpmevent9.VSINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent9.VSINH`<%- end -%> is set and the current privilege level is VS
+        * `mhpmevent9.VUINH` <%- if ext?(:Ssccfg) -%>or its alias `hpmevent9.VUINH`<%- end -%> is set and the current privilege level is VU
         <%- end -%>
         <%- end -%>
       --

--- a/spec/std/isa/csr/Zihpm/mhpmcounterN.layout
+++ b/spec/std/isa/csr/Zihpm/mhpmcounterN.layout
@@ -82,14 +82,14 @@ fields:
         <%%- if ext?(:Sscofpmf) -%>
         * `mhpmevent<%= hpm_num %>.MINH` is set and the current privilege level is M
         <%%- if ext?(:S) -%>
-        * `mhpmevent<%= hpm_num %>.SINH` <%%- if ext?(:Ssccfg) -%>or its alias `hpmevent<%= hpm_num %>..SINH`<%%- end -%> is set and the current privilege level is (H)S
+        * `mhpmevent<%= hpm_num %>.SINH` <%%- if ext?(:Ssccfg) -%>or its alias `hpmevent<%= hpm_num %>.SINH`<%%- end -%> is set and the current privilege level is (H)S
         <%%- end -%>
         <%%- if ext?(:U) -%>
-        * `mhpmevent<%= hpm_num %>.UINH` <%%- if ext?(:Ssccfg) -%>or its alias `hpmevent<%= hpm_num %>.SINH`<%%- end -%> is set and the current privilege level is U
+        * `mhpmevent<%= hpm_num %>.UINH` <%%- if ext?(:Ssccfg) -%>or its alias `hpmevent<%= hpm_num %>.UINH`<%%- end -%> is set and the current privilege level is U
         <%%- end -%>
         <%%- if ext?(:H) -%>
-        * `mhpmevent<%= hpm_num %>.VSINH` <%%- if ext?(:Ssccfg) -%>or its alias `hpmevent<%= hpm_num %>.SINH`<%%- end -%> is set and the current privilege level is VS
-        * `mhpmevent<%= hpm_num %>.VUINH` <%%- if ext?(:Ssccfg) -%>or its alias `hpmevent<%= hpm_num %>.SINH`<%%- end -%> is set and the current privilege level is VU
+        * `mhpmevent<%= hpm_num %>.VSINH` <%%- if ext?(:Ssccfg) -%>or its alias `hpmevent<%= hpm_num %>.VSINH`<%%- end -%> is set and the current privilege level is VS
+        * `mhpmevent<%= hpm_num %>.VUINH` <%%- if ext?(:Ssccfg) -%>or its alias `hpmevent<%= hpm_num %>.VUINH`<%%- end -%> is set and the current privilege level is VU
         <%%- end -%>
         <%%- end -%>
       --


### PR DESCRIPTION
`mhpmcounterN.layout`'s `COUNT` field description lists, for each privilege mode, which inhibit bit stops the counter and (when `Ssccfg` is implemented) its unprivileged alias name. Three of the four bullets named the wrong alias:

```
* `mhpmevent<n>.SINH`  ... or its alias `hpmevent<n>..SINH`   (H)S-mode   <- stray double dot
* `mhpmevent<n>.UINH`  ... or its alias `hpmevent<n>.SINH`    U-mode      <- should be .UINH
* `mhpmevent<n>.VSINH` ... or its alias `hpmevent<n>.SINH`    VS-mode     <- should be .VSINH
* `mhpmevent<n>.VUINH` ... or its alias `hpmevent<n>.SINH`    VU-mode     <- should be .VUINH
```

Fix these.