### PR TITLE
fix: VersionSpec#<=> compared operands in reverse order

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/version_spec.rb
+++ b/tools/ruby-gems/udb/lib/udb/version_spec.rb
@@ -114,7 +114,7 @@ module Udb
     sig { params(other: T.untyped).returns(T.nilable(Integer)).checked(:never) }
     def <=>(other)
       if other.is_a?(String)
-        VersionSpec.new(other) <=> self
+        self <=> VersionSpec.new(other)
       elsif other.is_a?(VersionSpec)
         if @major != other.major
           @major <=> other.major


### PR DESCRIPTION
`VersionSpec#<=>` in `tools/ruby-gems/udb/lib/udb/version_spec.rb`
reversed the comparison operands when the argument was a `String`:

Since `VersionSpec` includes `Comparable`, this silently flipped `<`, `>`,
`.between?`, `.sort`, etc. when comparing a `VersionSpec` to a `String`.

Reverse the comparision.

Fixes #2036 