### PR TITLE
fix(param): typo: SV32_VSMODE_TRANSLATION should require SV32, not SV39

### DIFF
--- a/spec/std/isa/param/SV32_VSMODE_TRANSLATION.yaml
+++ b/spec/std/isa/param/SV32_VSMODE_TRANSLATION.yaml
@@ -16,7 +16,7 @@ requirements:
   idl(): |
     # at least one of Bare, Sv32 must be supported
     !VSSTAGE_MODE_BARE
-      -> SV39_VSMODE_TRANSLATION;
+      -> SV32_VSMODE_TRANSLATION;
   reason: at least one of Bare, Sv32 must be supported
 definedBy:
   allOf:


### PR DESCRIPTION
`SV32_VSMODE_TRANSLATION`'s requirement reads "at least one of Bare, Sv32 must be supported" in both its comment and its `reason`, but concludes `SV39_VSMODE_TRANSLATION`. The two are gated on different XLENs: this parameter on `VSXLEN` including 32, that one on 64. Every sibling concludes its own parameter, as does the same construct in the G-stage family, `SV32X4_TRANSLATION`.

The constraint itself is not missing. `VSSTAGE_MODE_BARE` already enforces "at least one mode per XLEN" from both directions, so the effect is over-constraint rather than a hole: a hart where 32-bit guests use Sv32 and 64-bit guests use Sv48 is currently rejected, because the clause demands Sv39 support it has no need of. Every other rule is vacuous or satisfied for that configuration.

Conclude the parameter the file describes.

Closes #2214.