### PR TITLE
Security: Avoid shell interpolation when invoking external commands

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,6 @@ GEM
     erb (6.0.6)
     erubi (1.13.1)
     ffi (1.17.4-aarch64-linux-gnu)
-    ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     hana (1.3.7)
     hashery (2.1.2)
@@ -258,7 +257,6 @@ GEM
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
     rubydex (0.2.9-aarch64-linux)
-    rubydex (0.2.9-arm64-darwin)
     rubydex (0.2.9-x86_64-linux)
     rubyzip (3.4.1)
     securerandom (0.4.1)
@@ -271,7 +269,6 @@ GEM
       sorbet-static (= 0.6.13342)
     sorbet-runtime (0.6.13342)
     sorbet-static (0.6.13342-aarch64-linux)
-    sorbet-static (0.6.13342-universal-darwin)
     sorbet-static (0.6.13342-x86_64-linux)
     sorbet-static-and-runtime (0.6.13342)
       sorbet (= 0.6.13342)
@@ -347,7 +344,6 @@ GEM
 
 PLATFORMS
   aarch64-linux-gnu
-  arm64-darwin-23
   x86_64-linux
   x86_64-linux-gnu
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,7 @@ GEM
     erb (6.0.6)
     erubi (1.13.1)
     ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     hana (1.3.7)
     hashery (2.1.2)
@@ -257,6 +258,7 @@ GEM
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
     rubydex (0.2.9-aarch64-linux)
+    rubydex (0.2.9-arm64-darwin)
     rubydex (0.2.9-x86_64-linux)
     rubyzip (3.4.1)
     securerandom (0.4.1)
@@ -269,6 +271,7 @@ GEM
       sorbet-static (= 0.6.13342)
     sorbet-runtime (0.6.13342)
     sorbet-static (0.6.13342-aarch64-linux)
+    sorbet-static (0.6.13342-universal-darwin)
     sorbet-static (0.6.13342-x86_64-linux)
     sorbet-static-and-runtime (0.6.13342)
       sorbet (= 0.6.13342)
@@ -344,6 +347,7 @@ GEM
 
 PLATFORMS
   aarch64-linux-gnu
+  arm64-darwin-23
   x86_64-linux
   x86_64-linux-gnu
 

--- a/backends/indexer/tasks.rake
+++ b/backends/indexer/tasks.rake
@@ -7,7 +7,9 @@ namespace :gen do
     index_path = Pathname.new("#{$root}/gen/indexer/index-unified.json")
     Dir.chdir "#{$root}/backends/indexer" do
       FileUtils.mkdir_p index_path.dirname
-      File.write index_path, `node index-unifieddb.js #{$root}`
+      require "open3"
+      stdout, _stderr, _status = Open3.capture3("node", "index-unifieddb.js", $root.to_s)
+      File.write index_path, stdout
     end
   end
 end

--- a/backends/indexer/tasks.rake
+++ b/backends/indexer/tasks.rake
@@ -8,7 +8,8 @@ namespace :gen do
     Dir.chdir "#{$root}/backends/indexer" do
       FileUtils.mkdir_p index_path.dirname
       require "open3"
-      stdout, _stderr, _status = Open3.capture3("node", "index-unifieddb.js", $root.to_s)
+      stdout, stderr, status = Open3.capture3("node", "index-unifieddb.js", $root.to_s)
+      raise "index generation failed: #{stderr}" unless status.success?
       File.write index_path, stdout
     end
   end

--- a/backends/prm_pdf/tasks.rake
+++ b/backends/prm_pdf/tasks.rake
@@ -67,7 +67,7 @@ namespace :prm do
     when /darwin/
       system("open", pdf_path.to_s)
     when /mswin|mingw/
-      system("start", '""', pdf_path.to_s)
+      system("cmd", "/c", "start", '""', pdf_path.to_s)
     else
       puts "Please open: #{pdf_path}"
     end

--- a/backends/prm_pdf/tasks.rake
+++ b/backends/prm_pdf/tasks.rake
@@ -63,11 +63,11 @@ namespace :prm do
     puts "Opening PDF: #{pdf_path}"
     case RbConfig::CONFIG['host_os']
     when /linux/
-      system("xdg-open #{pdf_path} &")
+      spawn("xdg-open", pdf_path.to_s)
     when /darwin/
-      system("open #{pdf_path}")
+      system("open", pdf_path.to_s)
     when /mswin|mingw/
-      system("start \"\" #{pdf_path}")
+      system("start", '""', pdf_path.to_s)
     else
       puts "Please open: #{pdf_path}"
     end


### PR DESCRIPTION
## Description

Fixes #2149

This PR is a security-hardening and defense-in-depth improvement. It replaces shell-based process invocations with argument-based APIs across the generator backends to improve robustness and avoid unnecessary shell interpretation.

## Motivation

The `udb` repository currently contains several places where filesystem paths (such as `$root` and `pdf_path`) are interpolated directly into shell command strings.

Examples include:

```ruby
File.write index_path, `node index-unifieddb.js #{$root}`
```

```ruby
system("open #{pdf_path}")
```

Passing a single command string causes Ruby to invoke the system shell (for example, `/bin/sh` or `cmd.exe`). While these paths are typically trusted, using argument-based process invocation avoids shell interpretation, improves handling of paths containing spaces or special characters, and follows Ruby's recommended practices for executing external commands.

## Changes

To improve the security posture and robustness of the build tooling, this PR replaces shell-based invocations with argument-based APIs.

- **`backends/indexer/tasks.rake`**
  - Replace the backtick invocation with `Open3.capture3`.
  - Add explicit exit status checking and surface `stderr` if index generation fails.

- **`backends/prm_pdf/tasks.rake`**
  - Replace single-string `system()` calls with argument-based `spawn()` and `system()` calls.
  - Preserve Windows compatibility by explicitly invoking `cmd /c start`, since `start` is a `cmd.exe` built-in.

## Benefits

- Avoids shell interpretation of filesystem paths.
- Improves robustness for paths containing spaces or shell metacharacters.
- Improves error reporting for failed process execution.
- Aligns the implementation with Ruby's recommended process invocation practices.