### PR TITLE
fix(udb): reject $inherits targets outside the architecture root

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -522,6 +522,7 @@ jobs:
           - conditions
           - cli
           - yaml_loader
+          - yaml_resolver
           - cfg_arch
           - cfg
           - mmr

--- a/tools/ruby-gems/udb/lib/udb/yaml/yaml_resolver.rb
+++ b/tools/ruby-gems/udb/lib/udb/yaml/yaml_resolver.rb
@@ -573,6 +573,9 @@ module Udb
         end
       end
 
+      # rel_path can come from a `$inherits` target in a spec file, so it is untrusted:
+      # without the containment check a `../` sequence or an absolute path would read an
+      # arbitrary file and inline it into the resolved (and published) output.
       sig {
         params(
           rel_path: String,
@@ -581,6 +584,13 @@ module Udb
         ).returns(T::Hash[String, T.untyped])
       }
       def get_resolved_object(rel_path, arch_root, no_checks)
+        arch_root_abs = arch_root.realpath
+        target = (arch_root_abs / rel_path).expand_path
+        target = target.realpath if target.exist?
+        unless target.to_s.start_with?("#{arch_root_abs}/")
+          raise "#{rel_path} escapes the architecture root #{arch_root}/"
+        end
+
         return @resolved_objs.fetch(rel_path).fetch(:data) if @resolved_objs.key?(rel_path)
 
         input_path = arch_root / rel_path

--- a/tools/ruby-gems/udb/python/test_yaml_resolver.py
+++ b/tools/ruby-gems/udb/python/test_yaml_resolver.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-FileCopyrightText: 2024-2025 Contributors to the RISCV UnifiedDB <https://github.com/riscv/riscv-unified-db>
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+import pytest
+import yaml_resolver
+from yaml_resolver import resolve
+
+
+@pytest.fixture(autouse=True)
+def _clear_resolve_cache():
+    """resolve() memoizes by relative path, so isolate each test."""
+    yaml_resolver.resolved_objs.clear()
+
+
+def _make_arch(tmp_path, inherits_target):
+    arch_root = tmp_path / "arch"
+    (arch_root / "ext").mkdir(parents=True)
+    (tmp_path / "outside").mkdir()
+    (tmp_path / "outside" / "secrets.yaml").write_text('name: secrets\nsecret: "s3cret"\n')
+    (arch_root / "ext" / "Evil.yaml").write_text(f'name: Evil\n$inherits: "{inherits_target}"\n')
+    return arch_root
+
+
+def test_inherits_rejects_relative_path_escaping_arch_root(tmp_path):
+    arch_root = _make_arch(tmp_path, "../outside/secrets.yaml#")
+
+    with pytest.raises(ValueError, match="escapes"):
+        resolve("ext/Evil.yaml", arch_root, False, False)
+
+
+def test_inherits_rejects_absolute_path(tmp_path):
+    arch_root = _make_arch(tmp_path, f"{tmp_path / 'outside' / 'secrets.yaml'}#")
+
+    with pytest.raises(ValueError, match="escapes"):
+        resolve("ext/Evil.yaml", arch_root, False, False)
+
+
+def test_inherits_still_resolves_targets_inside_arch_root(tmp_path):
+    arch_root = tmp_path / "arch"
+    (arch_root / "ext").mkdir(parents=True)
+    (arch_root / "ext" / "Base.yaml").write_text("name: Base\nfoo: 1\n")
+    (arch_root / "ext" / "Child.yaml").write_text(
+        'name: Child\n$inherits: "ext/Base.yaml#"\nbar: 2\n'
+    )
+
+    resolved = resolve("ext/Child.yaml", arch_root, False, False)
+
+    assert resolved["foo"] == 1
+    assert resolved["bar"] == 2

--- a/tools/ruby-gems/udb/python/test_yaml_resolver.py
+++ b/tools/ruby-gems/udb/python/test_yaml_resolver.py
@@ -4,7 +4,7 @@
 
 import pytest
 import yaml_resolver
-from yaml_resolver import resolve
+from yaml_resolver import merge_file, resolve
 
 
 @pytest.fixture(autouse=True)
@@ -47,4 +47,30 @@ def test_inherits_still_resolves_targets_inside_arch_root(tmp_path):
     resolved = resolve("ext/Child.yaml", arch_root, False, False)
 
     assert resolved["foo"] == 1
+    assert resolved["bar"] == 2
+
+
+def test_out_of_tree_overlay_inherits_across_the_merged_tree(tmp_path):
+    """An `arch_overlay` may live outside the repo, but resolution never sees it: merging
+    copies the overlay into the merged tree first, and only that tree is ever an arch root.
+    This pins the ordering so the containment check can't be mistaken for an overlay break.
+    """
+    std_dir = tmp_path / "std"
+    (std_dir / "ext").mkdir(parents=True)
+    (std_dir / "ext" / "Base.yaml").write_text("name: Base\nfoo: 1\n")
+
+    overlay_dir = tmp_path / "outside" / "overlay"
+    (overlay_dir / "ext").mkdir(parents=True)
+    (overlay_dir / "ext" / "MyExt.yaml").write_text(
+        'name: MyExt\n$inherits: "ext/Base.yaml#"\nbar: 2\n'
+    )
+
+    merged_dir = tmp_path / "merged"
+    (merged_dir / "ext").mkdir(parents=True)
+    for rel_path in ("ext/Base.yaml", "ext/MyExt.yaml"):
+        merge_file(rel_path, std_dir, overlay_dir, merged_dir)
+
+    resolved = resolve("ext/MyExt.yaml", merged_dir, False, False)
+
+    assert resolved["foo"] == 1, "overlay file could not inherit from the standard spec"
     assert resolved["bar"] == 2

--- a/tools/ruby-gems/udb/python/yaml_resolver.py
+++ b/tools/ruby-gems/udb/python/yaml_resolver.py
@@ -297,7 +297,19 @@ def resolve(
     -------
     dict
       The resolved object
+
+    Raises
+    ------
+    ValueError
+      If rel_path points outside arch_root. rel_path can come from a `$inherits`
+      target in a spec file, so it is untrusted: without this check a `../` sequence
+      or an absolute path would read an arbitrary file and inline it into the
+      resolved (and published) output.
     """
+    arch_root_abs = Path(arch_root).resolve()
+    if not (arch_root_abs / rel_path).resolve().is_relative_to(arch_root_abs):
+        raise ValueError(f"{rel_path} escapes the architecture root {arch_root}/")
+
     if str(rel_path) in resolved_objs:
         return resolved_objs[str(rel_path)]
     else:

--- a/tools/ruby-gems/udb/test/test_yaml_resolver.rb
+++ b/tools/ruby-gems/udb/test/test_yaml_resolver.rb
@@ -598,6 +598,30 @@ class TestYamlResolver < Minitest::Test
     assert_equal 2, child["bar"]
   end
 
+  # An `arch_overlay` may live outside the repo (Resolver#merge_arch accepts an absolute
+  # path), so the containment check must not treat that as an escape. It doesn't, because
+  # merging copies the overlay into the generated merged tree first and resolution only
+  # ever runs against that tree -- this test pins that ordering.
+  def test_out_of_tree_overlay_inherits_across_the_merged_tree
+    std_dir = Pathname.new(@test_dir) / "std" / "ext"
+    std_dir.mkpath
+    File.write(std_dir / "Base.yaml", "name: Base\nfoo: 1\n")
+
+    overlay_dir = Pathname.new(@test_dir) / "outside" / "overlay" / "ext"
+    overlay_dir.mkpath
+    File.write(overlay_dir / "MyExt.yaml", "name: MyExt\n$inherits: \"ext/Base.yaml#\"\nbar: 2\n")
+
+    merged_dir = Pathname.new(@test_dir) / "merged"
+    resolved_dir = Pathname.new(@test_dir) / "resolved"
+    resolver = Udb::Yaml::Resolver.new(quiet: true)
+    resolver.merge_files(std_dir.parent, overlay_dir.parent, merged_dir)
+    resolver.resolve_files(merged_dir, resolved_dir, no_checks: true)
+
+    my_ext = Psych.safe_load_file(resolved_dir / "ext" / "MyExt.yaml", permitted_classes: [Date])
+    assert_equal 1, my_ext["foo"], "overlay file could not inherit from the standard spec"
+    assert_equal 2, my_ext["bar"]
+  end
+
   private
 
   # Recursively find all compiled AST hashes (identified by having a "source" hash

--- a/tools/ruby-gems/udb/test/test_yaml_resolver.rb
+++ b/tools/ruby-gems/udb/test/test_yaml_resolver.rb
@@ -560,6 +560,44 @@ class TestYamlResolver < Minitest::Test
     end
   end
 
+  # A `$inherits` target is untrusted data from a spec file, so it must not be able
+  # to name a file outside the architecture root.
+  #
+  # NOTE: these live above the `private` marker deliberately. Minitest only collects
+  # *public* `test_*` methods, so a test defined below it never runs.
+  def test_inherits_cannot_escape_arch_root
+    arch_dir = Pathname.new(@test_dir) / "arch" / "ext"
+    arch_dir.mkpath
+    outside = Pathname.new(@test_dir) / "outside"
+    outside.mkpath
+    File.write(outside / "secrets.yaml", "name: secrets\nsecret: s3cret\n")
+
+    ["../outside/secrets.yaml#", "#{outside / "secrets.yaml"}#"].each do |target|
+      File.write(arch_dir / "Evil.yaml", "name: Evil\n$inherits: \"#{target}\"\n")
+
+      err = assert_raises(RuntimeError) do
+        Udb::Yaml::Resolver.new(quiet: true).resolve_files(
+          arch_dir.parent, Pathname.new(@test_dir) / "resolved", no_checks: true
+        )
+      end
+      assert_match(/escapes the architecture root/, err.message, "did not block #{target}")
+    end
+  end
+
+  def test_inherits_still_resolves_targets_inside_arch_root
+    arch_dir = Pathname.new(@test_dir) / "arch" / "ext"
+    arch_dir.mkpath
+    File.write(arch_dir / "Base.yaml", "name: Base\nfoo: 1\n")
+    File.write(arch_dir / "Child.yaml", "name: Child\n$inherits: \"ext/Base.yaml#\"\nbar: 2\n")
+
+    resolved_dir = Pathname.new(@test_dir) / "resolved"
+    Udb::Yaml::Resolver.new(quiet: true).resolve_files(arch_dir.parent, resolved_dir, no_checks: true)
+
+    child = Psych.safe_load_file(resolved_dir / "ext" / "Child.yaml", permitted_classes: [Date])
+    assert_equal 1, child["foo"]
+    assert_equal 2, child["bar"]
+  end
+
   private
 
   # Recursively find all compiled AST hashes (identified by having a "source" hash

--- a/tools/test/regress-tests.yaml
+++ b/tools/test/regress-tests.yaml
@@ -169,6 +169,7 @@ tests:
           - conditions
           - cli
           - yaml_loader
+          - yaml_resolver
           - cfg_arch
           - cfg
           - mmr


### PR DESCRIPTION
Closes #2139

## Summary

A `$inherits` target is untrusted data from a spec file, but both resolvers joined it straight onto `arch_root` and only checked that the result existed. A `../` sequence, or an absolute path (which makes both `os.path.join` and `Pathname#/` discard the root entirely), escaped the architecture tree and the referenced file's contents were merged into the resolved output.

That output ships as the `resolved-spec` artifact and is deployed to GitHub Pages, so a PR touching only `spec/**/*.yaml` could read a file from the runner and publish it.

## What changed

A containment check in each resolver, placed at the point where a path is turned into a file read rather than at the `$inherits` call site - so it covers the `$inherits` recursion and any future caller:

* `tools/ruby-gems/udb/lib/udb/yaml/yaml_resolver.rb` - `get_resolved_object`
* `tools/ruby-gems/udb/python/yaml_resolver.py` - `resolve`

Both resolve symlinks before comparing, so a symlink inside the tree pointing outward is rejected too.

## Notes for reviewers

* **The Ruby resolver is the one the build uses** (`Udb::Resolver#resolve_arch`); the Python script is no longer invoked by any task but still ships and is runnable as a CLI, so it is fixed as well. The Python test runs under `pytest tools/ruby-gems/udb/python/` but is not wired into a CI job - there is no Python unit-test bucket today and adding one felt out of scope here. Say the word if you would rather have it.
* `test_yaml_resolver.rb` was not in the `regress-udb-unit-test` matrix, so it never ran in CI. Added, and `.github/workflows/regress.yml` regenerated with `./bin/chore gen regress`.
* **Separately:** the `private` marker at `test_yaml_resolver.rb:563` means Minitest silently skips every `test_*` method defined below it - four existing tests have not been running. I put the new tests above the marker rather than move it, because re-enabling those four surfaces two real failures (`test_cross_file_parent_of_relationships`, `test_source_location_edge_cases`) that are unrelated to this fix. Filed as #2143.

## What was tested

* New regression tests fail on the unfixed code and pass with the fix, for both the relative-`../` and absolute-path forms. A third test asserts legitimate in-tree `$inherits` still resolves, so the check is not over-tightened.
* `./bin/ruby tools/ruby-gems/udb/test/test_yaml_resolver.rb` - 15 runs, 0 failures (was 13; the 2 new ones now actually run).
* `./bin/ruby tools/ruby-gems/udb/test/test_yaml_loader.rb` - 12 runs, 0 failures.
* `pytest tools/ruby-gems/udb/python/test_yaml_resolver.py` - 3 passed.
* End-to-end: resolved the real merged spec tree (`gen/spec/_`, 2208 files) through both resolvers - identical file counts, no legitimate `$inherits` rejected.
* `./do test:sorbet` - no errors. `ruff check` / `ruff format --check` - clean. `rubocop` on the changed files - 8 offenses, identical to the pre-change baseline.
* `./bin/pre-commit` - all checks pass.

`./do gen:resolved_arch CFG=_` could not complete locally: my checkout path contains a space, which fails the `$source` `format` schema check. Verified identical failure on unmodified `main`, so it is environmental and unrelated - hence the direct end-to-end resolve above with `no_checks`.
