### PR TITLE
fix(idlc): short-circuit && and || on either operand

### DIFF
--- a/tools/ruby-gems/idlc/lib/idlc/ast.rb
+++ b/tools/ruby-gems/idlc/lib/idlc/ast.rb
@@ -5141,18 +5141,29 @@ module Idl
             end
           end
         elsif ["&&", "||"].include?(op)
-          # these can short circuit, so we might only need to check the lhs
-          lhs_value = lhs.value(symtab)
-          if (op == "&&") && lhs_value == false
-            false
-          elsif (op == "||") && lhs_value == true
-            true
+          # These short circuit, so one operand alone can determine the result. That holds for
+          # either operand: 'false && x' and 'x && false' are both false, and likewise for '||'.
+          # Checking both sides matters because a left-associative chain 'a && b && c' parses as
+          # '(a && b) && c', which puts the deciding operand on the right of the inner expression.
+          dominant = op == "&&" ? false : true
+
+          lhs_value = T.let(nil, T.untyped)
+          value_try do
+            lhs_value = lhs.value(symtab)
+          end
+          rhs_value = T.let(nil, T.untyped)
+          value_try do
+            rhs_value = rhs.value(symtab)
+          end
+
+          if lhs_value == dominant || rhs_value == dominant
+            dominant
+          elsif lhs_value.nil?
+            lhs.value(symtab) # unknown, and the rhs doesn't decide it: re-raise the value error
+          elsif rhs_value.nil?
+            rhs.value(symtab) # ditto
           else
-            if op == "&&"
-              lhs_value && rhs.value(symtab)
-            else
-              lhs_value || rhs.value(symtab)
-            end
+            op == "&&" ? (lhs_value && rhs_value) : (lhs_value || rhs_value)
           end
         elsif op == "=="
           value_result = value_try do

--- a/tools/ruby-gems/idlc/test/test_type_checking_comprehensive.rb
+++ b/tools/ruby-gems/idlc/test/test_type_checking_comprehensive.rb
@@ -446,6 +446,40 @@ class TestTypeCheckingComprehensive < Minitest::Test
   end
 
   # ============================================================================
+  # Section: Expressions -> Logical operators -> Short circuiting
+  # ============================================================================
+
+  # Regression test for https://github.com/riscv/riscv-unified-db/issues/1140
+  #
+  # '&&' and '||' short circuit, so a single operand with a known value decides the whole
+  # expression. That is true of either operand, not just the left one. It matters for chains,
+  # because 'a && b && c' is left associative and parses as '(a && b) && c': when only 'b' is
+  # known, the inner expression can only be resolved by looking at its right-hand side.
+  def add_short_circuit_syms
+    @symtab.add!("UNKNOWN", Idl::Var.new("UNKNOWN", Idl::Type.new(:boolean)))
+    @symtab.add!("FALSE", Idl::Var.new("FALSE", Idl::Type.new(:boolean), false))
+    @symtab.add!("TRUE", Idl::Var.new("TRUE", Idl::Type.new(:boolean), true))
+    # a non-boolean operand, so that failing to short circuit is a type error
+    @symtab.add!("STR", Idl::Var.new("STR", Idl::Type.new(:string), "not a boolean"))
+  end
+
+  def test_and_short_circuits_on_either_operand
+    add_short_circuit_syms
+
+    assert_equal false, compile_expression("UNKNOWN && (FALSE && STR)").value(@symtab)
+    assert_equal false, compile_expression("UNKNOWN && FALSE && STR").value(@symtab)
+    assert_equal false, compile_expression("STR && FALSE && UNKNOWN").value(@symtab)
+  end
+
+  def test_or_short_circuits_on_either_operand
+    add_short_circuit_syms
+
+    assert_equal true, compile_expression("UNKNOWN || (TRUE || STR)").value(@symtab)
+    assert_equal true, compile_expression("UNKNOWN || TRUE || STR").value(@symtab)
+    assert_equal true, compile_expression("STR || TRUE || UNKNOWN").value(@symtab)
+  end
+
+  # ============================================================================
   # Negative test cases: Type errors
   # ============================================================================
 


### PR DESCRIPTION
Closes #1140

`BinaryExpressionAst#value` only short-circuited on the left-hand side. `&&` and `||` are left associative, so `a && b && c` parses as `(a && b) && c`. When only `b` has a known value, the inner `(a && b)` could not be evaluated, so no short circuit was detected and `c` got type checked even though it is unreachable. Writing the same thing as `a && (b && c)` worked, which is the asymmetry reported in the issue.

The fix evaluates both operands and short-circuits when either one alone determines the result. `#type` and `#type_check` already looked at both sides (#891); `#value` was the one left over.

One thing worth flagging separately: the exact repro in the issue no longer errors on main, but not because it was fixed. #891 also removed the recursive `lhs.type_check` / `rhs.type_check` calls from `BinaryExpressionAst#type_check`, so binary expression operands are no longer type checked at all except inside the logical short-circuit branches. Restoring that recursion surfaces several unrelated latent type errors in the spec (a non-const widening shift amount in `misa.yaml`, a signed comparability error in `fp.idl`, a pruned literal array in `qc_iu`), so I left it out of this PR. Happy to open a separate issue for it.

## Testing

- `./do test:idlc:unit` - 525 runs, 0 failures. Reverting just the `ast.rb` change makes the two new tests fail with `UncaughtThrowError: uncaught throw :value_error`.
- `./do test:idl CFG=<cfg>` for `_`, `rv32`, `rv64`, `qc_iu` - all "All IDL passed type checking".
- Same four configs again after applying the issue's repro edit to `spec/std/isa/isa/globals.isa` (flattening the nested `if` into `!implemented?(ExtensionName::Svrsw60t59b) && (PTESIZE >= 64) && pte[60:59] != 0`) - all pass.
- `./bin/regress -n regress-sorbet` - "No errors! Great job."
- `./bin/prek run --files tools/ruby-gems/idlc/lib/idlc/ast.rb tools/ruby-gems/idlc/test/test_type_checking_comprehensive.rb` - all passed.

Not run: `./bin/regress --all`, which needs Linux-only `must`/`eqntott` binaries and cannot pass on macOS.
