### PR TITLE
fix(setup): support macOS native bash 3.2 in bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -51,7 +51,7 @@ printf "\n"
 if [[ -t 0 ]] && [[ -z "${GITHUB_ACTIONS:-}" ]]; then
   printf "    Press ${_BOLD}Enter${_RESET} to continue, or type ${_BOLD}m${_RESET} to see how to change these paths: "
   read -r _SETUP_LOC_CHOICE
-  if [[ "${_SETUP_LOC_CHOICE,,}" == m* ]]; then
+  if [[ "$_SETUP_LOC_CHOICE" == [mM]* ]]; then
     printf "\n"
     printf "    To change install paths, export XDG environment variables in your shell\n"
     printf "    profile (${_CYAN}~/.bashrc${_RESET}, ${_CYAN}~/.zshrc${_RESET}, etc.) before re-running setup:\n\n"


### PR DESCRIPTION
Fixes #2059

### Problem
On macOS, the default system shell at `/bin/bash` is Bash 3.2.57. When running `bin/setup`, line 54 uses the Bash 4.0+ lowercase parameter expansion syntax `${_SETUP_LOC_CHOICE,,}`, causing a fatal `bad substitution` syntax error and aborting the onboarding setup script immediately on Apple platforms.

### Solution
Replace `${_SETUP_LOC_CHOICE,,}` with standard POSIX/Bash 3.2 pattern matching:
```bash
if [[ "$_SETUP_LOC_CHOICE" == [mM]* ]]; then
```
This matches both lower and uppercase `m`/`M` natively without external subprocesses or Bash 4 syntax features.

### Verification
- Tested with macOS system `/bin/bash 3.2.57` via `/bin/bash -n bin/setup` (syntax clean, no error).
- Pre-commit hooks (`shfmt`, `shellcheck`, `reuse lint-file`) passed 100% cleanly.