### PR TITLE
fix(data): correct Q extension ratified version to 2.2.0

### DIFF
--- a/spec/std/isa/ext/Q.yaml
+++ b/spec/std/isa/ext/Q.yaml
@@ -17,7 +17,7 @@ description: |
   a double-precision value which is itself NaN-boxed inside a quad-precision value.
 type: unprivileged
 versions:
-  - version: "1.0.0"
+  - version: "2.2.0"
     state: ratified
     ratification_date: 2019-04
     requirements:


### PR DESCRIPTION
fixes: #2068 
Q shares the same floating-point ISA chapter as F and D, both of which are correctly versioned 2.2.0. The RISC-V ISA manual colophon table (and Chapter 'Q Standard Extension for Quad-Precision Floating-Point, Version 2.2') confirms Q was ratified at 2.2, not 1.0.0.