### PR TITLE
docs: add contributor guidance for Ruby DB interface and riscv-opcodes migration

### DIFF
--- a/doc/riscv-opcodes-migration.adoc
+++ b/doc/riscv-opcodes-migration.adoc
@@ -1,3 +1,28 @@
 = RISC-V opcodes migration
 
-TODO
+This page is a short guide for contributors migrating instruction data from
+`riscv-opcodes` into UnifiedDB.
+
+At a high level, the migration maps opcode definitions into the structured UDB
+data model:
+
+* instruction names and mnemonics
+* encodings and bit-pattern constraints
+* operand formats and assembly syntax
+* extension ownership and validation metadata
+
+The authoritative source for repository structure and data conventions is the
+top-level README:
+
+* xref:../README.adoc[Repository overview]
+
+When converting or validating instruction data, use the schema and regression
+tooling in this repository rather than editing generated output by hand.
+Relevant entry points include:
+
+* `./bin/do test:schema`
+* `./bin/regress --tag smoke`
+* `./bin/generate -h`
+
+If you are looking for the source-of-truth instruction data, start in
+`spec/std/isa/` and the related backend generators under `backends/`.

--- a/doc/riscv-opcodes-migration.adoc
+++ b/doc/riscv-opcodes-migration.adoc
@@ -20,7 +20,7 @@ When converting or validating instruction data, use the schema and regression
 tooling in this repository rather than editing generated output by hand.
 Relevant entry points include:
 
-* `./bin/do test:schema`
+* `./do test:schema`
 * `./bin/regress --tag smoke`
 * `./bin/generate -h`
 

--- a/doc/ruby.adoc
+++ b/doc/ruby.adoc
@@ -1,3 +1,21 @@
 = Ruby Database Interface
 
-TODO
+This page is a short entry point for contributors working with the `udb` Ruby
+library and command-line tools.
+
+The canonical project overview lives in the gem README:
+
+* xref:../tools/ruby-gems/udb/README.adoc[Unified Database Gem]
+
+Use the repository wrappers when working on the Ruby toolchain:
+
+* `bin/bundle` for Ruby gem commands
+* `bin/ruby` for running Ruby with the repository's managed environment
+* `bin/chore install gems` when you add or update gem dependencies
+
+The main entry point for Ruby code is `Udb.cfg_arch_for(...)`, which returns a
+configuration-scoped database view. From there you can inspect extensions,
+instructions, CSRs, and other generated objects.
+
+For repository setup and verification, see the top-level README and run
+`bin/setup` followed by `./bin/doctor`.


### PR DESCRIPTION
## What
Replaces two placeholder documentation pages with real contributor-facing guidance:
- Ruby database interface, how to interact with the UDB data model
- riscv-opcodes migration flow, how instruction data moves between riscv-opcodes and UDB

## Why
Both pages were empty/placeholder, which is a gap for new contributors trying to understand these two areas before making their first change.

## Testing
- `./bin/doctor` passes
- `./bin/regress --all` passes locally

Closes #2119