### PR TITLE
fix(isa): prevent NV flag on quiet NaN in softfloat_subMagsF32

### DIFF
--- a/spec/std/isa/isa/fp.idl
+++ b/spec/std/isa/isa/fp.idl
@@ -1489,6 +1489,9 @@ function softfloat_subMagsF32 {
 
       # check if A is infinity or NaN
       if (expA == 8'hFF) {
+        if ((sigA != 0) || (sigB != 0)) {
+          return SP_CANONICAL_NAN;
+        }
         set_fp_flag(FpFlag::NV);
         return SP_CANONICAL_NAN;
       }


### PR DESCRIPTION
Fixes #2048

### Problem Statement
In `spec/std/isa/isa/fp.idl`, `softfloat_subMagsF32` previously called `set_fp_flag(FpFlag::NV)` unconditionally whenever `expDiff == 0` and `expA == 8'hFF`.

For Quiet NaN inputs (`sigA != 0` or `sigB != 0`), IEEE 754-2019 §7.2 requires returning `SP_CANONICAL_NAN` **without** raising the Invalid Operation (`NV`) exception flag. Signaling NaNs are already handled by `is_sp_signaling_nan?` at the entry of `softfloat_subMagsF32`. Raising `NV` when `expA == 8'hFF` is only valid for infinity-minus-infinity (`Inf - Inf`, i.e., `sigA == 0 && sigB == 0`).

### Technical Explanation & Fix
In `softfloat_subMagsF32`, under the `expDiff == 0` and `expA == 8'hFF` block, we add a check for non-zero significands:

```idl
      # check if A is infinity or NaN
      if (expA == 8'hFF) {
        if ((sigA != 0) || (sigB != 0)) {
          return SP_CANONICAL_NAN;
        }
        set_fp_flag(FpFlag::NV);
        return SP_CANONICAL_NAN;
      }
```

### Verification
- `./do test:idl CFG=_` — **PASS** (`All IDL passed type checking`)
- `./do test:idlc:unit` — **PASS** (`523 runs, 36818 assertions, 0 failures`)
- `./do test:sorbet` — **PASS** (`No errors! Great job.`)
- `./do test:schema` — **PASS** (`All files validate against their schema`)