### PR TITLE
Resolve macOS crash due to Bash 4.0 parameter expansi

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -51,7 +51,7 @@ printf "\n"
 if [[ -t 0 ]] && [[ -z "${GITHUB_ACTIONS:-}" ]]; then
   printf "    Press ${_BOLD}Enter${_RESET} to continue, or type ${_BOLD}m${_RESET} to see how to change these paths: "
   read -r _SETUP_LOC_CHOICE
-  if [[ "${_SETUP_LOC_CHOICE,,}" == m* ]]; then
+  if [[ "$_SETUP_LOC_CHOICE" == [mM]* ]]; then
     printf "\n"
     printf "    To change install paths, export XDG environment variables in your shell\n"
     printf "    profile (${_CYAN}~/.bashrc${_RESET}, ${_CYAN}~/.zshrc${_RESET}, etc.) before re-running setup:\n\n"

--- a/tools/scripts/build_eqntott_with_docker.sh
+++ b/tools/scripts/build_eqntott_with_docker.sh
@@ -41,7 +41,9 @@ build_eqntott_with_docker() {
     local output_dir="${1:-./eqntott-build}"
     local architecture="${2:-x64}"
 
-    case "${architecture,,}" in
+    local arch_lower
+    arch_lower=$(echo "$architecture" | tr '[:upper:]' '[:lower:]')
+    case "$arch_lower" in
         x64|amd64|x86_64)
             architecture="x64"
             local docker_platform="linux/amd64"

--- a/tools/scripts/build_espresso_with_docker.sh
+++ b/tools/scripts/build_espresso_with_docker.sh
@@ -41,7 +41,9 @@ build_espresso_with_docker() {
     local output_dir="${1:-./espresso-build}"
     local architecture="${2:-x64}"
 
-    case "${architecture,,}" in
+    local arch_lower
+    arch_lower=$(echo "$architecture" | tr '[:upper:]' '[:lower:]')
+    case "$arch_lower" in
         x64|amd64|x86_64)
             architecture="x64"
             local docker_platform="linux/amd64"

--- a/tools/scripts/build_must_with_docker.sh
+++ b/tools/scripts/build_must_with_docker.sh
@@ -41,7 +41,9 @@ build_must_with_docker() {
     local output_dir="${1:-./must-build}"
     local architecture="${2:-x64}"
 
-    case "${architecture,,}" in
+    local arch_lower
+    arch_lower=$(echo "$architecture" | tr '[:upper:]' '[:lower:]')
+    case "$arch_lower" in
         x64|amd64|x86_64)
             architecture="x64"
             local docker_platform="linux/amd64"

--- a/tools/scripts/build_z3_with_docker.sh
+++ b/tools/scripts/build_z3_with_docker.sh
@@ -46,7 +46,9 @@ build_z3_with_docker() {
     fi
 
     # Validate and normalize architecture
-    case "${architecture,,}" in
+    local arch_lower
+    arch_lower=$(echo "$architecture" | tr '[:upper:]' '[:lower:]')
+    case "$arch_lower" in
         x64|amd64|x86_64)
             architecture="x64"
             local docker_platform="linux/amd64"


### PR DESCRIPTION
 Resolves macOS crash during `bin/setup` caused by Bash 4.0 `${var,,}` parameter expansion syntax.
macOS defaults to Bash 3.2.57 (`/bin/bash`), which throws a fatal 'bad substitution' syntax error on `${var,,}`.
Replaced `${_SETUP_LOC_CHOICE,,}` in `bin/setup` with Bash 3.2+ compatible pattern matching `[[ "$_SETUP_LOC_CHOICE" == [mM]* ]]`.
Updated Docker build scripts in `tools/scripts/` to use POSIX `tr` conversion instead of `${architecture,,}`.
Verified syntax and compatibility with `bash -n` and `shellcheck` (0 errors, 0 warnings).
