### PR TITLE
docs(param): correct SXLEN and UXLEN parameter descriptions

### DIFF
--- a/spec/std/isa/param/SXLEN.yaml
+++ b/spec/std/isa/param/SXLEN.yaml
@@ -9,8 +9,8 @@ name: SXLEN
 description: |
   Set of XLENs supported in S-mode. Can be one of:
 
-    * 32:   SXLEN is always 32
-    * 64:   SXLEN is always 64
+    * [32]:     SXLEN is always 32
+    * [64]:     SXLEN is always 64
     * [32, 64]: SXLEN can be changed (via mstatus.SXL) between 32 and 64
 long_name: TODO
 schema:

--- a/spec/std/isa/param/UXLEN.yaml
+++ b/spec/std/isa/param/UXLEN.yaml
@@ -7,7 +7,7 @@ $schema: param_schema.json#
 kind: parameter
 name: UXLEN
 description: |
-  Set of XLENs supported in U-mode. When both 32 and 64 are supported, SXLEN can be changed,
+  Set of XLENs supported in U-mode. When both 32 and 64 are supported, UXLEN can be changed,
   via mstatus.UXL, between 32 and 64.
 long_name: TODO
 schema:


### PR DESCRIPTION
`UXLEN` description uses "SXLEN" instead of "UXLEN".

`SXLEN` value is always an array, but the documentation example uses a scalar (e.g. "32") instead of an array ("[32]").

Fixes #2145.