### PR TITLE
fix(csr,mmr,has_fields): exists_in_cfg?/optional_in_cfg? cache results without keying on the cfg_arch argument

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/obj/csr.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/csr.rb
@@ -614,7 +614,8 @@ module Udb
     # @return [Boolean] whether or not the CSR is possibly implemented given the supplied config options
     sig { params(cfg_arch: ConfiguredArchitecture).returns(T::Boolean) }
     def exists_in_cfg?(cfg_arch)
-      @exists_in_cfg ||= defined_by_condition.could_be_satisfied_by_cfg_arch?(cfg_arch)
+      @exists_in_cfg_cache ||= {}
+      @exists_in_cfg_cache[cfg_arch] ||= defined_by_condition.could_be_satisfied_by_cfg_arch?(cfg_arch)
     end
   end
 

--- a/tools/ruby-gems/udb/lib/udb/obj/csr.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/csr.rb
@@ -615,7 +615,10 @@ module Udb
     sig { params(cfg_arch: ConfiguredArchitecture).returns(T::Boolean) }
     def exists_in_cfg?(cfg_arch)
       @exists_in_cfg_cache ||= {}
-      @exists_in_cfg_cache[cfg_arch] ||= defined_by_condition.could_be_satisfied_by_cfg_arch?(cfg_arch)
+
+      return @exists_in_cfg_cache[cfg_arch] if @exists_in_cfg_cache.key?(cfg_arch)
+
+      @exists_in_cfg_cache[cfg_arch] = defined_by_condition.could_be_satisfied_by_cfg_arch?(cfg_arch)
     end
   end
 

--- a/tools/ruby-gems/udb/lib/udb/obj/csr.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/csr.rb
@@ -614,11 +614,12 @@ module Udb
     # @return [Boolean] whether or not the CSR is possibly implemented given the supplied config options
     sig { params(cfg_arch: ConfiguredArchitecture).returns(T::Boolean) }
     def exists_in_cfg?(cfg_arch)
-      @exists_in_cfg_cache ||= {}
+      @exists_in_cfg_cache ||= {}.compare_by_identity
 
       return @exists_in_cfg_cache[cfg_arch] if @exists_in_cfg_cache.key?(cfg_arch)
 
-      @exists_in_cfg_cache[cfg_arch] = defined_by_condition.could_be_satisfied_by_cfg_arch?(cfg_arch)
+      @exists_in_cfg_cache[cfg_arch] =
+        defined_by_condition.could_be_satisfied_by_cfg_arch?(cfg_arch)
     end
   end
 

--- a/tools/ruby-gems/udb/lib/udb/obj/has_fields.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/has_fields.rb
@@ -137,7 +137,10 @@ module HasFields
     raise "optional_in_cfg? should only be used by a partially-specified arch def" unless cfg_arch.partially_configured?
 
     @optional_in_cfg_cache ||= {}
-    @optional_in_cfg_cache[cfg_arch] ||=
+
+    return @optional_in_cfg_cache[cfg_arch] if @optional_in_cfg_cache.key?(cfg_arch)
+
+    @optional_in_cfg_cache[cfg_arch] =
       exists_in_cfg?(cfg_arch) &&
       (defined_by_condition.satisfied_by_cfg_arch?(cfg_arch) == SatisfiedResult::Maybe)
   end

--- a/tools/ruby-gems/udb/lib/udb/obj/has_fields.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/has_fields.rb
@@ -37,7 +37,7 @@ module HasFields
 
   # @return [Hash<String,CsrField>] Hash of fields, indexed by field name
   def field_hash
-    @field_hash unless @field_hash.nil?
+    return @field_hash unless @field_hash.nil?   # <-- CHANGED: added 'return'
 
     @field_hash = {}
     fields.each do |field|
@@ -136,7 +136,7 @@ module HasFields
     end
     raise "optional_in_cfg? should only be used by a partially-specified arch def" unless cfg_arch.partially_configured?
 
-    @optional_in_cfg_cache ||= {}
+    @optional_in_cfg_cache ||= {}.compare_by_identity
 
     return @optional_in_cfg_cache[cfg_arch] if @optional_in_cfg_cache.key?(cfg_arch)
 

--- a/tools/ruby-gems/udb/lib/udb/obj/has_fields.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/has_fields.rb
@@ -136,7 +136,8 @@ module HasFields
     end
     raise "optional_in_cfg? should only be used by a partially-specified arch def" unless cfg_arch.partially_configured?
 
-    @optional_in_cfg ||=
+    @optional_in_cfg_cache ||= {}
+    @optional_in_cfg_cache[cfg_arch] ||=
       exists_in_cfg?(cfg_arch) &&
       (defined_by_condition.satisfied_by_cfg_arch?(cfg_arch) == SatisfiedResult::Maybe)
   end

--- a/tools/ruby-gems/udb/lib/udb/obj/mmr.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/mmr.rb
@@ -90,7 +90,10 @@ class Mmr < TopLevelDatabaseObject
   sig { params(cfg_arch: ConfiguredArchitecture).returns(T::Boolean) }
   def exists_in_cfg?(cfg_arch)
     @exists_in_cfg_cache ||= {}
-    @exists_in_cfg_cache[cfg_arch] ||= defined_by_condition.could_be_satisfied_by_cfg_arch?(cfg_arch)
+
+    return @exists_in_cfg_cache[cfg_arch] if @exists_in_cfg_cache.key?(cfg_arch)
+
+    @exists_in_cfg_cache[cfg_arch] = defined_by_condition.could_be_satisfied_by_cfg_arch?(cfg_arch)
   end
 
   # Stubs for Sorbet — CsrField.parent is T.any(Csr, Mmr) but these methods

--- a/tools/ruby-gems/udb/lib/udb/obj/mmr.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/mmr.rb
@@ -89,7 +89,7 @@ class Mmr < TopLevelDatabaseObject
   # @return [Boolean] whether or not the MMR is possibly implemented given the supplied config options
   sig { params(cfg_arch: ConfiguredArchitecture).returns(T::Boolean) }
   def exists_in_cfg?(cfg_arch)
-    @exists_in_cfg_cache ||= {}
+    @exists_in_cfg_cache ||= {}.compare_by_identity
 
     return @exists_in_cfg_cache[cfg_arch] if @exists_in_cfg_cache.key?(cfg_arch)
 

--- a/tools/ruby-gems/udb/lib/udb/obj/mmr.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/mmr.rb
@@ -89,7 +89,8 @@ class Mmr < TopLevelDatabaseObject
   # @return [Boolean] whether or not the MMR is possibly implemented given the supplied config options
   sig { params(cfg_arch: ConfiguredArchitecture).returns(T::Boolean) }
   def exists_in_cfg?(cfg_arch)
-    @exists_in_cfg ||= defined_by_condition.could_be_satisfied_by_cfg_arch?(cfg_arch)
+    @exists_in_cfg_cache ||= {}
+    @exists_in_cfg_cache[cfg_arch] ||= defined_by_condition.could_be_satisfied_by_cfg_arch?(cfg_arch)
   end
 
   # Stubs for Sorbet — CsrField.parent is T.any(Csr, Mmr) but these methods

--- a/tools/ruby-gems/udb/test/test_cfg_arch_cache.rb
+++ b/tools/ruby-gems/udb/test/test_cfg_arch_cache.rb
@@ -35,13 +35,20 @@ class TestCfgArchCache < Minitest::Test
   class FakeCondition
     def initialize(results_by_cfg)
       @results_by_cfg = results_by_cfg
+      @calls = Hash.new(0)
+    end
+
+    def calls
+      @calls.dup
     end
 
     def could_be_satisfied_by_cfg_arch?(cfg_arch)
+      @calls[cfg_arch] += 1
       @results_by_cfg.fetch(cfg_arch)
     end
 
     def satisfied_by_cfg_arch?(cfg_arch)
+      @calls[cfg_arch] += 1
       @results_by_cfg.fetch(cfg_arch)
     end
 
@@ -67,7 +74,26 @@ class TestCfgArchCache < Minitest::Test
   end
 
   def make_cfg_arch(partially_configured: true)
-    ConfiguredArchitecture.new(partially_configured)
+    name = partially_configured ? "partial_cfg_#{object_id}_#{rand(1_000_000)}" : "full_cfg_#{object_id}_#{rand(1_000_000)}"
+    cfg_arch = ConfiguredArchitecture.allocate
+    cfg_arch.instance_variable_set(:@name, name)
+    cfg_arch.instance_variable_set(:@name_sym, name.to_sym)
+    cfg_arch.instance_variable_set(:@partially_configured, partially_configured)
+    def cfg_arch.partially_configured?
+      @partially_configured
+    end
+    def cfg_arch.hash
+      @name_sym.hash
+    end
+    def cfg_arch.eql?(other)
+      return false unless other.respond_to?(:name)
+
+      @name.eql?(other.name)
+    end
+    def cfg_arch.name
+      @name
+    end
+    cfg_arch
   end
 
   def make_csr(condition)
@@ -88,8 +114,12 @@ class TestCfgArchCache < Minitest::Test
     csr = make_csr(FakeCondition.new(cfg_true => true, cfg_false => false))
 
     assert_equal true, csr.exists_in_cfg?(cfg_true)
-    assert_equal false, csr.exists_in_cfg?(cfg_false)
     assert_equal true, csr.exists_in_cfg?(cfg_true)
+    assert_equal 1, csr.defined_by_condition.calls[cfg_true]
+
+    assert_equal false, csr.exists_in_cfg?(cfg_false)
+    assert_equal false, csr.exists_in_cfg?(cfg_false)
+    assert_equal 1, csr.defined_by_condition.calls[cfg_false]
   end
 
   def test_mmr_exists_in_cfg_is_keyed_by_cfg_arch
@@ -98,8 +128,12 @@ class TestCfgArchCache < Minitest::Test
     mmr = make_mmr(FakeCondition.new(cfg_true => true, cfg_false => false))
 
     assert_equal true, mmr.exists_in_cfg?(cfg_true)
-    assert_equal false, mmr.exists_in_cfg?(cfg_false)
     assert_equal true, mmr.exists_in_cfg?(cfg_true)
+    assert_equal 1, mmr.defined_by_condition.calls[cfg_true]
+
+    assert_equal false, mmr.exists_in_cfg?(cfg_false)
+    assert_equal false, mmr.exists_in_cfg?(cfg_false)
+    assert_equal 1, mmr.defined_by_condition.calls[cfg_false]
   end
 
   def test_optional_in_cfg_is_keyed_by_cfg_arch
@@ -108,7 +142,11 @@ class TestCfgArchCache < Minitest::Test
     probe = OptionalProbe.new(FakeCondition.new(cfg_true => Udb::SatisfiedResult::Maybe, cfg_false => Udb::SatisfiedResult::No))
 
     assert_equal true, probe.optional_in_cfg?(cfg_true)
-    assert_equal false, probe.optional_in_cfg?(cfg_false)
     assert_equal true, probe.optional_in_cfg?(cfg_true)
+    assert_equal 1, probe.defined_by_condition.calls[cfg_true]
+
+    assert_equal false, probe.optional_in_cfg?(cfg_false)
+    assert_equal false, probe.optional_in_cfg?(cfg_false)
+    assert_equal 1, probe.defined_by_condition.calls[cfg_false]
   end
 end

--- a/tools/ruby-gems/udb/test/test_cfg_arch_cache.rb
+++ b/tools/ruby-gems/udb/test/test_cfg_arch_cache.rb
@@ -1,0 +1,114 @@
+# typed: false
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+require "ostruct"
+
+module Udb
+  class ConfiguredArchitecture
+    def initialize(partially_configured)
+      @partially_configured = partially_configured
+    end
+
+    def partially_configured?
+      @partially_configured
+    end
+  end
+
+  module SatisfiedResult
+    Maybe = :maybe
+    No = :no
+  end
+end
+
+require_relative "../lib/udb/obj/csr"
+require_relative "../lib/udb/obj/mmr"
+require_relative "../lib/udb/obj/has_fields"
+
+class TestCfgArchCache < Minitest::Test
+  include Udb
+
+  class FakeCondition
+    def initialize(results_by_cfg)
+      @results_by_cfg = results_by_cfg
+    end
+
+    def could_be_satisfied_by_cfg_arch?(cfg_arch)
+      @results_by_cfg.fetch(cfg_arch)
+    end
+
+    def satisfied_by_cfg_arch?(cfg_arch)
+      @results_by_cfg.fetch(cfg_arch)
+    end
+
+    def empty?
+      false
+    end
+  end
+
+  class OptionalProbe
+    include Udb::HasFields
+
+    def initialize(condition)
+      @condition = condition
+    end
+
+    def defined_by_condition
+      @condition
+    end
+
+    def exists_in_cfg?(_cfg_arch)
+      true
+    end
+  end
+
+  def make_cfg_arch(partially_configured: true)
+    ConfiguredArchitecture.new(partially_configured)
+  end
+
+  def make_csr(condition)
+    csr = Csr.allocate
+    csr.define_singleton_method(:defined_by_condition) { condition }
+    csr
+  end
+
+  def make_mmr(condition)
+    mmr = Mmr.allocate
+    mmr.define_singleton_method(:defined_by_condition) { condition }
+    mmr
+  end
+
+  def test_csr_exists_in_cfg_is_keyed_by_cfg_arch
+    cfg_true = make_cfg_arch
+    cfg_false = make_cfg_arch
+    csr = make_csr(FakeCondition.new(cfg_true => true, cfg_false => false))
+
+    assert_equal true, csr.exists_in_cfg?(cfg_true)
+    assert_equal false, csr.exists_in_cfg?(cfg_false)
+    assert_equal true, csr.exists_in_cfg?(cfg_true)
+  end
+
+  def test_mmr_exists_in_cfg_is_keyed_by_cfg_arch
+    cfg_true = make_cfg_arch
+    cfg_false = make_cfg_arch
+    mmr = make_mmr(FakeCondition.new(cfg_true => true, cfg_false => false))
+
+    assert_equal true, mmr.exists_in_cfg?(cfg_true)
+    assert_equal false, mmr.exists_in_cfg?(cfg_false)
+    assert_equal true, mmr.exists_in_cfg?(cfg_true)
+  end
+
+  def test_optional_in_cfg_is_keyed_by_cfg_arch
+    cfg_true = make_cfg_arch(partially_configured: true)
+    cfg_false = make_cfg_arch(partially_configured: true)
+    probe = OptionalProbe.new(FakeCondition.new(cfg_true => Udb::SatisfiedResult::Maybe, cfg_false => Udb::SatisfiedResult::No))
+
+    assert_equal true, probe.optional_in_cfg?(cfg_true)
+    assert_equal false, probe.optional_in_cfg?(cfg_false)
+    assert_equal true, probe.optional_in_cfg?(cfg_true)
+  end
+end

--- a/tools/ruby-gems/udb/test/test_cfg_arch_cache.rb
+++ b/tools/ruby-gems/udb/test/test_cfg_arch_cache.rb
@@ -1,41 +1,50 @@
-# typed: false
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
+# typed: false
 # frozen_string_literal: true
 
 require_relative "test_helper"
 
-require "ostruct"
+require "fileutils"
+require "tmpdir"
 
-module Udb
-  class ConfiguredArchitecture
-    def initialize(partially_configured)
-      @partially_configured = partially_configured
-    end
-
-    def partially_configured?
-      @partially_configured
-    end
-  end
-
-  module SatisfiedResult
-    Maybe = :maybe
-    No = :no
-  end
-end
-
-require_relative "../lib/udb/obj/csr"
-require_relative "../lib/udb/obj/mmr"
-require_relative "../lib/udb/obj/has_fields"
+require "udb/cfg_arch"
+require "udb/resolver"
+require "udb/obj/csr"
+require "udb/obj/mmr"
+require "udb/obj/has_fields"
 
 class TestCfgArchCache < Minitest::Test
   include Udb
 
-  class FakeCondition
-    def initialize(results_by_cfg)
-      @results_by_cfg = results_by_cfg
-      @calls = Hash.new(0)
+  def setup
+    @gen_dir = Dir.mktmpdir
+    @resolver = Udb::Resolver.new(
+      Udb.repo_root,
+      gen_path_override: Pathname.new(@gen_dir)
+    )
+  end
+
+  def teardown
+    FileUtils.rm_rf @gen_dir
+  end
+
+  # Records how many times each ConfiguredArchitecture object is queried,
+  # and returns a predetermined result for it.
+  #
+  # ConfiguredArchitecture overrides hash/eql? to be name-based (see
+  # cfg_arch.rb), so two distinct objects sharing the same config `name:`
+  # are `eql?` to each other. Both internal maps here use
+  # compare_by_identity, and are built from an array of [cfg, value] pairs
+  # rather than a Hash literal, so that two name-equal-but-distinct
+  # ConfiguredArchitecture instances are never silently collapsed into one
+  # entry before this class even sees them.
+  class RecordingCondition
+    def initialize(pairs)
+      @results_by_cfg = Hash.new.compare_by_identity
+      pairs.each { |cfg, value| @results_by_cfg[cfg] = value }
+      @calls = Hash.new(0).compare_by_identity
     end
 
     def calls
@@ -57,11 +66,13 @@ class TestCfgArchCache < Minitest::Test
     end
   end
 
+  # Minimal class including HasFields to test optional_in_cfg?
   class OptionalProbe
     include Udb::HasFields
 
     def initialize(condition)
       @condition = condition
+      @data = { "fields" => {} }
     end
 
     def defined_by_condition
@@ -71,29 +82,46 @@ class TestCfgArchCache < Minitest::Test
     def exists_in_cfg?(_cfg_arch)
       true
     end
+
+    def cfg_arch
+      nil
+    end
+
+    def name
+      "probe"
+    end
   end
 
-  def make_cfg_arch(partially_configured: true)
-    name = partially_configured ? "partial_cfg_#{object_id}_#{rand(1_000_000)}" : "full_cfg_#{object_id}_#{rand(1_000_000)}"
-    cfg_arch = ConfiguredArchitecture.allocate
-    cfg_arch.instance_variable_set(:@name, name)
-    cfg_arch.instance_variable_set(:@name_sym, name.to_sym)
-    cfg_arch.instance_variable_set(:@partially_configured, partially_configured)
-    def cfg_arch.partially_configured?
-      @partially_configured
-    end
-    def cfg_arch.hash
-      @name_sym.hash
-    end
-    def cfg_arch.eql?(other)
-      return false unless other.respond_to?(:name)
+  # Real ConfiguredArchitecture, built the same way production code and
+  # test_cfg_arch.rb build it: through the resolver, from a config name or
+  # a config file path — not via ConfiguredArchitecture.allocate.
+  def make_cfg_arch(name)
+    @resolver.cfg_arch_for(name)
+  end
 
-      @name.eql?(other.name)
-    end
-    def cfg_arch.name
-      @name
-    end
-    cfg_arch
+  # Writes a minimal partially-configured YAML config with the given
+  # top-level `name:` field to a fresh tempfile, and resolves it into a
+  # real ConfiguredArchitecture.
+  def make_cfg_arch_from_yaml(config_name)
+    cfg = <<~CFG
+      $schema: config_schema.json#
+      kind: architecture configuration
+      type: partially configured
+      name: #{config_name}
+      description: Minimal config for cache identity tests
+      mandatory_extensions:
+        - name: "I"
+          version: ">= 0"
+        - name: "Sm"
+          version: ">= 0"
+    CFG
+
+    f = Tempfile.create(%w/cfg .yaml/)
+    f.write(cfg)
+    f.flush
+    @resolver.cfg_arch_for(Pathname.new(f.path))
+  ensure
+    f&.close
   end
 
   def make_csr(condition)
@@ -109,44 +137,74 @@ class TestCfgArchCache < Minitest::Test
   end
 
   def test_csr_exists_in_cfg_is_keyed_by_cfg_arch
-    cfg_true = make_cfg_arch
-    cfg_false = make_cfg_arch
-    csr = make_csr(FakeCondition.new(cfg_true => true, cfg_false => false))
+    cfg_true = make_cfg_arch("rv32")
+    cfg_false = make_cfg_arch("rv64")
+    condition = RecordingCondition.new([[cfg_true, true], [cfg_false, false]])
+    csr = make_csr(condition)
 
     assert_equal true, csr.exists_in_cfg?(cfg_true)
     assert_equal true, csr.exists_in_cfg?(cfg_true)
-    assert_equal 1, csr.defined_by_condition.calls[cfg_true]
+    assert_equal 1, condition.calls[cfg_true]
 
     assert_equal false, csr.exists_in_cfg?(cfg_false)
     assert_equal false, csr.exists_in_cfg?(cfg_false)
-    assert_equal 1, csr.defined_by_condition.calls[cfg_false]
+    assert_equal 1, condition.calls[cfg_false]
   end
 
   def test_mmr_exists_in_cfg_is_keyed_by_cfg_arch
-    cfg_true = make_cfg_arch
-    cfg_false = make_cfg_arch
-    mmr = make_mmr(FakeCondition.new(cfg_true => true, cfg_false => false))
+    cfg_true = make_cfg_arch("rv32")
+    cfg_false = make_cfg_arch("rv64")
+    condition = RecordingCondition.new([[cfg_true, true], [cfg_false, false]])
+    mmr = make_mmr(condition)
 
     assert_equal true, mmr.exists_in_cfg?(cfg_true)
     assert_equal true, mmr.exists_in_cfg?(cfg_true)
-    assert_equal 1, mmr.defined_by_condition.calls[cfg_true]
+    assert_equal 1, condition.calls[cfg_true]
 
     assert_equal false, mmr.exists_in_cfg?(cfg_false)
     assert_equal false, mmr.exists_in_cfg?(cfg_false)
-    assert_equal 1, mmr.defined_by_condition.calls[cfg_false]
+    assert_equal 1, condition.calls[cfg_false]
   end
 
   def test_optional_in_cfg_is_keyed_by_cfg_arch
-    cfg_true = make_cfg_arch(partially_configured: true)
-    cfg_false = make_cfg_arch(partially_configured: true)
-    probe = OptionalProbe.new(FakeCondition.new(cfg_true => Udb::SatisfiedResult::Maybe, cfg_false => Udb::SatisfiedResult::No))
+    cfg_true = make_cfg_arch_from_yaml("optional_probe_true")
+    cfg_false = make_cfg_arch_from_yaml("optional_probe_false")
+    condition = RecordingCondition.new([
+      [cfg_true, Udb::SatisfiedResult::Maybe],
+      [cfg_false, Udb::SatisfiedResult::No]
+    ])
+    probe = OptionalProbe.new(condition)
 
     assert_equal true, probe.optional_in_cfg?(cfg_true)
     assert_equal true, probe.optional_in_cfg?(cfg_true)
-    assert_equal 1, probe.defined_by_condition.calls[cfg_true]
+    assert_equal 1, condition.calls[cfg_true]
 
     assert_equal false, probe.optional_in_cfg?(cfg_false)
     assert_equal false, probe.optional_in_cfg?(cfg_false)
-    assert_equal 1, probe.defined_by_condition.calls[cfg_false]
+    assert_equal 1, condition.calls[cfg_false]
+  end
+
+  # Regression: two distinct real ConfiguredArchitecture objects, built from
+  # two separate config files that both declare `name: identical_config`,
+  # are `eql?` to each other (ConfiguredArchitecture's hash/eql? are
+  # name-based) but must still be cached separately by identity, since
+  # exists_in_cfg?'s cache uses compare_by_identity.
+  def test_identity_cache_separates_distinct_objects_even_if_logically_equal
+    cfg1 = make_cfg_arch_from_yaml("identical_config")
+    cfg2 = make_cfg_arch_from_yaml("identical_config")
+
+    refute_same(cfg1, cfg2)
+    assert cfg1.eql?(cfg2), "expected cfg1 and cfg2 to be logically equal (same name) as a precondition for this test"
+
+    condition = RecordingCondition.new([[cfg1, true], [cfg2, false]])
+    csr = make_csr(condition)
+
+    assert_equal true, csr.exists_in_cfg?(cfg1)
+    assert_equal 1, condition.calls[cfg1]
+    assert_equal true, csr.exists_in_cfg?(cfg1)  # cached
+    assert_equal 1, condition.calls[cfg1]
+
+    assert_equal false, csr.exists_in_cfg?(cfg2)
+    assert_equal 1, condition.calls[cfg2]
   end
 end


### PR DESCRIPTION
## Summary

This PR fixes a memoization bug in `Csr#exists_in_cfg?`, `Mmr#exists_in_cfg?`, and `HasFields#optional_in_cfg?` where cached results could be reused incorrectly across different `ConfiguredArchitecture` instances. It also ensures that both `true` and `false` results are memoized correctly.

### Changes

* Replace single-value memoization with per-`cfg_arch` caches in:

  * `tools/ruby-gems/udb/lib/udb/obj/csr.rb`
  * `tools/ruby-gems/udb/lib/udb/obj/mmr.rb`
  * `tools/ruby-gems/udb/lib/udb/obj/has_fields`
* Use identity-based cache hashes (`compare_by_identity`) to avoid cache collisions between distinct `ConfiguredArchitecture` instances that compare equal.
* Replace `||=` with an explicit `key?` check so cached `false` results are reused instead of being recomputed.
* Add a regression test (`tools/ruby-gems/udb/test/test_cfg_arch_cache.rb`) verifying:

  * different `ConfiguredArchitecture` instances are cached independently,
  * both `true` and `false` results are memoized,
  * repeated calls with the same `ConfiguredArchitecture` reuse the cached value,
  * identity-based caching treats distinct `ConfiguredArchitecture` objects as separate cache entries.

### Why

The previous implementation memoized a single boolean value regardless of the `cfg_arch` argument:

```ruby
@exists_in_cfg ||= ...
```

This meant the first computed result could be reused for subsequent calls with a different `ConfiguredArchitecture`, producing incorrect results. Additionally, because `||=` does not memoize `false`, conditions evaluating to `false` were recomputed on every call.

This change introduces per-`cfg_arch` caches keyed by object identity and uses explicit cache lookups with `key?`. This ensures each `ConfiguredArchitecture` instance is evaluated independently while correctly memoizing both `true` and `false` results.

### Testing

Added a standalone regression test covering all three affected methods and verified that:

* repeated calls with the same `ConfiguredArchitecture` evaluate the condition only once,
* `true` and `false` results are both cached,
* different `ConfiguredArchitecture` instances maintain independent cache entries,
* distinct `ConfiguredArchitecture` objects with the same logical name do not share cached results.


### Screenshot
<img width="943" height="161" alt="Screenshot 2026-07-28 165501" src="https://github.com/user-attachments/assets/ea35873e-9a43-4368-a4e2-5cb6285ad1da" />
