### PR TITLE
test(udb-gen): run orphaned cfg-header golden tests

### DIFF
--- a/tools/ruby-gems/udb-gen/test/integration/run.rb
+++ b/tools/ruby-gems/udb-gen/test/integration/run.rb
@@ -4,6 +4,8 @@
 # typed: false
 # frozen_string_literal: true
 
+require_relative "../test_helper"
 require_relative "test_helper"
 
 require_relative "test_inst_table"
+require_relative "../test_cfg_headers"

--- a/tools/ruby-gems/udb-gen/test/run.rb
+++ b/tools/ruby-gems/udb-gen/test/run.rb
@@ -1,9 +1,0 @@
-# Copyright (c) Jordan Carlin, Harvey Mudd College.
-# SPDX-License-Identifier: BSD-3-Clause-Clear
-
-# typed: false
-# frozen_string_literal: true
-
-require_relative "test_helper"
-
-require_relative "test_cfg_headers"


### PR DESCRIPTION
Closes #2113

`tools/ruby-gems/udb-gen/test/run.rb` required `test_cfg_headers`, but no rake task ever ran that file, so the `cfg-c-header` and `cfg-svh-header` golden tests have never executed in CI. The only udb-gen test tasks are `test:udb_gen:unit` and `test:udb_gen:integration`, and both only require `test_inst_table`.

This requires `test_cfg_headers` from `test/integration/run.rb` and deletes the orphaned `test/run.rb`. Integration rather than unit because `TestCfgHeaders#setup` is identical to the existing integration test's: it builds a real resolved architecture from a tmpdir resolver. Deleting the dead entry point keeps someone from adding a test there and having it silently skipped again. The top-level `test_helper` is required first so SimpleCov starts before `udb-gen` is loaded.

No new rake task or regress target, so `.github/workflows/regress.yml` is unchanged.

The tests pass as-is, so nothing was broken here, just unguarded. `regress-cfg-headers` only regenerates the golden files and diffs them, which is not the same as running the assertions.

Note #2110 adds more tests to `tools/ruby-gems/udb-gen/test/test_cfg_headers.rb`. This PR deliberately does not touch that file, so the two should not conflict.

## Testing

- `./do test:udb_gen:integration` - 3 runs, 3 assertions, 0 failures (was 1 run before this change), 61s
- `./bin/regress -n regress-udb-gen-unit` - passed, 2 runs
- `./bin/regress -n regress-cfg-headers` - passed
- `./bin/regress -n regress-sorbet` - passed, no errors
- `./bin/prek run --files tools/ruby-gems/udb-gen/test/integration/run.rb` - passed

Run on macOS. `./bin/regress --all` was not run; it does not fully pass locally because of the Linux-only `must`/`eqntott` binaries.