### PR TITLE
feat: Add AST evaluation support for CSR sw_read functions

### DIFF
--- a/tools/ruby-gems/idlc/lib/idlc/ast.rb
+++ b/tools/ruby-gems/idlc/lib/idlc/ast.rb
@@ -9712,9 +9712,16 @@ module Idl
       when "sw_read"
         value_error "CSR not knowable" unless csr_known?(symtab)
         cd = csr_def(symtab)
-        cd.fields.each { |f| value_error "#{csr_name}.#{f.name} not RO" unless f.type == "RO" }
 
-        value_error "TODO: CSRs with sw_read function"
+        if cd.has_custom_sw_read?
+          ast = cd.sw_read_ast(symtab)
+          ast.return_value(symtab)
+        else
+          cd.fields.each { |f| value_error "#{csr_name}.#{f.name} not RO" unless f.type == "RO" }
+          v = cd.value
+          value_error "CSR value not knowable" if v.nil?
+          v
+        end
       when "address"
         value_error "CSR not knowable" unless csr_known?(symtab)
         cd = csr_def(symtab)


### PR DESCRIPTION
Resolves #2078 

**Description**
This PR resolves the outstanding `TODO: CSRs with sw_read function` in `tools/ruby-gems/idlc/lib/idlc/ast.rb`.

The IDL compiler can now correctly evaluate the software read value of a Control and Status Register (CSR). If the CSR definition dictates a custom `sw_read` function, the AST of that function is executed to get the return value. Otherwise, the software read value falls back to evaluating the read-only (`RO`) fields of the CSR.

**Changes**
* Removed the explicit `cd.fields.each { |f| ... not RO }` restriction on custom `sw_read` definitions since custom reads might dynamically compute values based on non-RO fields.
* Added logic in `value(symtab)` for `sw_read` function calls to evaluate `cd.sw_read_ast(symtab).return_value(symtab)` when `has_custom_sw_read?` is true.
* Added fallback logic to retrieve `cd.value` when no custom `sw_read` function exists, gracefully raising a `ValueError` if the value is not compile-time knowable.

**Testing**
* Tested compile-time evaluation paths to ensure no breaking changes in existing CSR constant evaluation.
