### PR TITLE
fix(has_fields): field_hash rebuilds on every call due to missing return in memoization guard

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/obj/has_fields.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/has_fields.rb
@@ -37,7 +37,7 @@ module HasFields
 
   # @return [Hash<String,CsrField>] Hash of fields, indexed by field name
   def field_hash
-    @field_hash unless @field_hash.nil?
+    return @field_hash unless @field_hash.nil?
 
     @field_hash = {}
     fields.each do |field|

--- a/tools/ruby-gems/udb/test/test_mmr.rb
+++ b/tools/ruby-gems/udb/test/test_mmr.rb
@@ -242,6 +242,7 @@ class TestMmr < Minitest::Test
       }
     )
     assert_instance_of Hash, mmr.field_hash
+    assert_same mmr.field_hash, mmr.field_hash
     assert mmr.field_hash.key?("EN")
     assert_equal "EN", mmr.field_hash["EN"].name
   end


### PR DESCRIPTION
## Summary

### What changed

* Fixed the memoization guard in `HasFields#field_hash` by adding the missing `return`.
* Added a regression test to verify repeated calls to `field_hash` return the same cached hash object instead of rebuilding it.

### Why

`field_hash` was intended to cache the mapping from field names to `CsrField` objects. However, the memoization guard did not return the cached value, causing the hash to be rebuilt on every invocation.

Since methods such as `field?` and `field` rely on `field_hash`, every field lookup unnecessarily re-iterated over all fields and reallocated the hash, resulting in avoidable overhead.

With this change, the hash is built once per object and reused on subsequent calls.

### Testing

* Added a regression test asserting that repeated calls to `field_hash` return the same object.
* Verified the memoization behavior with a focused Ruby validation that loads `HasFields` directly and confirms the cached hash is reused.
