### PR TITLE
fix: implement complex extension requirement creation

### DIFF
--- a/tools/ruby-gems/udb/lib/udb/obj/extension.rb
+++ b/tools/ruby-gems/udb/lib/udb/obj/extension.rb
@@ -1345,8 +1345,18 @@ module Udb
             if range.satisfying_versions.size == uniq_ext_vers.size && uniq_ext_vers.all? { |ext_ver| range.satisfied_by?(ext_ver) }
               range
             else
-              # TODO: this is a complicated one
-              raise "TODO: complicated extension requirement creation"
+              reqs = [">= #{min_ver.version_str}", "<= #{max_ver.version_str}"]
+              ext.versions.each do |v|
+                if v > min_ver && v < max_ver && !uniq_ext_vers.include?(v)
+                  reqs << "!= #{v.version_str}"
+                end
+              end
+              complex_req = uniq_ext_vers.fetch(0).arch.extension_requirement(ext.name, reqs)
+              if complex_req.satisfying_versions.size == uniq_ext_vers.size && uniq_ext_vers.all? { |ext_ver| complex_req.satisfied_by?(ext_ver) }
+                complex_req
+              else
+                raise "Failed to create complex extension requirement for #{ext.name}"
+              end
             end
           end
         end


### PR DESCRIPTION
Fixes #2180

## Summary

This PR implements support for creating complex extension requirements in `ExtensionRequirement::create_from_ext_vers`.

Previously, the method raised:

```ruby
raise "TODO: complicated extension requirement creation"
```

when presented with discontinuous version subsets that could not be represented as a simple equality or contiguous range.

This change replaces the placeholder implementation with logic that constructs the corresponding `ExtensionRequirement` instead of raising an exception.

## What changed

Instead of aborting for discontinuous version subsets, `create_from_ext_vers` now:

1. Computes the minimum and maximum versions in the requested subset to establish the enclosing range.
2. Iterates over all known versions of the target extension.
3. Excludes intermediate versions that fall within the enclosing range but are not part of the requested subset by generating `!=` requirements.
4. Returns the resulting composite `ExtensionRequirement`.

## Validation

- Verified that Sorbet static type checking passes without errors.
- Verified that the generated composite requirement matches the intended discontinuous version subset for the tested cases.