### PR TITLE
fix(csr): add MISA guard to mstatus.FS reset_value method

### DIFF
--- a/spec/std/isa/csr/mstatus.yaml
+++ b/spec/std/isa/csr/mstatus.yaml
@@ -436,6 +436,10 @@ fields:
           - name: F
           - name: S
     reset_value(): |
+      if (MISA_CSR_IMPLEMENTED && (CSR[misa].S == 1'b0) && (CSR[misa].F == 1'b0)) {
+        # must be read-only-0
+        return 0;
+      }
       return $array_size(MSTATUS_FS_LEGAL_VALUES) == 1 ? MSTATUS_FS_LEGAL_VALUES[0] : UNDEFINED_LEGAL;
     sw_write(csr_value): |
       if (MISA_CSR_IMPLEMENTED && (CSR[misa].S == 1'b0) && (CSR[misa].F == 1'b0)) {


### PR DESCRIPTION
Add MISA_CSR_IMPLEMENTED read-only zero guard to mstatus.FS reset_value() method.

Issue #1057 cleanup on mstatus.VS revealed that mstatus.FS reset_value() lacked an explicit MISA_CSR_IMPLEMENTED read-only zero check (when CSR[misa].S == 0 && CSR[misa].F == 0). While sw_write() already included this guard, reset_value() returned UNDEFINED_LEGAL when MSTATUS_FS_LEGAL_VALUES size was greater than 1 instead of returning 0.

This change aligns reset_value() with sw_write() in mstatus.FS by returning 0 when MISA_CSR_IMPLEMENTED is true and both misa.S and misa.F are 0.