### PR TITLE
Updated several ISA parameter spec files to replace placeholder long_name: TODO entries with concrete names. 

### DIFF
--- a/spec/std/isa/param/ELEN.yaml
+++ b/spec/std/isa/param/ELEN.yaml
@@ -8,7 +8,7 @@ kind: parameter
 name: ELEN
 description: |
   The maximum size in bits of a vector element that any operation can produce or consume.
-long_name: TODO
+long_name: Maximum vector element size
 schema:
   type: integer
 #    requirements:

--- a/spec/std/isa/param/VLEN.yaml
+++ b/spec/std/isa/param/VLEN.yaml
@@ -8,7 +8,7 @@ kind: parameter
 name: VLEN
 description: |
   The number of bits in a single vector register.
-long_name: TODO
+long_name: Vector register length
 schema:
   type: integer
   minimum: 32

--- a/spec/std/isa/param/VMID_WIDTH.yaml
+++ b/spec/std/isa/param/VMID_WIDTH.yaml
@@ -11,7 +11,7 @@ description:
   of a virtual machine ID).
 
   "
-long_name: TODO
+long_name: Virtual machine ID width
 schema:
   type: integer
   minimum: 0

--- a/spec/std/isa/param/VS_MODE_ENDIANNESS.yaml
+++ b/spec/std/isa/param/VS_MODE_ENDIANNESS.yaml
@@ -13,7 +13,7 @@ description: |
    * big:     VS-mode data is always big endian
    * dynamic: VS-mode data can be either little or big endian,
               depending on the CSR field `hstatus.VSBE`
-long_name: Vs-mode data endianness
+long_name: VS-mode data endianness
 schema:
   type: string
   enum:

--- a/spec/std/isa/param/VS_MODE_ENDIANNESS.yaml
+++ b/spec/std/isa/param/VS_MODE_ENDIANNESS.yaml
@@ -13,7 +13,7 @@ description: |
    * big:     VS-mode data is always big endian
    * dynamic: VS-mode data can be either little or big endian,
               depending on the CSR field `hstatus.VSBE`
-long_name: TODO
+long_name: Vs-mode data endianness
 schema:
   type: string
   enum:


### PR DESCRIPTION
The change covers:

VLEN.yaml
ELEN.yaml
VMID_WIDTH.yaml
VS_MODE_ENDIANNESS.yaml
This is a metadata cleanup only. It does not change behavior, generated logic, or runtime code. Static validation of the edited YAML files reported no errors.
