### PR TITLE
docs: replace deleted CODEOWNERS and LICENSE references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,6 @@ CI is split into PR tests (`ci_stage: pr`) and merge-queue deployment tests (`ci
 
 - Squash merge policy: PR title/description becomes the commit message
 - Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) style (not enforced)
-- PRs require approval from a Code Owner (see `.github/CODEOWNERS`)
+- PRs require approval from a maintainer
 - Link PRs to issues with `Fixes #<number>` or `Closes #<number>` in the PR description
 - All PRs must pass `./bin/regress --all`

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -56,9 +56,7 @@ Closes #<issue number>
 
 All Pull Requests must go through the code review process.
 
-All Pull Requests require approval by at least one Code Owner.
-
-Code Owners are maintained in `.github/CODEOWNERS`.
+All Pull Requests require approval by at least one maintainer.
 
 == Finding tasks
 
@@ -66,7 +64,7 @@ If you are looking to contribute but are unsure what to do, browse through the h
 
 == Legal
 
-All contributions to UnifiedDB are by default made under the xref:LICENSE[BSD-3-clear license].
+All contributions to UnifiedDB are by default made under the xref:LICENSE-BSD-3-Clause-Clear.txt[BSD-3-Clause-Clear license].
 Copyrights are held by the specific contributors, and are not tracked by the UnifiedDB project other
 than what can be gleaned through git history.
 


### PR DESCRIPTION
 Closes #2104
`CONTRIBUTING.adoc` and `AGENTS.md` both point at files that no longer exist in
 the repo. Three edits, two files:
 
 - `CONTRIBUTING.adoc:69` — `xref:LICENSE[...]` pointed at a file removed in #424
    when the project moved to REUSE-style multi-licensing. 
    Now points at `LICENSE-BSD-3-Clause-Clear.txt`, and the link text uses the correct SPDX name
    `BSD-3-Clause-Clear` rather than "BSD-3-clear".
    
  - **The "Code Owner" → "maintainer" wording is a proposal, not a claim about
     current policy.**
  
  Docs-only; no code or data touched.