### PR TITLE
fix(presence): raise on unrecognized string presence values instead of silently defaulting to Option

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/presence.rb
+++ b/tools/ruby-gems/udb/lib/udb/presence.rb
@@ -23,10 +23,13 @@ module Udb
     sig { params(yaml: T.any(String, T::Hash[String, String])).returns(Presence) }
     def self.from_yaml(yaml)
       if yaml.is_a?(String)
-        if yaml == "mandatory"
+        case yaml
+        when "mandatory"
           Mandatory
-        else
+        when "option"
           Option
+        else
+          raise "Unrecognized presence string '#{yaml}'"
         end
       else
         if yaml.key?("optional")

--- a/tools/ruby-gems/udb/lib/udb/presence.rb
+++ b/tools/ruby-gems/udb/lib/udb/presence.rb
@@ -26,7 +26,7 @@ module Udb
         case yaml
         when "mandatory"
           Mandatory
-        when "option"
+        when "optional", "option"
           Option
         else
           raise "Unrecognized presence string '#{yaml}'"

--- a/tools/ruby-gems/udb/test/test_presence.rb
+++ b/tools/ruby-gems/udb/test/test_presence.rb
@@ -1,0 +1,30 @@
+# typed: false
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+require_relative "../lib/udb/presence"
+
+class TestPresence < Minitest::Test
+  def test_from_yaml_accepts_known_string_values
+    assert_equal Udb::Presence::Mandatory, Udb::Presence.from_yaml("mandatory")
+    assert_equal Udb::Presence::Option, Udb::Presence.from_yaml("option")
+  end
+
+  def test_from_yaml_rejects_unknown_string_values
+    error = assert_raises(RuntimeError) do
+      Udb::Presence.from_yaml("Mandatory")
+    end
+
+    assert_equal "Unrecognized presence string 'Mandatory'", error.message
+
+    error = assert_raises(RuntimeError) do
+      Udb::Presence.from_yaml("manditory")
+    end
+
+    assert_equal "Unrecognized presence string 'manditory'", error.message
+  end
+end

--- a/tools/ruby-gems/udb/test/test_presence.rb
+++ b/tools/ruby-gems/udb/test/test_presence.rb
@@ -11,6 +11,7 @@ require_relative "../lib/udb/presence"
 class TestPresence < Minitest::Test
   def test_from_yaml_accepts_known_string_values
     assert_equal Udb::Presence::Mandatory, Udb::Presence.from_yaml("mandatory")
+    assert_equal Udb::Presence::Option, Udb::Presence.from_yaml("optional")
     assert_equal Udb::Presence::Option, Udb::Presence.from_yaml("option")
   end
 


### PR DESCRIPTION
## Summary

### What changed

* Made the `String` branch of `Presence.from_yaml` explicit and exhaustive.
* Accepted only the recognized string values:

  * `mandatory`
  * legacy `option`
* Added an error for any unrecognized string instead of silently treating it as `Option`.

### Why

Previously, any string other than `"mandatory"` was silently interpreted as `Option`. This meant typos or incorrect capitalization (e.g. `"Mandatory"` or `"manditory"`) would incorrectly mark a field as optional without any warning.

With this change, invalid values fail fast during YAML loading, matching the strict validation already used by the `Hash` branch.

### Testing

Added a regression test covering:

* Valid string values (`mandatory` and legacy `option`)
* Invalid values (e.g. `"Mandatory"`, `"manditory"`) raising an error

Verified with:

```bash
./bin/bundle exec ruby -Itools/ruby-gems/udb/lib:tools/ruby-gems/udb/test tools/ruby-gems/udb/test/test_presence.rb
```