### PR TITLE
fix(gdbserver): send empty response for unsupported qRcmd packet

### DIFF
--- a/backends/cpp_hart_gen/cpp/src/GDBServer.cpp
+++ b/backends/cpp_hart_gen/cpp/src/GDBServer.cpp
@@ -443,6 +443,7 @@ int GDBServer::HandlePacket(GDBPacket& packet)
       else if(strCmd == "Rcmd")
       {
         //TODO: Implement
+        result = SendResponse("");
       }
       else
       {


### PR DESCRIPTION
Fixes #2177

## Summary

This PR fixes the handling of the `qRcmd` packet in the C++ ISS GDB server (`backends/cpp_hart_gen/cpp/src/GDBServer.cpp`).

While investigating the `q` packet handling logic, I found that unsupported or unrecognized `q` packets generally fall through to the default handler, which responds with `SendResponse("")`. This allows GDB to recognize that the feature is unsupported and continue the debugging session normally.

However, the `qRcmd` handler was explicitly defined but left unimplemented:

```cpp
else if (strCmd == "Rcmd")
{
    // TODO: Implement
}
```

Because `qRcmd` is handled separately, it does not fall through to the default unsupported-packet handler.

This PR adds an explicit:

```cpp
result = SendResponse("");
```

to the `qRcmd` branch, making its behavior consistent with the existing handling of other unsupported `q` packets while leaving monitor command support itself for a future implementation.

## Validation

- Reviewed the existing `q` packet handling logic in `GDBServer.cpp`.
- Confirmed that unsupported `q` packets already respond with `SendResponse("")` through the default fallback.
- Confirmed that `qRcmd` bypasses this fallback because it has its own dedicated branch.
- Verified that this change keeps `qRcmd` behavior consistent with the existing protocol handling for unsupported features.