### PR TITLE
feat(helpers): add IDL code links and anchors for CSRs and CSR fields

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/doc_link.rb
+++ b/tools/ruby-gems/udb/lib/udb/doc_link.rb
@@ -29,7 +29,8 @@
 #                      appendix for UDB documentation that has normative rules and test plans in appendices
 #                   where <id> is the ID of the normative rule
 #   IDL code      idl:code:inst:<inst-name>:<location>
-#                 TODO for CSR and CSR Fields
+#                 idl:code:csr:<csr-name>:<location>
+#                 idl:code:csr_field:<csr-name>:<field-name>:<location>
 module Udb
   class DocLink
     # @param dst_link [String] The documentation link provided in the YAML

--- a/tools/ruby-gems/udb_helpers/lib/udb_helpers/backend_helpers.rb
+++ b/tools/ruby-gems/udb_helpers/lib/udb_helpers/backend_helpers.rb
@@ -194,7 +194,22 @@ module Udb
       def link_into_idl_inst_code(inst_name, id)
         "%%IDL_CODE_LINK%inst;#{inst_name.sanitize}.#{id.sanitize};#{inst_name}.#{id}%%"
       end
-      # TODO: Add csr and csr_field support
+
+      # @return [String] A hyperlink into IDL CSR code
+      # @param csr_name [String] Name of the CSR
+      # @param id [String] ID within the CSR code
+      def link_into_idl_csr_code(csr_name, id)
+        "%%IDL_CODE_LINK%csr;#{csr_name.sanitize}.#{id.sanitize};#{csr_name}.#{id}%%"
+      end
+
+      # @return [String] A hyperlink into IDL CSR field code
+      # @param csr_name [String] Name of the CSR
+      # @param field_name [String] Name of the CSR field
+      # @param id [String] ID within the CSR field code
+      def link_into_idl_csr_field_code(csr_name, field_name, id)
+        "%%IDL_CODE_LINK%csr_field;#{csr_name.sanitize}*#{field_name.sanitize}.#{id.sanitize};" \
+          "#{csr_name}.#{field_name}.#{id}%%"
+      end
 
       ###########
       # ANCHORS #
@@ -273,7 +288,21 @@ module Udb
       def anchor_inside_idl_inst_code(inst_name, id)
         "[#idl:code:inst:#{inst_name.sanitize}:#{id.sanitize}]"
       end
-      # TODO: Add csr and csr_field support
+
+      # @return [String] An anchor inside IDL CSR code
+      # @param csr_name [String] Name of the CSR
+      # @param id [String] ID within the CSR code
+      def anchor_inside_idl_csr_code(csr_name, id)
+        "[#idl:code:csr:#{csr_name.sanitize}:#{id.sanitize}]"
+      end
+
+      # @return [String] An anchor inside IDL CSR field code
+      # @param csr_name [String] Name of the CSR
+      # @param field_name [String] Name of the CSR field
+      # @param id [String] ID within the CSR field code
+      def anchor_inside_idl_csr_field_code(csr_name, field_name, id)
+        "[#idl:code:csr_field:#{csr_name.sanitize}:#{field_name.sanitize}:#{id.sanitize}]"
+      end
 
       #@ param s [String]
       def check_no_periods(s)
@@ -352,7 +381,13 @@ module Udb
           when "inst"
             inst_name, id = name.split(".")
             "<<idl:code:inst:#{inst_name}:#{id},#{link_text}>>"
-          # TODO: Add csr and csr_field support
+          when "csr"
+            csr_name, id = name.split(".")
+            "<<idl:code:csr:#{csr_name}:#{id},#{link_text}>>"
+          when "csr_field"
+            csr_name, rest = name.split("*")
+            field_name, id = rest.split(".")
+            "<<idl:code:csr_field:#{csr_name}:#{field_name}:#{id},#{link_text}>>"
           else
             raise "Unhandled link type of '#{type}' for '#{name}' with link_text '#{link_text}'"
           end
@@ -426,7 +461,13 @@ module Udb
           when "inst"
             inst_name, id = name.split(".")
             "xref:insts:#{inst_name}.adoc#idl:code:inst:#{inst_name}:#{id}[#{link_text}]"
-          # TODO: Add csr and csr_field support
+          when "csr"
+            csr_name, id = name.split(".")
+            "xref:csrs:#{csr_name}.adoc#idl:code:csr:#{csr_name}:#{id}[#{link_text}]"
+          when "csr_field"
+            csr_name, rest = name.split("*")
+            field_name, id = rest.split(".")
+            "xref:csrs:#{csr_name}.adoc#idl:code:csr_field:#{csr_name}:#{field_name}:#{id}[#{link_text}]"
           else
             raise "Unhandled link type of '#{type}' for '#{name}' with link_text '#{link_text}'"
           end

--- a/tools/ruby-gems/udb_helpers/test/test_backend_helpers.rb
+++ b/tools/ruby-gems/udb_helpers/test/test_backend_helpers.rb
@@ -67,6 +67,19 @@ class TestBackendHelpers < Minitest::Test
     assert_equal("[#idl:code:inst:foo:bar]", anchor_inside_idl_inst_code("foo","bar"))
     assert_equal("%%IDL_CODE_LINK%inst;fo_o.ba_r;fo.o.ba.r%%", link_into_idl_inst_code("fo.o","ba.r"))
     assert_equal("[#idl:code:inst:fo_o:ba_r]", anchor_inside_idl_inst_code("fo.o","ba.r"))
+
+    assert_equal("%%IDL_CODE_LINK%csr;foo.bar;foo.bar%%", link_into_idl_csr_code("foo","bar"))
+    assert_equal("[#idl:code:csr:foo:bar]", anchor_inside_idl_csr_code("foo","bar"))
+    assert_equal("%%IDL_CODE_LINK%csr;fo_o.ba_r;fo.o.ba.r%%", link_into_idl_csr_code("fo.o","ba.r"))
+    assert_equal("[#idl:code:csr:fo_o:ba_r]", anchor_inside_idl_csr_code("fo.o","ba.r"))
+
+    assert_equal("%%IDL_CODE_LINK%csr_field;foo*bar.baz;foo.bar.baz%%",
+                 link_into_idl_csr_field_code("foo","bar","baz"))
+    assert_equal("[#idl:code:csr_field:foo:bar:baz]", anchor_inside_idl_csr_field_code("foo","bar","baz"))
+    assert_equal("%%IDL_CODE_LINK%csr_field;fo_o*ba_r.ba_z;fo.o.ba.r.ba.z%%",
+                 link_into_idl_csr_field_code("fo.o","ba.r","ba.z"))
+    assert_equal("[#idl:code:csr_field:fo_o:ba_r:ba_z]",
+                 anchor_inside_idl_csr_field_code("fo.o","ba.r","ba.z"))
   end
 
 end
@@ -114,6 +127,14 @@ class TestAsciidocUtils < Minitest::Test
   def test_resolve_links_idl_code
     assert_equal("<<idl:code:inst:foo:bar,zort>>", AsciidocUtils.resolve_links("%%IDL_CODE_LINK%inst;foo.bar;zort%%"))
     assert_equal("<<idl:code:inst:foo:bar,foo.bar>>", AsciidocUtils.resolve_links(link_into_idl_inst_code("foo","bar")))
+
+    assert_equal("<<idl:code:csr:foo:bar,zort>>", AsciidocUtils.resolve_links("%%IDL_CODE_LINK%csr;foo.bar;zort%%"))
+    assert_equal("<<idl:code:csr:foo:bar,foo.bar>>", AsciidocUtils.resolve_links(link_into_idl_csr_code("foo","bar")))
+
+    assert_equal("<<idl:code:csr_field:foo:bar:baz,zort>>",
+                 AsciidocUtils.resolve_links("%%IDL_CODE_LINK%csr_field;foo*bar.baz;zort%%"))
+    assert_equal("<<idl:code:csr_field:foo:bar:baz,foo.bar.baz>>",
+                 AsciidocUtils.resolve_links(link_into_idl_csr_field_code("foo","bar","baz")))
   end
 end
 
@@ -154,5 +175,15 @@ class TestAntoraUtils < Minitest::Test
   def test_resolve_links_idl_code
     assert_equal("xref:insts:foo.adoc#idl:code:inst:foo:bar[zort]", AntoraUtils.resolve_links("%%IDL_CODE_LINK%inst;foo.bar;zort%%"))
     assert_equal("xref:insts:foo.adoc#idl:code:inst:foo:bar[foo.bar]", AntoraUtils.resolve_links(link_into_idl_inst_code("foo","bar")))
+
+    assert_equal("xref:csrs:foo.adoc#idl:code:csr:foo:bar[zort]",
+                 AntoraUtils.resolve_links("%%IDL_CODE_LINK%csr;foo.bar;zort%%"))
+    assert_equal("xref:csrs:foo.adoc#idl:code:csr:foo:bar[foo.bar]",
+                 AntoraUtils.resolve_links(link_into_idl_csr_code("foo","bar")))
+
+    assert_equal("xref:csrs:foo.adoc#idl:code:csr_field:foo:bar:baz[zort]",
+                 AntoraUtils.resolve_links("%%IDL_CODE_LINK%csr_field;foo*bar.baz;zort%%"))
+    assert_equal("xref:csrs:foo.adoc#idl:code:csr_field:foo:bar:baz[foo.bar.baz]",
+                 AntoraUtils.resolve_links(link_into_idl_csr_field_code("foo","bar","baz")))
   end
 end


### PR DESCRIPTION
## What this adds

Documentation links already cover CSRs — `udb:doc:csr:<name>` and `udb:doc:csr_field:<csr>:<field>` both resolve. But IDL **code** links only supported instructions, so there was no way to link into the IDL inside a CSR definition (`sw_read()`, `type()`, `reset_value()`, …).

Five TODOs marked the gap:

| Location | TODO |
|---|---|
| `backend_helpers.rb` (after `link_into_idl_inst_code`) | `# TODO: Add csr and csr_field support` |
| `backend_helpers.rb` (after `anchor_inside_idl_inst_code`) | `# TODO: Add csr and csr_field support` |
| `backend_helpers.rb` `AsciidocUtils.resolve_links` | `# TODO: Add csr and csr_field support` |
| `backend_helpers.rb` `AntoraUtils.resolve_links` | `# TODO: Add csr and csr_field support` |
| `doc_link.rb` link-scheme comment | `TODO for CSR and CSR Fields` |

## What changed

Four new helpers, mirroring the existing `inst` implementations exactly:

```ruby
link_into_idl_csr_code(csr_name, id)
link_into_idl_csr_field_code(csr_name, field_name, id)
anchor_inside_idl_csr_code(csr_name, id)
anchor_inside_idl_csr_field_code(csr_name, field_name, id)
```

plus `"csr"` / `"csr_field"` branches in both `AsciidocUtils.resolve_links` and `AntoraUtils.resolve_links`, and the `doc_link.rb` comment updated to document the two new forms.

## Encoding decisions

Both follow conventions already established on the documentation-link side rather than inventing anything:

- **Antora module for CSRs is `csrs`** — matching the existing `udb:doc:csr` branch (`xref:csrs:<csr>.adoc#…`), same way `inst` uses `insts`.
- **`csr_field` packs its components as `<csr>*<field>`** — the existing `udb:doc:csr_field` branch already uses `*` as its separator, so this is consistent and can't collide with a name.

Since `String#sanitize` maps `.` → `_`, splitting the remainder on `.` is unambiguous — verified by the `fo.o`/`ba.r`/`ba.z` test cases below.

## Verification

- `./do test:udb_helpers:unit` — **23 runs, 84 assertions, 0 failures**
- `./do test:sorbet` — **No errors**
- New tests mirror the existing `inst` cases across all three suites (`test_idl_code`, `test_resolve_links_idl_code` for both Asciidoc and Antora), including the dotted-name sanitization cases.

Example round-trip now covered:

```ruby
link_into_idl_csr_field_code("foo","bar","baz")
# => "%%IDL_CODE_LINK%csr_field;foo*bar.baz;foo.bar.baz%%"

AntoraUtils.resolve_links(...)
# => "xref:csrs:foo.adoc#idl:code:csr_field:foo:bar:baz[foo.bar.baz]"
```

## Note

This adds the plumbing; no call sites are switched over in this PR, so it's inert until something emits these links. Happy to follow up with the CSR-side emission (or split differently) if you'd prefer them landed together.
