### PR TITLE
docs: add PR message style guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,3 +126,12 @@ CI is split into PR tests (`ci_stage: pr`) and merge-queue deployment tests (`ci
 - PRs require approval from a maintainer
 - Link PRs to issues with `Fixes #<number>` or `Closes #<number>` in the PR description
 - All PRs must pass `./bin/regress --all`
+
+### Pull Request Message Style
+
+Because PRs are squash-merged, write the PR title and description as the final commit message.
+
+- Keep the title short and specific; use a conventional prefix when it helps.
+- Keep the body to one to three concise paragraphs explaining what changed and why.
+- Avoid AI-generated boilerplate: long summaries, exhaustive change lists, validation logs, large tables, and copied diffs.
+- Mention validation only when it is non-obvious, special, or cannot be inferred from CI.


### PR DESCRIPTION
Because squash merges use PR titles and descriptions as commit messages, this adds concise guidance to keep PR messages short and avoid AI-generated boilerplate.