### PR TITLE
fix(data): HPM_EVENTS.yaml has duplicate HPM_COUNTER_EN index 4 in definedBy and missing long_name in HPM_EVENTS and HPM_COUNTER_EN

### DIFF
--- a/spec/std/isa/param/HPM_COUNTER_EN.yaml
+++ b/spec/std/isa/param/HPM_COUNTER_EN.yaml
@@ -13,7 +13,7 @@ description: |
   The first three entries *must* be false (as they correspond to CY, IR, TM in, _e.g._ `mhmpcountinhibit`)
   Index 3 in HPM_COUNTER_EN corresponds to mhpmcounter3.
   Index 31 in HPM_COUNTER_EN corresponds to mhpmcounter31.
-long_name: Hardware Performance Monitor counter enable flags
+long_name: Hardware Performance Monitor counter registers implemented list
 schema:
   type: array
   items:

--- a/spec/std/isa/param/HPM_COUNTER_EN.yaml
+++ b/spec/std/isa/param/HPM_COUNTER_EN.yaml
@@ -13,7 +13,7 @@ description: |
   The first three entries *must* be false (as they correspond to CY, IR, TM in, _e.g._ `mhmpcountinhibit`)
   Index 3 in HPM_COUNTER_EN corresponds to mhpmcounter3.
   Index 31 in HPM_COUNTER_EN corresponds to mhpmcounter31.
-long_name: TODO
+long_name: Hardware Performance Monitor counter enable flags
 schema:
   type: array
   items:

--- a/spec/std/isa/param/HPM_EVENTS.yaml
+++ b/spec/std/isa/param/HPM_EVENTS.yaml
@@ -7,7 +7,7 @@ $schema: param_schema.json#
 kind: parameter
 name: HPM_EVENTS
 description: List of defined event numbers that can be written into mhpmeventN
-long_name: TODO
+long_name: Hardware Performance Monitor event selector values
 schema:
   type: array
   items:
@@ -28,9 +28,7 @@ definedBy:
           - name: HPM_COUNTER_EN
             index: 4
             equal: true
-          - name: HPM_COUNTER_EN
-            index: 4
-            equal: true
+
           - name: HPM_COUNTER_EN
             index: 5
             equal: true


### PR DESCRIPTION
## Summary
Removes a duplicate `HPM_COUNTER_EN index: 4` entry from the `definedBy.anyOf`
list in `HPM_EVENTS.yaml` and replaces `long_name: TODO` placeholders in
both `HPM_EVENTS.yaml` and `HPM_COUNTER_EN.yaml` with descriptive names.

## Motivation
Fixes #2046

## Changes
- `spec/std/isa/param/HPM_EVENTS.yaml` — removed duplicate `index: 4` block, updated `long_name`
- `spec/std/isa/param/HPM_COUNTER_EN.yaml` — updated `long_name`

## Verification
- [x] `./do test:schema` passes
- [x] `./bin/regress --tag smoke` passes