### PR TITLE
fix(ci): compare schema bytes, not decoded strings, in version check

### DIFF
--- a/tools/scripts/check_schema_versions.rb
+++ b/tools/scripts/check_schema_versions.rb
@@ -41,8 +41,14 @@ gen_schemas_dir.glob("**/*.json").sort.each do |schema_file|
   end
 
   if response.code == "200"
-    remote_content = response.body
-    local_content = schema_file.read
+    # Compare raw bytes. Net::HTTP returns a body tagged ASCII-8BIT while
+    # Pathname#read returns UTF-8, and Ruby considers two strings with
+    # different encodings unequal as soon as either contains a non-ASCII
+    # byte -- even when their bytes are identical. Comparing the decoded
+    # strings therefore reported a spurious mismatch for every published
+    # schema containing a non-ASCII character.
+    remote_content = response.body.b
+    local_content = schema_file.binread
     if remote_content.strip != local_content.strip
       failures << "Schema mismatch for #{published_id}:\n" \
                   "  Local:  #{schema_file}\n" \


### PR DESCRIPTION
Fixes #2148

## Root cause

`regress-schema-versions` was **not** failing because a schema drifted from its published copy. It was failing because of an encoding bug in the check itself.

`check_schema_versions.rb` compared:

```ruby
remote_content = response.body   # Net::HTTP -> ASCII-8BIT
local_content  = schema_file.read # Pathname#read -> UTF-8
if remote_content.strip != local_content.strip
```

Ruby treats two strings with different encodings as unequal as soon as either contains a non-ASCII byte — even when the bytes are identical. Demonstrated against the live published schema:

```
remote encoding: ASCII-8BIT
local  encoding: UTF-8
raw bytes equal?: true
md5 (both):       880abd951fc58eef4eaf93e1aa39f9e7
strip == strip  : false     <-- what the check does
force-UTF8 equal: true
```

Identical bytes, identical MD5, reported as a mismatch.

## Why only `config_schema.json`

It is the only published schema containing a non-ASCII character — an em dash (`—`) in the `compatible` description. Of the three schemas currently published:

| Schema | Version | Non-ASCII | Result |
|---|---|---|---|
| `config_schema.json` | v0.1 | `—` | **failed** |
| `csr_schema.json` | v0.2 | none | passed |
| `exception_code_schema.json` | v0.1 | none | passed |

Perfect correlation with the bug, and none with content drift.

## Fix

Compare raw bytes (`response.body.b` vs `schema_file.binread`).

## Verification

With `$id` left untouched at `v0.1`:

```
OK (matches published): .../config_schema.json/v0.1/config_schema.json
All schema version checks passed.
```

And it still catches genuine drift — deliberately editing `title` in `config_schema.json` (same `v0.1`) reproduces the failure as intended, so this isn't just silencing the check.

## Note on #2150

I opened #2150 earlier to bump `config_schema.json`'s `$id` to `v0.2`, before finding this. **That fix would not have held.** Bumping only passes because `v0.2` returns 404 (`OK (not yet published)`); once `v0.2` published automatically on the next merge to main, the same em dash would have triggered the same encoding bug and broken CI again. I'll close #2150 in favour of this unless you'd prefer the version bump on policy grounds — see the notes I left on #2148 about that.
