### PR TITLE
Check old schema docs in CI

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -880,6 +880,25 @@ jobs:
         uses: ./.github/actions/mise-setup
       - name: Generate schema documentation
         run: ./bin/chore gen -f schema-docs
+      - name: Check old schema MDX files were not modified
+        run: |
+          git fetch --no-tags --depth=1 origin main
+          base="$(git merge-base origin/main HEAD)"
+          changed_old_docs="$(
+            git diff --name-only --diff-filter=ACDMRT "$base" HEAD -- 'doc/docs/schemas/*/*.mdx' \
+              | while IFS= read -r doc; do
+                  schema="spec/schemas/$(basename "$doc" .mdx).json"
+                  version="$(basename "$(dirname "$doc")")"
+                  current_version="$(./bin/python -c 'import json,pathlib,sys; p=pathlib.Path(sys.argv[1]); print(json.loads(p.read_text()).get("$id", "") if p.exists() else "")' "$schema")"
+                  [ "$version" = "$current_version" ] || printf '%s\n' "$doc"
+                done
+          )"
+          if [ -n "$changed_old_docs" ]; then
+            echo "Schema docs for old versions changed:"
+            echo "$changed_old_docs"
+            echo "Bump the schema \$id and add a new generated page instead."
+            exit 1
+          fi
 
   build-idl-doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -876,13 +876,14 @@ jobs:
     steps:
       - name: Clone Github Repo Action
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - name: Set up mise environment
         uses: ./.github/actions/mise-setup
       - name: Generate schema documentation
         run: ./bin/chore gen -f schema-docs
       - name: Check old schema MDX files were not modified
         run: |
-          git fetch --no-tags --depth=1 origin main
           base="$(git merge-base origin/main HEAD)"
           changed_old_docs="$(
             git diff --name-only --diff-filter=ACDMRT "$base" HEAD -- 'doc/docs/schemas/*/*.mdx' \

--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -895,9 +895,13 @@ jobs:
                 done
           )"
           if [ -n "$changed_old_docs" ]; then
-            echo "Schema docs for old versions changed:"
+            echo "ERROR: Schema docs for old versions changed:"
             echo "$changed_old_docs"
-            echo "Bump the schema \$id and add a new generated page instead."
+            echo
+            echo "Schema documentation for old schema versions is immutable. To update docs for a schema change:"
+            echo '  1. Increment the "$id" value in the modified schema file.'
+            echo "  2. Restore the old doc file(s) listed above."
+            echo "  3. The new versioned doc page will be generated automatically by autofix."
             exit 1
           fi
 

--- a/tools/test/regress-tests.yaml
+++ b/tools/test/regress-tests.yaml
@@ -434,9 +434,13 @@ tests:
                 done
           )"
           if [ -n "$changed_old_docs" ]; then
-            echo "Schema docs for old versions changed:"
+            echo "ERROR: Schema docs for old versions changed:"
             echo "$changed_old_docs"
-            echo "Bump the schema \$id and add a new generated page instead."
+            echo
+            echo "Schema documentation for old schema versions is immutable. To update docs for a schema change:"
+            echo '  1. Increment the "$id" value in the modified schema file.'
+            echo "  2. Restore the old doc file(s) listed above."
+            echo "  3. The new versioned doc page will be generated automatically by autofix."
             exit 1
           fi
 

--- a/tools/test/regress-tests.yaml
+++ b/tools/test/regress-tests.yaml
@@ -419,6 +419,25 @@ tests:
     test:
       - name: Generate schema documentation
         run: ./bin/chore gen -f schema-docs
+      - name: Check old schema MDX files were not modified
+        run: |
+          git fetch --no-tags --depth=1 origin main
+          base="$(git merge-base origin/main HEAD)"
+          changed_old_docs="$(
+            git diff --name-only --diff-filter=ACDMRT "$base" HEAD -- 'doc/docs/schemas/*/*.mdx' \
+              | while IFS= read -r doc; do
+                  schema="spec/schemas/$(basename "$doc" .mdx).json"
+                  version="$(basename "$(dirname "$doc")")"
+                  current_version="$(./bin/python -c 'import json,pathlib,sys; p=pathlib.Path(sys.argv[1]); print(json.loads(p.read_text()).get("$id", "") if p.exists() else "")' "$schema")"
+                  [ "$version" = "$current_version" ] || printf '%s\n' "$doc"
+                done
+          )"
+          if [ -n "$changed_old_docs" ]; then
+            echo "Schema docs for old versions changed:"
+            echo "$changed_old_docs"
+            echo "Bump the schema \$id and add a new generated page instead."
+            exit 1
+          fi
 
   build-idl-doc:
     ci_stage: merge_queue

--- a/tools/test/regress-tests.yaml
+++ b/tools/test/regress-tests.yaml
@@ -416,12 +416,13 @@ tests:
     ci_stage: pr
     tags:
       - smoke
+    checkout_with:
+      fetch-depth: 0
     test:
       - name: Generate schema documentation
         run: ./bin/chore gen -f schema-docs
       - name: Check old schema MDX files were not modified
         run: |
-          git fetch --no-tags --depth=1 origin main
           base="$(git merge-base origin/main HEAD)"
           changed_old_docs="$(
             git diff --name-only --diff-filter=ACDMRT "$base" HEAD -- 'doc/docs/schemas/*/*.mdx' \


### PR DESCRIPTION
Adds a schema-docs CI check that rejects changes to generated MDX files for schema versions that are no longer current. New docs for bumped schema versions remain allowed.